### PR TITLE
Prepare xtrm-tools npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,31 @@
   "name": "xtrm-tools",
   "version": "2.0.0",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "xtrm": "./cli/dist/index.cjs"
+  },
+  "files": [
+    "README.md",
+    "CHANGELOG.md",
+    "cli/dist",
+    "cli/package.json",
+    "config",
+    "hooks",
+    "skills",
+    "project-skills"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Jaggerxtrm/xtrm-tools.git"
+  },
+  "homepage": "https://github.com/Jaggerxtrm/xtrm-tools#readme",
+  "bugs": {
+    "url": "https://github.com/Jaggerxtrm/xtrm-tools/issues"
   },
   "scripts": {
     "build": "npm run build --prefix cli",


### PR DESCRIPTION
## Summary
- publish from the root package name xtrm-tools
- add explicit package files for npm publishing
- add publish metadata (license, repository, homepage, bugs, public access)

## Verification
- npm pack --dry-run --cache /tmp/xtrm-npm-cache
- npm whoami --cache /tmp/xtrm-npm-cache
- npm view xtrm-tools version --cache /tmp/xtrm-npm-cache