### PR TITLE
Release 2.0.1

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xtrm-cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtrm-cli",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "boxen": "^8.0.1",
         "cli-table3": "^0.6.5",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtrm-cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "main": "./dist/index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jaggers-agent-tools",
-  "version": "1.1.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jaggers-agent-tools",
-      "version": "1.1.0",
+      "version": "2.0.1",
       "dependencies": {
         "comment-json": "^4.2.3",
         "conf": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtrm-tools",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump package/cli versions to 2.0.1 for the release
- add the Claude + agents-skills targets and update docs/tests describing them
- document the install-all/project-all workflow in the README/help changelog

## Verification
- npm test --prefix cli
- npm run build --prefix cli
- XDG_CONFIG_HOME=/tmp node cli/dist/index.cjs install all --dry-run -y
