### PR TITLE
fix(hooks): correct total-work counting and run hook tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,5 @@ jobs:
     - name: Run Tests
       run: |
         npm test || echo "npm test not configured yet"
+        npm test --prefix cli
         pytest skills/documenting/tests || echo "Pytest failed or not found"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **xtrm-tools** (2184 symbols, 5154 relationships, 155 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **xtrm-tools** (2197 symbols, 5177 relationships, 155 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **xtrm-tools** (2184 symbols, 5154 relationships, 155 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **xtrm-tools** (2197 symbols, 5177 relationships, 155 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/cli/test/hooks.test.ts
+++ b/cli/test/hooks.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync, execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync, chmodSync, rmSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -25,6 +26,14 @@ function runHook(
     encoding: 'utf8',
     env: { ...process.env, ...env },
   });
+}
+
+function withFakeBdDir(scriptBody: string) {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'xtrm-fakebd-'));
+  const fakeBdPath = path.join(tempDir, 'bd');
+  writeFileSync(fakeBdPath, scriptBody, { encoding: 'utf8' });
+  chmodSync(fakeBdPath, 0o755);
+  return { tempDir, fakeBdPath };
 }
 
 // ── main-guard.mjs — MAIN_GUARD_PROTECTED_BRANCHES ──────────────────────────
@@ -89,6 +98,45 @@ describe('beads-edit-gate.mjs', () => {
   it('imports from beads-gate-utils.mjs (no inline duplicate logic)', () => {
     const content = readFileSync(path.join(HOOKS_DIR, 'beads-edit-gate.mjs'), 'utf8');
     expect(content).toContain("from './beads-gate-utils.mjs'");
+  });
+
+  it('blocks when session has no claim but open issues exist (regression guard)', () => {
+    const projectDir = mkdtempSync(path.join(os.tmpdir(), 'xtrm-beads-project-'));
+    mkdirSync(path.join(projectDir, '.beads'));
+    const fake = withFakeBdDir(`#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "kv" && "$2" == "get" ]]; then
+  exit 1
+fi
+if [[ "$1" == "list" ]]; then
+  cat <<'EOF'
+○ issue-1 P2 Open issue
+
+--------------------------------------------------------------------------------
+Total: 1 issues (1 open, 0 in progress)
+EOF
+  exit 0
+fi
+exit 1
+`);
+
+    try {
+      const r = runHook(
+        'beads-edit-gate.mjs',
+        {
+          session_id: 'session-regression-test',
+          tool_name: 'Write',
+          tool_input: { file_path: '/tmp/x' },
+          cwd: projectDir,
+        },
+        { PATH: `${fake.tempDir}:${process.env.PATH ?? ''}` },
+      );
+      expect(r.status).toBe(2);
+      expect(r.stderr).toContain('no active claim');
+    } finally {
+      rmSync(fake.tempDir, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/hooks/beads-gate-utils.mjs
+++ b/hooks/beads-gate-utils.mjs
@@ -77,8 +77,9 @@ export function getInProgress(cwd) {
  */
 export function getTotalWork(cwd) {
   try {
-    // A single call with no status filter gives us both counts in the Total line.
-    const output = execSync('bd list --status=open --status=in_progress', {
+    // Use default status filter (non-closed) and parse Total summary.
+    // Repeating --status is not additive in bd CLI and can collapse to one status.
+    const output = execSync('bd list', {
       encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe'], timeout: 8000,
     });
     const counts = parseCounts(output);


### PR DESCRIPTION
## Summary
- fix beads total-work counting regression in hooks/beads-gate-utils.mjs
- add regression coverage in cli/test/hooks.test.ts for open-only + no-claim scenario
- run cli tests in CI workflow
- include GitNexus index count refresh in AGENTS.md and CLAUDE.md

## Validation
- npm test --prefix cli -- test/hooks.test.ts
- manual hook repro: beads-edit-gate exits 2 when session has no claim and open work exists

Closes jaggers-agent-tools-ccm.