### PR TITLE
fix(main-guard): block mutating checkout/switch forms on protected branches

### DIFF
--- a/cli/test/hooks.test.ts
+++ b/cli/test/hooks.test.ts
@@ -92,6 +92,23 @@ describe('main-guard.mjs — MAIN_GUARD_PROTECTED_BRANCHES', () => {
     }
   });
 
+  it('blocks mutating checkout forms on protected branch', () => {
+    const blockedCommands = [
+      'git checkout -- README.md',
+      'git checkout HEAD -- README.md',
+      'git switch --detach HEAD',
+    ];
+    for (const command of blockedCommands) {
+      const r = runHook(
+        'main-guard.mjs',
+        { tool_name: 'Bash', tool_input: { command } },
+        { MAIN_GUARD_PROTECTED_BRANCHES: CURRENT_BRANCH },
+      );
+      expect(r.status, `expected exit 2 for: ${command}`).toBe(2);
+      expect(r.stderr).toContain('Bash is restricted');
+    }
+  });
+
   it('allows Bash when MAIN_GUARD_ALLOW_BASH=1 is set', () => {
     const r = runHook(
       'main-guard.mjs',

--- a/hooks/main-guard.mjs
+++ b/hooks/main-guard.mjs
@@ -69,13 +69,16 @@ if (tool === 'Bash') {
     process.exit(0);
   }
 
-  // Safe allowlist — non-mutating commands allowed on protected branches
+  // Safe allowlist — non-mutating commands + explicit branch-exit paths.
+  // Important: do not allow generic checkout/switch forms, which include
+  // mutating variants such as `git checkout -- <path>`.
   const SAFE_BASH_PATTERNS = [
     /^git\s+(status|log|diff|branch|show|describe|fetch|remote|config)\b/,
     /^git\s+pull\b/,
     /^git\s+stash\b/,
     /^git\s+worktree\b/,
-    /^git\s+(checkout|switch)\b/,
+    /^git\s+checkout\s+-b\s+\S+/,
+    /^git\s+switch\s+-c\s+\S+/,
     /^gh\s+/,
     /^bd\s+/,
   ];


### PR DESCRIPTION
## Summary
- tighten Bash allowlist in hooks/main-guard.mjs
- allow only branch-creation exits: git checkout -b and git switch -c
- block mutating checkout/switch variants via default-deny path
- add regression tests for blocked checkout/switch forms

## Validation
- npm test --prefix cli -- test/hooks.test.ts (17/17 pass)

Closes jaggers-agent-tools-xmy.