### PR TITLE
feat(cli): beads+dolt guided install + comprehensive help (zu7, n5s)

### DIFF
--- a/cli/src/commands/help.ts
+++ b/cli/src/commands/help.ts
@@ -1,102 +1,132 @@
 import { Command } from 'commander';
 import kleur from 'kleur';
 
+import path from 'path';
+import fs from 'fs-extra';
+import { findRepoRoot } from '../utils/repo-root.js';
+
+const HOOK_CATALOG: Array<{ file: string; event: string; desc: string; beads?: true }> = [
+    { file: 'main-guard.mjs',               event: 'PreToolUse',       desc: 'Blocks edits and commits on main/master branch' },
+    { file: 'skill-suggestion.py',           event: 'UserPromptSubmit', desc: 'Suggests relevant skills based on user prompt' },
+    { file: 'serena-workflow-reminder.py',   event: 'UserPromptSubmit', desc: 'Reminds agent to use Serena LSP semantic tools' },
+    { file: 'type-safety-enforcement.py',    event: 'PostToolUse',      desc: 'Enforces type safety checks after file edits' },
+    { file: 'skill-discovery.py',            event: 'UserPromptSubmit', desc: 'Discovers available skills for user requests' },
+    { file: 'agent_context.py',              event: 'SessionStart',     desc: 'Injects project agent context at session start' },
+    { file: 'beads-edit-gate.mjs',           event: 'PreToolUse',       desc: 'Blocks file edits if no beads issue is claimed',      beads: true },
+    { file: 'beads-commit-gate.mjs',         event: 'PreToolUse',       desc: 'Blocks commits when no beads issue is in progress',   beads: true },
+    { file: 'beads-stop-gate.mjs',           event: 'Stop',             desc: 'Blocks session stop with an unclosed beads claim',    beads: true },
+    { file: 'beads-close-memory-prompt.mjs', event: 'PostToolUse',      desc: 'Prompts memory save when closing a beads issue',      beads: true },
+];
+
+async function readSkillsFromDir(dir: string): Promise<Array<{ name: string; desc: string }>> {
+    if (!(await fs.pathExists(dir))) return [];
+    const entries = await fs.readdir(dir);
+    const skills: Array<{ name: string; desc: string }> = [];
+    for (const name of entries.sort()) {
+        const skillMd = path.join(dir, name, 'SKILL.md');
+        if (!(await fs.pathExists(skillMd))) continue;
+        const content = await fs.readFile(skillMd, 'utf8');
+        const m = content.match(/^description:\s*(.+)$/m);
+        skills.push({ name, desc: m ? m[1].replace(/^["']|["']$/g, '').trim() : '' });
+    }
+    return skills;
+}
+
+function col(s: string, width: number): string {
+    return s.length >= width ? s.slice(0, width - 1) + '\u2026' : s.padEnd(width);
+}
+
 export function createHelpCommand(): Command {
     return new Command('help')
-        .description('Show help information')
-        .action(() => {
-            console.log(`
-${kleur.bold('XTRM - Claude Code Tools Installer')}
+        .description('Show help information and component catalogue')
+        .action(async () => {
+            let repoRoot: string;
+            try { repoRoot = await findRepoRoot(); } catch { repoRoot = ''; }
 
-${kleur.cyan('USAGE:')}
-  xtrm <command> [options]
+            const skills = repoRoot ? await readSkillsFromDir(path.join(repoRoot, 'skills')) : [];
+            const projectSkills = repoRoot ? await readSkillsFromDir(path.join(repoRoot, 'project-skills')) : [];
 
-${kleur.cyan('COMMANDS:')}
+            const W = 80;
+            const hr = kleur.dim('-'.repeat(W));
+            const section = (title: string) => `\n${kleur.bold().cyan(title)}\n${hr}`;
 
-  ${kleur.bold('install')} [target-selector] [options]
-    Install Claude Code tools (skills, hooks, MCP servers) to your environment.
-    
-    Options:
-      --dry-run    Preview changes without making modifications
-      -y, --yes    Skip confirmation prompts
-      --prune      Remove items not in the canonical repository
-      --backport   Backport drifted local changes to the repository
-    
-    Examples:
-      xtrm install              # Interactive install with confirmation
-      xtrm install all          # Install to all Claude Code targets without prompting
-      xtrm install '*'          # Same as above; quote to avoid shell expansion
-      xtrm install --dry-run    # Preview what would be installed
-      xtrm install all --dry-run -y  # CI-friendly preview across all Claude targets
-      xtrm install -y           # Non-interactive install
+            const installSection = [
+                section('INSTALL COMMANDS'),
+                '',
+                `  ${kleur.bold('xtrm install all')}`,
+                `    ${kleur.dim('Global install: skills + all hooks (including beads gates) + MCP servers.')}`,
+                `    ${kleur.dim('Checks for beads+dolt and prompts to install if missing.')}`,
+                '',
+                `  ${kleur.bold('xtrm install basic')}`,
+                `    ${kleur.dim('Global install: skills + general hooks + MCP servers.')}`,
+                `    ${kleur.dim('No beads dependency -- safe to run with zero external deps.')}`,
+                '',
+                `  ${kleur.bold('xtrm install project')} ${kleur.dim('<tool-name | all>')}`,
+                `    ${kleur.dim('Project-scoped install into .claude/ of current git root.')}`,
+                `    ${kleur.dim('Run xtrm install project list to see available project skills.')}`,
+                '',
+                `  ${kleur.dim('Flags (all profiles): --dry-run  --yes / -y  --no-mcp  --force')}`,
+            ].join('\n');
 
-  ${kleur.bold('install project')} <tool-name>
-    Install a project-specific skill package into the current project.
-    
-    This command installs modular tools (like tdd-guard, ts-quality-gate, etc.)
-    into your project's .claude/ directory with proper hook injection.
-    
-    Examples:
-      xtrm install project tdd-guard       # Install TDD Guard
-      xtrm install project ts-quality-gate # Install TypeScript Quality Gate
-      xtrm install project all             # Install every available project skill
-      xtrm install project '*'             # Same as above; quote to avoid shell expansion
+            const general = HOOK_CATALOG.filter(h => !h.beads);
+            const beads   = HOOK_CATALOG.filter(h => h.beads);
+            const hookRows = (hooks: typeof HOOK_CATALOG) =>
+                hooks.map(h =>
+                    `  ${kleur.white(col(h.file, 34))}${kleur.yellow(col(h.event, 20))}${kleur.dim(h.desc)}`
+                ).join('\n');
 
-  ${kleur.bold('install project list')}
-    List all available project skills with descriptions and usage examples.
-    
-    Shows a table of installable project-specific tools that can enhance
-    Claude's capabilities for your specific project needs.
+            const hooksSection = [
+                section('GLOBAL HOOKS'),
+                '',
+                kleur.dim('  ' + col('File', 34) + col('Event', 20) + 'Description'),
+                '',
+                hookRows(general),
+                '',
+                `  ${kleur.dim('beads gate hooks (xtrm install all -- require beads+dolt):')}`,
+                hookRows(beads),
+            ].join('\n');
 
-  ${kleur.bold('status')}
-    Show diff of pending changes without making modifications.
-    
-    Displays what skills, hooks, and config would be updated if you ran
-    'xtrm install'. Useful for reviewing changes before applying them.
+            const skillRows = skills.map(s => {
+                const desc = s.desc.length > 46 ? s.desc.slice(0, 45) + '\u2026' : s.desc;
+                return `  ${kleur.white(col(s.name, 30))}${kleur.dim(desc)}`;
+            }).join('\n');
 
-  ${kleur.bold('reset')}
-    Clear saved preferences (sync mode, target selections, etc.).
-    
-    Use this to reset the CLI configuration and start fresh.
+            const skillsSection = [
+                section(`SKILLS  ${kleur.dim('(' + skills.length + ' available)')}`),
+                '',
+                skills.length ? skillRows : kleur.dim('  (none found -- run from repo root to see skills)'),
+            ].join('\n');
 
-${kleur.cyan('PROJECT SKILLS:')}
+            const psRows = projectSkills.map(s =>
+                `  ${kleur.white(col(s.name, 30))}${kleur.dim(s.desc)}`
+            ).join('\n');
 
-  Project skills are modular, plug-and-play tool packages that extend
-  Claude's capabilities for specific workflows. Each skill includes:
-  
-  • Pre-configured hooks for Claude Code
-  • Skills to provide context and guidance
-  • Documentation for manual setup steps
-  
-  Available project skills:
-  • ${kleur.white('service-skills-set')} — Docker service expertise (SessionStart, PreToolUse, PostToolUse)
-  • ${kleur.white('tdd-guard')} — Enforce Test-Driven Development (PreToolUse, UserPromptSubmit)
-  • ${kleur.white('ts-quality-gate')} — TypeScript/ESLint/Prettier quality gate (PostToolUse)
-  • ${kleur.white('py-quality-gate')} — Python ruff/mypy quality gate (PostToolUse)
+            const psSection = [
+                section('PROJECT SKILLS'),
+                '',
+                projectSkills.length ? psRows : kleur.dim('  (none found)'),
+                '',
+                `  ${kleur.dim('Install: xtrm install project <name>  |  xtrm install project list')}`,
+            ].join('\n');
 
-${kleur.cyan('INSTALL TARGETS:')}
+            const otherSection = [
+                section('OTHER COMMANDS'),
+                '',
+                `  ${kleur.bold('xtrm status')}    ${kleur.dim('Show pending changes without applying them')}`,
+                `  ${kleur.bold('xtrm reset')}     ${kleur.dim('Clear saved preferences and start fresh')}`,
+                `  ${kleur.bold('xtrm help')}      ${kleur.dim('Show this overview')}`,
+            ].join('\n');
 
-  xtrm-tools v2.0.0 installs into Claude Code targets and the .agents/skills cache:
-  • ~/.claude
-  • %APPDATA%/Claude on Windows
-  • ~/.agents/skills (skills-only copy)
+            const resourcesSection = [
+                section('RESOURCES'),
+                '',
+                `  Repository  https://github.com/Jaggerxtrm/xtrm-tools`,
+                `  Issues      https://github.com/Jaggerxtrm/xtrm-tools/issues`,
+                '',
+                `  ${kleur.dim("Run 'xtrm <command> --help' for command-specific options.")}`,
+                '',
+            ].join('\n');
 
-${kleur.cyan('ARCHITECTURE:')}
-
-  xtrm-tools v2.0.0 supports Claude Code exclusively. This decision was made
-  to focus on providing a robust, well-tested installation engine rather than
-  maintaining fragile translations for unofficial hook ecosystems.
-  
-  For Gemini CLI or Qwen CLI, users must manually configure their environments.
-  See the repository README for manual setup instructions.
-
-${kleur.cyan('RESOURCES:')}
-
-  • Repository: https://github.com/Jaggerxtrm/xtrm-tools
-  • Documentation: See README.md in the repository
-  • Report Issues: https://github.com/Jaggerxtrm/xtrm-tools/issues
-
-${kleur.dim('Run \\'xtrm <command> --help\\' for more information on a specific command.')}
-`);
+            console.log([installSection, hooksSection, skillsSection, psSection, otherSection, resourcesSection].join('\n'));
         });
 }

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -82,6 +82,7 @@ async function renderSummaryCard(
 
 import { execSync } from 'child_process';
 
+import { spawnSync } from 'child_process';
 const BEADS_HOOK_PATTERN = /^beads-/;
 
 function filterBeadsFromChangeSet(changeSet: ChangeSet): ChangeSet {
@@ -97,9 +98,18 @@ function filterBeadsFromChangeSet(changeSet: ChangeSet): ChangeSet {
     };
 }
 
-async function isBeadsInstalled(): Promise<boolean> {
+function isBeadsInstalled(): boolean {
     try {
         execSync('bd --version', { stdio: 'ignore' });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function isDoltInstalled(): boolean {
+    try {
+        execSync('dolt version', { stdio: 'ignore' });
         return true;
     } catch {
         return false;
@@ -125,22 +135,50 @@ async function runGlobalInstall(
     let skipBeads = installOpts.excludeBeads ?? false;
 
     if (installOpts.checkBeads && !skipBeads) {
-        const beadsOk = await isBeadsInstalled();
-        if (!beadsOk) {
-            if (yes) {
-                console.log(t.muted('  ℹ beads not found — skipping beads gate hooks (re-run after installing beads+dolt)\n'));
-                skipBeads = true;
-            } else {
-                const { installBeads } = await prompts({
+        console.log(t.bold('\n  ⚙  beads + dolt  (workflow enforcement backend)'));
+        console.log(t.muted('  beads is a git-backed issue tracker; dolt is its SQL+git storage backend.'));
+        console.log(t.muted('  Without them the gate hooks install but provide no enforcement.\n'));
+
+        const beadsOk = isBeadsInstalled();
+        const doltOk = isDoltInstalled();
+
+        if (beadsOk && doltOk) {
+            console.log(t.success('  ✓ beads + dolt already installed\n'));
+        } else {
+            const missing = [!beadsOk && 'bd', !doltOk && 'dolt'].filter(Boolean).join(', ');
+
+            let doInstall = yes;
+            if (!yes) {
+                const { install } = await prompts({
                     type: 'confirm',
-                    name: 'installBeads',
-                    message: 'Install beads+dolt? Required for workflow enforcement hooks',
-                    initial: false,
+                    name: 'install',
+                    message: `Install beads + dolt? (${missing} not found) — required for workflow enforcement hooks`,
+                    initial: true,
                 });
-                if (!installBeads) {
-                    console.log(t.muted('  ℹ Skipping beads gate hooks. Re-run xtrm install all after installing beads+dolt.\n'));
-                    skipBeads = true;
+                doInstall = install;
+            }
+
+            if (doInstall) {
+                if (!beadsOk) {
+                    console.log(t.muted('\n  Installing @beads/bd...'));
+                    spawnSync('npm', ['install', '-g', '@beads/bd'], { stdio: 'inherit' });
+                    console.log(t.success('  ✓ bd installed'));
                 }
+                if (!doltOk) {
+                    console.log(t.muted('\n  Installing dolt...'));
+                    if (process.platform === 'darwin') {
+                        spawnSync('brew', ['install', 'dolt'], { stdio: 'inherit' });
+                    } else {
+                        spawnSync('sudo', ['bash', '-c',
+                            'curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash',
+                        ], { stdio: 'inherit' });
+                    }
+                    console.log(t.success('  ✓ dolt installed'));
+                }
+                console.log('');
+            } else {
+                console.log(t.muted('  ℹ Skipping beads gate hooks. Re-run xtrm install all after installing beads+dolt.\n'));
+                skipBeads = true;
             }
         }
     }
@@ -267,7 +305,8 @@ export function createInstallCommand(): Command {
         .option('--backport', 'Backport drifted local changes back to the repository', false)
         .action(async (targetSelector, opts) => {
             const { dryRun, yes, prune, backport } = opts;
-            const actionType = backport ? 'backport' : 'install';
+            const syncType: 'sync' | 'backport' = backport ? 'backport' : 'sync';
+            const actionLabel = backport ? 'backport' : 'install';
 
             const repoRoot = await findRepoRoot();
             const ctx = await getContext({
@@ -308,13 +347,16 @@ export function createInstallCommand(): Command {
             // MCP sync always runs regardless of file changes
             if (!backport && !dryRun) {
                 const emptyChangeSet = {
-                    skills: { missing: [], outdated: [], drifted: [], total: 0 },
-                    hooks: { missing: [], outdated: [], drifted: [], total: 0 },
-                    config: { missing: [], outdated: [], drifted: [], total: 0 },
+                    skills: { missing: [] as string[], outdated: [] as string[], drifted: [] as string[], total: 0 },
+                    hooks: { missing: [] as string[], outdated: [] as string[], drifted: [] as string[], total: 0 },
+                    config: { missing: [] as string[], outdated: [] as string[], drifted: [] as string[], total: 0 },
+                    commands: { missing: [] as string[], outdated: [] as string[], drifted: [] as string[], total: 0 },
+                    'qwen-commands': { missing: [] as string[], outdated: [] as string[], drifted: [] as string[], total: 0 },
+                    'antigravity-workflows': { missing: [] as string[], outdated: [] as string[], drifted: [] as string[], total: 0 },
                 };
                 for (const target of targets) {
                     console.log(t.bold(`\n  ${sym.arrow} ${path.basename(target)}`));
-                    await executeSync(repoRoot, target, emptyChangeSet, syncMode, 'install', false);
+                    await executeSync(repoRoot, target, emptyChangeSet, syncMode, 'sync', false);
                 }
             }
 
@@ -337,7 +379,7 @@ export function createInstallCommand(): Command {
                 const { confirm } = await prompts({
                     type: 'confirm',
                     name: 'confirm',
-                    message: `Proceed with ${actionType} (${totalChangesCount} total changes)?`,
+                    message: `Proceed with ${actionLabel} (${totalChangesCount} total changes)?`,
                     initial: true,
                 });
                 if (!confirm) {
@@ -346,19 +388,18 @@ export function createInstallCommand(): Command {
                 }
             }
 
-            // Phase 4: Execute install
+            // Phase 4: Execute
             let totalCount = 0;
 
             for (const { target, changeSet, skippedDrifted } of allChanges) {
                 console.log(t.bold(`\n  ${sym.arrow} ${path.basename(target)}`));
 
-                const count = await executeSync(repoRoot, target, changeSet, syncMode, actionType, dryRun);
+                const count = await executeSync(repoRoot, target, changeSet, syncMode, syncType, dryRun);
                 totalCount += count;
 
-                // Track skipped drifted
                 for (const [category, cat] of Object.entries(changeSet)) {
                     const c = cat as any;
-                    if (c.drifted.length > 0 && actionType === 'install') {
+                    if (c.drifted.length > 0 && syncType === 'sync') {
                         skippedDrifted.push(...c.drifted.map((item: string) => `${category}/${item}`));
                     }
                 }


### PR DESCRIPTION
Rebased version of #24 (which had squash-merge conflict).

- **zu7**: Real beads+dolt install — checks `bd` + `dolt`, explains what they are, prompts [Y/n] (default yes), runs `npm install -g @beads/bd` + brew/curl; `--yes` auto-installs
- **n5s**: Comprehensive `xtrm help` — dynamic skill listing from SKILL.md frontmatter, hook catalogue with event names, updated install profiles
- Fixes pre-existing `install.ts` bugs: emptyChangeSet missing fields, `'install'` actionType corrected to `'sync'`