### PR TITLE
chore: bump root package version to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtrm-tools",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bumps root `package.json` version from 2.0.3 → 2.1.0 to match `cli/package.json`
- This is what gets published to npm as `xtrm-tools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)