### PR TITLE
chore: remove main-guard hook from project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,17 +1,7 @@
 {
   "hooks": {
     "PreToolUse": [
-      {
-        "matcher": "Write|Edit|MultiEdit|Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/hooks/main-guard.mjs\"",
-            "timeout": 5
-          }
-        ]
-      },
-      {
+{
         "matcher": "Read|Write|Edit|Glob|Grep|Bash",
         "hooks": [
           {


### PR DESCRIPTION
Removes the main-guard PreToolUse hook entry from `.claude/settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)