### PR TITLE
feat(tdd-guard): wire VitestReporter and gitignore data dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ cli/node_modules
 # Dolt database files (added by bd init)
 .dolt/
 *.db
+
+# TDD Guard runtime data
+.claude/tdd-guard/data/

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+import { VitestReporter } from 'tdd-guard-vitest'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    reporters: ['default', new VitestReporter(path.resolve(__dirname, '..'))],
+  },
+})


### PR DESCRIPTION
Add cli/vitest.config.ts to register tdd-guard-vitest VitestReporter,
pointing to the project root so test results are written to
.claude/tdd-guard/data/test.json. Also gitignore the data directory
since it contains runtime state, not source.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
