### PR TITLE
fix(main-guard): use systemMessage only, exit 2 for deny

### DIFF
--- a/hooks/main-guard.mjs
+++ b/hooks/main-guard.mjs
@@ -38,14 +38,9 @@ const hookEventName = input.hook_event_name ?? 'PreToolUse';
 function deny(reason) {
   process.stdout.write(JSON.stringify({
     systemMessage: reason,
-    hookSpecificOutput: {
-      hookEventName,
-      permissionDecision: 'deny',
-      permissionDecisionReason: reason,
-    },
   }));
   process.stdout.write('\n');
-  process.exit(0);
+  process.exit(2);
 }
 
 const WRITE_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);


### PR DESCRIPTION
Removed hookSpecificOutput from deny() — it caused the block message
to appear twice in Claude Code (once as systemMessage, once as
permissionDecisionReason). Using systemMessage alone is sufficient.
Also switched to exit(2) which is the correct code for blocking.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
