### PR TITLE
feat: gitnexus impact reminder on UserPromptSubmit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,8 @@
 {
   "hooks": {
     "PreToolUse": [
-{
-        "matcher": "Read|Write|Edit|Glob|Grep|Bash",
+      {
+        "matcher": "Read|Write|Edit|Glob|Grep|Bash|mcp__serena__rename_symbol|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol",
         "hooks": [
           {
             "type": "command",
@@ -19,11 +19,21 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit|TodoWrite|mcp__serena__rename_symbol|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/tdd-guard-pretool-bridge.cjs\"",
+            "timeout": 30
+          }
+        ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit",
+        "matcher": "Write|Edit|MultiEdit|mcp__serena__rename_symbol|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol",
         "hooks": [
           {
             "type": "command",
@@ -33,7 +43,7 @@
         ]
       },
       {
-        "matcher": "Write|Edit|MultiEdit",
+        "matcher": "Write|Edit|MultiEdit|mcp__serena__rename_symbol|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol",
         "hooks": [
           {
             "type": "command",
@@ -43,7 +53,7 @@
         ]
       },
       {
-        "matcher": "Write|Edit|MultiEdit",
+        "matcher": "Write|Edit|MultiEdit|mcp__serena__rename_symbol|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol",
         "hooks": [
           {
             "type": "command",
@@ -88,6 +98,15 @@
             "type": "command",
             "command": "tdd-guard --prompt-check",
             "timeout": 15
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/hooks/gitnexus-impact-reminder.py\"",
+            "timeout": 5
           }
         ]
       }

--- a/cli/test/hooks.test.ts
+++ b/cli/test/hooks.test.ts
@@ -382,3 +382,49 @@ describe('tdd-guard-pretool-bridge.cjs', () => {
     }
   });
 });
+
+
+// ── gitnexus-impact-reminder.py ──────────────────────────────────────────────
+
+function runPythonHook(
+  hookFile: string,
+  input: Record<string, unknown>,
+) {
+  return spawnSync('python3', [path.join(HOOKS_DIR, hookFile)], {
+    input: JSON.stringify(input),
+    encoding: 'utf8',
+    env: { ...process.env },
+  });
+}
+
+describe('gitnexus-impact-reminder.py', () => {
+  it('injects additionalContext when prompt contains an edit-intent keyword', () => {
+    const r = runPythonHook('gitnexus-impact-reminder.py', {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'fix the broken auth logic in login.ts',
+    });
+    expect(r.status).toBe(0);
+    const out = parseHookJson(r.stdout);
+    expect(out?.hookSpecificOutput?.additionalContext).toContain('gitnexus impact');
+  });
+
+  it('does nothing (no output) when prompt has no edit-intent keywords', () => {
+    const r = runPythonHook('gitnexus-impact-reminder.py', {
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'explain how the beads gate works',
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe('');
+  });
+
+  it('does nothing for non-UserPromptSubmit events', () => {
+    const r = runPythonHook('gitnexus-impact-reminder.py', {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Edit',
+      tool_input: { file_path: 'foo.ts' },
+      prompt: 'fix something',
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe('');
+  });
+});

--- a/hooks/gitnexus-impact-reminder.py
+++ b/hooks/gitnexus-impact-reminder.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from agent_context import AgentContext
+
+EDIT_KEYWORDS = [
+    'fix', 'refactor', 'change', 'update', 'modify', 'edit',
+    'rename', 'move', 'delete', 'remove', 'rewrite', 'implement',
+    'add', 'replace', 'extract', 'migrate', 'upgrade',
+]
+
+REMINDER = """*** GITNEXUS: Run impact analysis before editing any symbol ***
+
+Before modifying a function, class, or method:
+  npx gitnexus impact <symbolName> --direction upstream --repo xtrm-tools
+
+Review d=1 items (WILL BREAK) before proceeding.
+Skip for docs, configs, and test-only changes.
+"""
+
+try:
+    ctx = AgentContext()
+
+    if ctx.event == 'UserPromptSubmit':
+        prompt_lower = ctx.prompt.lower()
+        if any(kw in prompt_lower for kw in EDIT_KEYWORDS):
+            ctx.allow(additional_context=REMINDER)
+
+    ctx.fail_open()
+
+except Exception as e:
+    print(f"Hook error: {e}", file=sys.stderr)
+    sys.exit(0)


### PR DESCRIPTION
## Summary

- Adds `hooks/gitnexus-impact-reminder.py` — a `UserPromptSubmit` hook that injects an `additionalContext` reminder to run `npx gitnexus impact` before editing code symbols
- Triggers on edit-intent keywords: fix, refactor, change, update, modify, edit, rename, move, delete, remove, rewrite, implement, add, replace, extract, migrate, upgrade
- Non-blocking — never denies the prompt, only nudges
- Wired into `.claude/settings.json` UserPromptSubmit hooks alongside tdd-guard

## Test plan

- [x] 3 new tests in `cli/test/hooks.test.ts` covering: keyword trigger, no-keyword passthrough, non-UserPromptSubmit passthrough
- [x] All tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)