### PR TITLE
fix(security): semgrepignore — use glob '*' so re-include actually works

### DIFF
--- a/.xtrm/skills/default/security-pipeline/templates/.semgrepignore
+++ b/.xtrm/skills/default/security-pipeline/templates/.semgrepignore
@@ -28,9 +28,11 @@ traefik/logs/
 .xtrm/skills/active/
 .xtrm/skills/optional/
 .xtrm/skills/user/
-.xtrm/skills/default/
-!.xtrm/skills/default/security-pipeline/
-!.xtrm/skills/default/security-pipeline/**
+# Use glob '*' on immediate children so the parent stays included; this lets
+# the negation actually re-include security-pipeline (gitignore semantics
+# refuse to descend into an excluded parent directory).
+.xtrm/skills/default/*
+!.xtrm/skills/default/security-pipeline
 
 # Test fixtures and snapshots — false positive heavy
 **/test_fixtures/

--- a/skills/security-pipeline/templates/.semgrepignore
+++ b/skills/security-pipeline/templates/.semgrepignore
@@ -28,9 +28,11 @@ traefik/logs/
 .xtrm/skills/active/
 .xtrm/skills/optional/
 .xtrm/skills/user/
-.xtrm/skills/default/
-!.xtrm/skills/default/security-pipeline/
-!.xtrm/skills/default/security-pipeline/**
+# Use glob '*' on immediate children so the parent stays included; this lets
+# the negation actually re-include security-pipeline (gitignore semantics
+# refuse to descend into an excluded parent directory).
+.xtrm/skills/default/*
+!.xtrm/skills/default/security-pipeline
 
 # Test fixtures and snapshots — false positive heavy
 **/test_fixtures/


### PR DESCRIPTION
Codex P1 finding: gitignore semantics refuse to descend into an excluded
parent directory, so '.xtrm/skills/default/' + '!.../security-pipeline/'
results in security-pipeline being silently excluded. Replace with a glob
on immediate children: '.xtrm/skills/default/*' + the negation. This is
the canonical gitignore pattern for 'exclude all but one'.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
