### PR TITLE
fix(doctor): resolve project root when xt doctor invoked from subdir

### DIFF
--- a/.pi/npm
+++ b/.pi/npm
@@ -1,0 +1,1 @@
+/home/dawid/dev/xtrm-tools/.pi/npm

--- a/cli/dist/index.cjs
+++ b/cli/dist/index.cjs
@@ -63775,6 +63775,14 @@ async function toRows(registry2, cwd, surface, drift) {
 async function loadRegistry(cwd) {
   return import_fs_extra34.default.readJson(import_node_path22.default.join(cwd, ".xtrm", "registry.json"));
 }
+async function resolveDoctorCwd(optsCwd) {
+  const cwd = optsCwd ? import_node_path22.default.resolve(optsCwd) : await findProjectRoot();
+  const registryPath = import_node_path22.default.join(cwd, ".xtrm", "registry.json");
+  if (!await import_fs_extra34.default.pathExists(registryPath)) {
+    throw new Error(`Not inside an xtrm project: ${cwd}`);
+  }
+  return cwd;
+}
 async function readSpecialistsSkillNames(repoPath) {
   const skillsRoot = import_node_path22.default.join(repoPath, "config", "skills");
   if (!await import_fs_extra34.default.pathExists(skillsRoot)) return [];
@@ -63882,7 +63890,7 @@ function hasCatBIssues(report) {
 }
 function createDoctorCommand() {
   return new Command("doctor").description("Health check for the xtrm-managed surfaces of the current project").option("--cwd <path>", "Operate on this directory (default: process.cwd())").option("--json", "Output machine-readable JSON", false).option("--check-drift", "Exit non-zero on any drift, missing, extra, or duplicate").action(async (opts) => {
-    const cwd = import_node_path22.default.resolve(opts.cwd ?? process.cwd());
+    const cwd = await resolveDoctorCwd(opts.cwd);
     const registry2 = await loadRegistry(cwd);
     const drift = await checkDrift(import_node_path22.default.join(cwd, ".xtrm", "registry.json"), import_node_path22.default.join(cwd, ".xtrm"));
     const runtimeView = await checkRuntimeSkillsViews(cwd);

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -9,6 +9,7 @@ import { checkRuntimeSkillsViews, type RuntimeViewCheckResult } from '../core/sk
 import { getXtManagedPiPackageDoctorReport, type XtManagedPiPackageDoctorReport } from '../core/pi-runtime.js';
 import { discoverDefaultSkills, type DiscoveredSkill } from '../core/skill-discovery.js';
 import { ensureBeadsSharedServerEnabled, hasBeadsDir, type SharedBeadsServerState } from '../core/beads-shared-server.js';
+import { findProjectRoot } from '../utils/repo-root.js';
 
 interface CheckJson {
   managed_sections: Array<{ name: string; version: string; canonical_version: string | null }>;
@@ -182,6 +183,17 @@ async function loadRegistry(cwd: string): Promise<RegistryManifest> {
   return fs.readJson(path.join(cwd, '.xtrm', 'registry.json')) as Promise<RegistryManifest>;
 }
 
+async function resolveDoctorCwd(optsCwd?: string): Promise<string> {
+  const cwd = optsCwd ? path.resolve(optsCwd) : await findProjectRoot();
+  const registryPath = path.join(cwd, '.xtrm', 'registry.json');
+
+  if (!(await fs.pathExists(registryPath))) {
+    throw new Error(`Not inside an xtrm project: ${cwd}`);
+  }
+
+  return cwd;
+}
+
 async function readSpecialistsSkillNames(repoPath: string): Promise<string[]> {
   const skillsRoot = path.join(repoPath, 'config', 'skills');
   if (!await fs.pathExists(skillsRoot)) return [];
@@ -313,7 +325,7 @@ export function createDoctorCommand(): Command {
     .option('--json', 'Output machine-readable JSON', false)
     .option('--check-drift', 'Exit non-zero on any drift, missing, extra, or duplicate')
     .action(async (opts: { cwd?: string; json?: boolean; checkDrift?: boolean }) => {
-      const cwd = path.resolve(opts.cwd ?? process.cwd());
+      const cwd = await resolveDoctorCwd(opts.cwd);
       const registry = await loadRegistry(cwd);
       const drift = await checkDrift(path.join(cwd, '.xtrm', 'registry.json'), path.join(cwd, '.xtrm'));
       const runtimeView = await checkRuntimeSkillsViews(cwd);

--- a/cli/src/tests/doctor.test.ts
+++ b/cli/src/tests/doctor.test.ts
@@ -126,4 +126,17 @@ describe('xt doctor command', () => {
     expect(parsed.piPackages.issues.some((issue: { state: string }) => issue.state === 'version-unknown')).toBe(true);
     expect(parsed.piPackages.hasIssues).toBe(true);
   });
+
+  it('resolves project root from subdirectories', async () => {
+    getXtManagedPiPackageDoctorReportMock.mockResolvedValue(buildReport());
+    const nestedDir = path.join(tmpDir, 'cli', 'nested');
+    fs.ensureDirSync(nestedDir);
+    process.chdir(nestedDir);
+
+    const jsonLogs = await runDoctorCli(['--json']);
+    const parsed = JSON.parse(jsonLogs[0]);
+
+    expect(parsed.catB.runtimeView).toBeDefined();
+    expect(parsed.piPackages.hasIssues).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- `xt doctor` previously crashed with `ENOENT: no such file or directory, open '/.xtrm/registry.json'` when run from any directory other than the project root.
- Adds `resolveDoctorCwd()` helper: explicit `--cwd` still wins; otherwise walks up via `findProjectRoot()`; throws a clear "Not inside an xtrm project: …" error instead of opaque ENOENT.
- Adds regression test: `xt doctor --json` works when cwd is a nested subdir under a fixture project.

Bead: xtrm-sxug (A2 from 2026-05-13 stabilization audit).

## Test plan
- [x] `npm run typecheck --workspace cli`
- [x] sp merge gate (TypeScript pass after merge)
- [ ] Manual smoke: `cd cli && node dist/index.cjs doctor --json` succeeds
- [ ] Manual smoke: `cd / && node $REPO/cli/dist/index.cjs doctor` errors with clear message