### PR TITLE
fix(status): non-interactive mode for xt status (--check + non-TTY auto-skip)

### DIFF
--- a/cli/dist/index.cjs
+++ b/cli/dist/index.cjs
@@ -59969,8 +59969,8 @@ function formatRelativeTime(timestamp) {
   return `${days} day${days > 1 ? "s" : ""} ago`;
 }
 function createStatusCommand() {
-  return new Command("status").description("Show status and optionally sync target environments").option("--json", "Output machine-readable JSON", false).action(async (opts) => {
-    const { json: json2 } = opts;
+  return new Command("status").description("Show status and optionally sync target environments").option("--json", "Output machine-readable JSON", false).option("--check", "Non-interactive summary; never prompt", false).action(async (opts) => {
+    const { json: json2, check: check2 } = opts;
     const repoRoot = await findRepoRoot();
     const candidates = getCandidatePaths();
     const targets = [];
@@ -60037,6 +60037,10 @@ function createStatusCommand() {
     console.log(kleur_default.yellow(`
   \u26A0  ${totalPending} pending change${totalPending !== 1 ? "s" : ""} across ${pending.length} environment${pending.length !== 1 ? "s" : ""}
 `));
+    if (check2 || !process.stdin.isTTY) {
+      console.log(kleur_default.gray("  Skipped. Run 'xt sync' to apply.\n"));
+      return;
+    }
     const { selected } = await (0, import_prompts4.default)({
       type: "multiselect",
       name: "selected",

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -37,8 +37,9 @@ export function createStatusCommand(): Command {
     return new Command('status')
         .description('Show status and optionally sync target environments')
         .option('--json', 'Output machine-readable JSON', false)
+        .option('--check', 'Non-interactive summary; never prompt', false)
         .action(async (opts) => {
-            const { json } = opts;
+            const { json, check } = opts;
 
             const repoRoot = await findRepoRoot();
 
@@ -131,6 +132,11 @@ export function createStatusCommand(): Command {
 
             const pending = results.filter(r => r.totalChanges > 0);
             console.log(kleur.yellow(`\n  ⚠  ${totalPending} pending change${totalPending !== 1 ? 's' : ''} across ${pending.length} environment${pending.length !== 1 ? 's' : ''}\n`));
+
+            if (check || !process.stdin.isTTY) {
+                console.log(kleur.gray("  Skipped. Run 'xt sync' to apply.\n"));
+                return;
+            }
 
             // ── Inline sync offer ────────────────────────────────────────────
             const { selected } = await prompts({

--- a/cli/src/tests/status.test.ts
+++ b/cli/src/tests/status.test.ts
@@ -1,0 +1,75 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'fs-extra';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const promptsMock = vi.hoisted(() => vi.fn());
+const calculateDiffMock = vi.hoisted(() => vi.fn());
+const getCandidatePathsMock = vi.hoisted(() => vi.fn());
+const findRepoRootMock = vi.hoisted(() => vi.fn());
+
+vi.mock('prompts', () => ({ default: promptsMock }));
+vi.mock('../core/diff.js', () => ({ calculateDiff: calculateDiffMock }));
+vi.mock('../core/context.js', () => ({ getCandidatePaths: getCandidatePathsMock }));
+vi.mock('../utils/repo-root.js', () => ({ findRepoRoot: findRepoRootMock }));
+
+import { createStatusCommand } from '../commands/status.js';
+
+let tmpDir = '';
+let previousCwd = '';
+let previousIsTTY: boolean | undefined;
+
+beforeEach(() => {
+  previousCwd = process.cwd();
+  previousIsTTY = process.stdin.isTTY;
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'xtrm-status-test-'));
+  process.chdir(tmpDir);
+  fs.ensureDirSync(path.join(tmpDir, '.xtrm'));
+  fs.ensureDirSync(path.join(tmpDir, 'env-a'));
+  getCandidatePathsMock.mockReturnValue([{ path: path.join(tmpDir, 'env-a') }]);
+  findRepoRootMock.mockResolvedValue(tmpDir);
+  calculateDiffMock.mockResolvedValue({
+    packageA: { missing: ['a'], outdated: [], drifted: [] },
+  });
+  promptsMock.mockReset();
+  Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+});
+
+afterEach(() => {
+  process.chdir(previousCwd);
+  fs.removeSync(tmpDir);
+  Object.defineProperty(process.stdin, 'isTTY', { value: previousIsTTY, configurable: true });
+  vi.restoreAllMocks();
+});
+
+async function runStatusCli(args: string[]): Promise<string[]> {
+  const logs: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((...values: unknown[]) => {
+    logs.push(values.map(String).join(' '));
+  });
+
+  try {
+    const command = createStatusCommand();
+    await command.parseAsync(['node', 'xtrm-status-test', ...args]);
+    return logs;
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe('xt status command', () => {
+  it.each([
+    ['--check', 'check'],
+    ['non-tty', 'non-tty'],
+  ])('skips prompt and prints summary in %s mode', async (args, label) => {
+    if (label === 'non-tty') {
+      Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true });
+    }
+
+    const logs = await runStatusCli(label === 'check' ? ['--check'] : []);
+
+    expect(promptsMock).not.toHaveBeenCalled();
+    expect(logs.join('\n')).toContain('pending change');
+    expect(logs.join('\n')).toContain("Run 'xt sync' to apply.");
+  });
+});


### PR DESCRIPTION
## Summary
- `xt status` was unconditionally interactive when there were pending changes — agents, CI, and any non-TTY caller couldn't get a quick "is everything fine?" check.
- Adds `--check` flag (`Non-interactive summary; never prompt`) and gates the inline sync prompt on `check || !process.stdin.isTTY`.
- JSON path unchanged. Interactive TTY default behavior unchanged.

Bead: xtrm-d3wx (A3 from 2026-05-13 stabilization audit).

## Reviewer note
Reviewer 397547 returned PARTIAL 91/100 citing "missing gitnexus_impact telemetry." Verified against `.specialists/db/observability.db` — executor b385c4 actually made **13 gitnexus tool calls** (2× impact on `status` and `createStatusCommand`, plus query/context/detect_changes). The PARTIAL stemmed from a `sp feed` visibility bug (filed as `unitAI-889dv` in dev/specialists) — `sp feed <job>` returns only an 8-line tail, not the full DB-backed replay. Functional review was clean.

## Test plan
- [x] `npm run typecheck --workspace cli`
- [x] `npm test -- --run src/tests/status.test.ts` (new regression: non-TTY + --check both skip prompt)
- [x] sp merge TypeScript gate passed
- [ ] Manual smoke: `xt status --check` exits cleanly with summary
- [ ] Manual smoke: `echo | xt status` exits cleanly with summary