### PR TITLE
fix(tests): harden resolveHooksForProjectRuntime against single-object wrapper shape

### DIFF
--- a/cli/dist/index.cjs
+++ b/cli/dist/index.cjs
@@ -38962,7 +38962,8 @@ function resolveHooksForProjectRuntime(hooks, projectHooksDir) {
   const normalizedHooksDir = normalizeHookCommandPath(projectHooksDir);
   const rewrittenHooks = {};
   for (const [eventName, wrappers] of Object.entries(hooks)) {
-    rewrittenHooks[eventName] = wrappers.map((wrapper) => ({
+    const wrapperList = Array.isArray(wrappers) ? wrappers : [wrappers];
+    rewrittenHooks[eventName] = wrapperList.map((wrapper) => ({
       ...wrapper,
       hooks: wrapper.hooks.map((hook) => {
         if (hook.type !== "command") {

--- a/cli/src/core/claude-runtime-sync.ts
+++ b/cli/src/core/claude-runtime-sync.ts
@@ -189,7 +189,8 @@ function resolveHooksForProjectRuntime(hooks: Record<string, HookWrapper[]>, pro
     const rewrittenHooks: Record<string, HookWrapper[]> = {};
 
     for (const [eventName, wrappers] of Object.entries(hooks)) {
-        rewrittenHooks[eventName] = wrappers.map(wrapper => ({
+        const wrapperList = Array.isArray(wrappers) ? wrappers : [wrappers as HookWrapper];
+        rewrittenHooks[eventName] = wrapperList.map(wrapper => ({
             ...wrapper,
             hooks: wrapper.hooks.map(hook => {
                 if (hook.type !== 'command') {


### PR DESCRIPTION
## Summary
- `cli/src/tests/install-integration.test.ts` was flaking in full-suite runs (~2/3 of local runs on 2026-05-13) with `TypeError: wrappers.map is not a function` at `claude-runtime-sync.ts:192`. Some upstream test was leaving `hooks.json` in `{event: { hooks: [...] }}` shape instead of `{event: [{ hooks: [...] }]}`.
- Hardens `resolveHooksForProjectRuntime` to accept both shapes via `Array.isArray(wrappers) ? wrappers : [wrappers as HookWrapper]`. Behavior on the canonical array path is unchanged.
- Verified by 3 consecutive full-suite green runs.

Bead: xtrm-0kgm (A1 from 2026-05-13 stabilization audit).

## Test plan
- [x] `npm run typecheck --workspace cli`
- [x] `cd cli && npm test` ×3 consecutive runs → all green (65 passed | 5 skipped)
- [x] Reviewer PASS 95 (gitnexus_impact ran upstream, blast-radius HIGH, change behavior-preserving)
- [ ] Optional follow-up: dual-shape regression test for `resolveHooksForProjectRuntime` (debugger noted as optional)