### PR TITLE
feat(pack): add payload hygiene denylist + absolute-path leak scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,12 +63,13 @@
     "check:layout-guards": "node scripts/check-layout-guards.mjs",
     "check:gitnexus-no-counter": "node scripts/check-gitnexus-no-counter.mjs",
     "check:skills-symlinks": "node scripts/check-skills-symlinks.mjs",
-    "prepublishOnly": "npm run sync:cli-version && npm run check:package && npm run check:skills-ownership && node scripts/vendor-specialists-skills.mjs --specialists-package specialists --specialists-ref master && npm run gen-registry && npm run check:registry-pack-parity && npm run check:specialists-vendor && npm run check:layout-guards && npm run check:gitnexus-no-counter && npm run check:skills-symlinks && npm run build",
+    "prepublishOnly": "npm run sync:cli-version && npm run check:package && npm run check:skills-ownership && node scripts/vendor-specialists-skills.mjs --specialists-package specialists --specialists-ref master && npm run gen-registry && npm run check:registry-pack-parity && npm run check:payload-hygiene && npm run check:specialists-vendor && npm run check:layout-guards && npm run check:gitnexus-no-counter && npm run check:skills-symlinks && npm run build",
     "release": "npm publish --tag latest",
     "release:pi-extensions": "npm publish --workspace @jaggerxtrm/pi-extensions --tag latest --access public",
     "release:all": "npm run release && npm run release:pi-extensions",
     "gen-registry": "node scripts/gen-registry.mjs",
-    "check:registry-pack-parity": "node scripts/check-registry-pack-parity.mjs"
+    "check:registry-pack-parity": "node scripts/check-registry-pack-parity.mjs",
+    "check:payload-hygiene": "node scripts/check-payload-hygiene.mjs"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/scripts/__tests__/check-payload-hygiene.test.mjs
+++ b/scripts/__tests__/check-payload-hygiene.test.mjs
@@ -31,3 +31,15 @@ test('flags absolute path leaks in packed text', () => {
     { filePath: 'config.json', match: '/home/alice/' },
   ]);
 });
+
+test('reports both denylist hits and absolute-path leaks together', () => {
+  const forbidden = findForbiddenPackFiles(['.pi/logs/run.log']);
+  const leaks = findAbsolutePathLeaks(new Map([
+    ['README.md', 'see /home/alice/project'],
+  ]));
+
+  assert.equal(forbidden.length, 1);
+  assert.equal(leaks.length, 1);
+  assert.equal(forbidden[0].filePath, '.pi/logs/run.log');
+  assert.equal(leaks[0].filePath, 'README.md');
+});

--- a/scripts/__tests__/check-payload-hygiene.test.mjs
+++ b/scripts/__tests__/check-payload-hygiene.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { findAbsolutePathLeaks, findForbiddenPackFiles } from '../check-payload-hygiene.mjs';
+
+test('flags forbidden packed paths', () => {
+  const hits = findForbiddenPackFiles([
+    '.xtrm/worktrees/tmp/file.txt',
+    '.pi/logs/run.log',
+    'packages/pi-extensions/.serena/state.json',
+    '.beads/issues.jsonl',
+    'ok/readme.md',
+  ]);
+
+  assert.deepEqual(hits.map((hit) => hit.filePath), [
+    '.xtrm/worktrees/tmp/file.txt',
+    '.pi/logs/run.log',
+    'packages/pi-extensions/.serena/state.json',
+    '.beads/issues.jsonl',
+  ]);
+});
+
+test('flags absolute path leaks in packed text', () => {
+  const leaks = findAbsolutePathLeaks(new Map([
+    ['README.md', 'see /home/alice/project'],
+    ['config.json', '{"url":"file:///home/alice/file"}'],
+    ['safe.json', '{"ok":true}'],
+  ]));
+
+  assert.deepEqual(leaks, [
+    { filePath: 'README.md', match: '/home/alice/' },
+    { filePath: 'config.json', match: '/home/alice/' },
+  ]);
+});

--- a/scripts/check-payload-hygiene.mjs
+++ b/scripts/check-payload-hygiene.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const FORBIDDEN_PATH_PATTERNS = [
+  { pattern: /^\.xtrm\/worktrees\//, reason: 'worktree payload' },
+  { pattern: /(^|\/)\.pi(\/|$)/, reason: 'pi runtime artifact' },
+  { pattern: /(^|\/)\.serena(\/|$)/, reason: 'serena metadata' },
+  { pattern: /(^|\/)__pycache__(\/|$)/, reason: 'python cache' },
+  { pattern: /(^|\/)workspace\//, reason: 'workspace output' },
+  { pattern: /(^|\/)evals?(\/|$)/, reason: 'eval output' },
+  { pattern: /(^|\/)\.specialists\/(jobs|db)\//, reason: 'specialists runtime data' },
+  { pattern: /(^|\/)\.beads\/(dolt|backup)\//, reason: 'beads backup data' },
+  { pattern: /(^|\/)\.beads\/issues\.jsonl$/, reason: 'beads issue journal' },
+  { pattern: /(^|\/)logs?(\/|$)|\.(log|db|sqlite)(?:-|$)|\.sqlite$/, reason: 'log/database artifact' },
+];
+
+const TEXT_FILE_PATTERN = /\.(md|json|js|cjs|mjs|ts|cts|tsx|txt|yaml|yml|sh)$/;
+const ABSOLUTE_PATH_PATTERNS = [
+  /\/home\/[A-Za-z0-9._-]+\//,
+  /\/Users\/[A-Za-z0-9._-]+\//,
+  /file:\/\/\/home\//,
+  /file:\/\/\/Users\//,
+];
+
+const allowlist = new Set([]);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+function toPosix(value) {
+  return value.split(path.sep).join('/');
+}
+
+export function findForbiddenPackFiles(packFiles) {
+  return packFiles.flatMap((filePath) => {
+    const match = FORBIDDEN_PATH_PATTERNS.find(({ pattern }) => pattern.test(filePath) && !allowlist.has(filePath));
+    return match ? [{ filePath, reason: match.reason }] : [];
+  });
+}
+
+export function findAbsolutePathLeaks(textByFile) {
+  const leaks = [];
+  for (const [filePath, content] of textByFile) {
+    for (const pattern of ABSOLUTE_PATH_PATTERNS) {
+      const match = content.match(pattern);
+      if (match && !allowlist.has(filePath)) {
+        leaks.push({ filePath, match: match[0] });
+        break;
+      }
+    }
+  }
+  return leaks;
+}
+
+function formatList(title, items, formatItem) {
+  if (items.length === 0) return `${title}: none`;
+  return `${title}:\n${items.map((item) => `- ${formatItem(item)}`).join('\n')}`;
+}
+
+function runPackDryRun() {
+  const output = execFileSync('npm', ['pack', '--dry-run', '--json'], { cwd: repoRoot, encoding: 'utf8' });
+  const results = JSON.parse(output);
+  if (!Array.isArray(results) || results.length !== 1) throw new Error(`Expected one pack result, got ${Array.isArray(results) ? results.length : 'non-array'}`);
+  return results[0].files?.map((file) => toPosix(file.path)) ?? [];
+}
+
+function runPackTarball(tempDir) {
+  const output = execFileSync('npm', ['pack', '--json', '--pack-destination', tempDir], { cwd: repoRoot, encoding: 'utf8' });
+  const results = JSON.parse(output);
+  const tarball = results?.[0]?.filename;
+  if (!tarball) throw new Error('npm pack did not return tarball filename');
+  return path.join(tempDir, tarball);
+}
+
+function listTarballFiles(tarballPath) {
+  const output = execFileSync('tar', ['-tf', tarballPath], { encoding: 'utf8' });
+  return output.trim().split('\n').filter(Boolean).map((entry) => entry.replace(/^package\//, ''));
+}
+
+function readTarballFile(tarballPath, filePath) {
+  return execFileSync('tar', ['-xOf', tarballPath, `package/${filePath}`], { encoding: 'utf8' });
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  const jsonOutput = args.has('--json');
+  const reportOnly = args.has('--report-only');
+
+  const packFiles = runPackDryRun();
+  const forbiddenFiles = findForbiddenPackFiles(packFiles);
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xtrm-payload-'));
+  const textLeaks = [];
+  try {
+    if (forbiddenFiles.length === 0) {
+      const tarballPath = runPackTarball(tempDir);
+      const tarballFiles = listTarballFiles(tarballPath).filter((filePath) => TEXT_FILE_PATTERN.test(filePath));
+      const textByFile = new Map(tarballFiles.map((filePath) => [filePath, readTarballFile(tarballPath, filePath)]));
+      textLeaks.push(...findAbsolutePathLeaks(textByFile));
+    }
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+
+  const ok = forbiddenFiles.length === 0 && textLeaks.length === 0;
+  if (jsonOutput) {
+    console.log(JSON.stringify({ ok, forbiddenFiles, textLeaks }, null, 2));
+  } else if (ok) {
+    console.log(`Payload hygiene ok: ${packFiles.length} packed files`);
+  }
+
+  if (!ok) {
+    if (!jsonOutput) {
+      console.error(formatList('Forbidden packed paths', forbiddenFiles, (item) => `${item.filePath} (${item.reason})`));
+      console.error(formatList('Absolute path leaks', textLeaks, (item) => `${item.filePath}: ${item.match}`));
+    }
+    if (!reportOnly) process.exit(1);
+  }
+}
+
+if (process.argv[1] === __filename) {
+  await main();
+}

--- a/scripts/check-payload-hygiene.mjs
+++ b/scripts/check-payload-hygiene.mjs
@@ -98,12 +98,10 @@ async function main() {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xtrm-payload-'));
   const textLeaks = [];
   try {
-    if (forbiddenFiles.length === 0) {
-      const tarballPath = runPackTarball(tempDir);
-      const tarballFiles = listTarballFiles(tarballPath).filter((filePath) => TEXT_FILE_PATTERN.test(filePath));
-      const textByFile = new Map(tarballFiles.map((filePath) => [filePath, readTarballFile(tarballPath, filePath)]));
-      textLeaks.push(...findAbsolutePathLeaks(textByFile));
-    }
+    const tarballPath = runPackTarball(tempDir);
+    const tarballFiles = listTarballFiles(tarballPath).filter((filePath) => TEXT_FILE_PATTERN.test(filePath));
+    const textByFile = new Map(tarballFiles.map((filePath) => [filePath, readTarballFile(tarballPath, filePath)]));
+    textLeaks.push(...findAbsolutePathLeaks(textByFile));
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Adds `scripts/check-payload-hygiene.mjs` — runs `npm pack --dry-run --json`, fails on packed files matching a denylist (`.xtrm/worktrees/`, `.pi/`, `.serena/`, `__pycache__/`, `*.log`, `*.db`, `*.sqlite*`, `workspace/`, `evals/`, `.specialists/jobs/`, `.specialists/db/`, `.beads/dolt/`, `.beads/backup/`, `.beads/issues.jsonl`).
- Adds independent absolute-path leak scan over packed `*.md/*.json/*.js/*.cjs` text content for `/home/*`, `/Users/*`, `file:///home/`, `file:///Users/`.
- **Both checks always run and report independently** (initially gated only on denylist hit; reviewer flagged; fixed before merge).
- Wires `check:payload-hygiene` into `prepublishOnly` chain after `check:registry-pack-parity`. Pure Node, no new deps.
- Unit test in `scripts/__tests__/check-payload-hygiene.test.mjs` covers denylist-only, absolute-path-only, and combined-hit cases.

Bead: xtrm-7xxz (C1 from 2026-05-13 stabilization audit).

## Surfaced pre-existing leaks
Gate currently fails on 3 pre-existing packed artifacts (intended — that's what the gate is for):
- `.xtrm/.../evals/evals.json` → follow-up bead filed (P2, discovered-from xtrm-7xxz)
- `.xtrm/.../workspace/.../outputs/response.md` → follow-up bead filed (P2)
- `packages/pi-extensions/.serena/project.yml` → follow-up bead filed (P2)

These don't block this PR; they block `npm publish` until cleaned. Release was already deferred per the 2026-05-13 stabilization audit.

## Reviewer note
Initial review PARTIAL 91 on absolute-path scan being gated behind `forbiddenFiles.length === 0` — fixed (scan now always runs and reports independently). Re-review PASS.

## Test plan
- [x] `node --test scripts/__tests__/check-payload-hygiene.test.mjs` (denylist, absolute-path, combined cases)
- [x] `npm run check:payload-hygiene -- --report-only` runs and surfaces real leaks
- [x] `npm run typecheck --workspace cli`
- [x] sp merge TypeScript gate
- [x] pre-push hooks (gitleaks, semgrep, osv-scanner) pass
- [ ] After follow-up cleanups land, `npm run prepublishOnly` end-to-end green