### PR TITLE
fix(check-payload-hygiene): bump tar execFileSync maxBuffer for large packed files

### DIFF
--- a/scripts/__tests__/check-payload-hygiene.test.mjs
+++ b/scripts/__tests__/check-payload-hygiene.test.mjs
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { findAbsolutePathLeaks, findForbiddenPackFiles } from '../check-payload-hygiene.mjs';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { findAbsolutePathLeaks, findForbiddenPackFiles, readTarballFile } from '../check-payload-hygiene.mjs';
 
 test('flags forbidden packed paths', () => {
   const hits = findForbiddenPackFiles([
@@ -42,4 +46,22 @@ test('reports both denylist hits and absolute-path leaks together', () => {
   assert.equal(leaks.length, 1);
   assert.equal(forbidden[0].filePath, '.pi/logs/run.log');
   assert.equal(leaks[0].filePath, 'README.md');
+});
+
+test('reads large tarball files without buffer exhaustion', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xtrm-payload-test-'));
+  try {
+    const packageDir = path.join(tempDir, 'package');
+    await fs.mkdir(packageDir);
+    const bigFilePath = path.join(packageDir, 'big.txt');
+    await fs.writeFile(bigFilePath, 'x'.repeat(2 * 1024 * 1024 + 1));
+
+    const tarballPath = path.join(tempDir, 'payload.tgz');
+    execFileSync('tar', ['-czf', tarballPath, '-C', tempDir, 'package']);
+
+    const content = readTarballFile(tarballPath, 'big.txt');
+    assert.equal(content.length, 2 * 1024 * 1024 + 1);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 });

--- a/scripts/check-payload-hygiene.mjs
+++ b/scripts/check-payload-hygiene.mjs
@@ -83,8 +83,14 @@ function listTarballFiles(tarballPath) {
   return output.trim().split('\n').filter(Boolean).map((entry) => entry.replace(/^package\//, ''));
 }
 
-function readTarballFile(tarballPath, filePath) {
-  return execFileSync('tar', ['-xOf', tarballPath, `package/${filePath}`], { encoding: 'utf8' });
+const TAR_READ_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
+export function readTarballFile(tarballPath, filePath) {
+  // Large packed files need more than execFileSync default 1MB buffer.
+  return execFileSync('tar', ['-xOf', tarballPath, `package/${filePath}`], {
+    encoding: 'utf8',
+    maxBuffer: TAR_READ_MAX_BUFFER_BYTES,
+  });
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- `scripts/check-payload-hygiene.mjs` (landed in #228) crashed with `spawnSync tar ENOBUFS` when reading `cli/dist/index.cjs` (~2.37MB) for absolute-path scanning. `execFileSync` defaults `maxBuffer` to 1MB.
- Bumps `maxBuffer` to 64MB via `TAR_READ_MAX_BUFFER_BYTES` constant. Exports `readTarballFile` for test coverage.
- Extends unit test with a large-file synthetic case.

Bead: xtrm-zb9q.

## Test plan
- [x] `npm run check:payload-hygiene` now runs to completion (still surfaces the 3 expected pre-existing leaks tracked by xtrm-fldz/kuss/of65)
- [x] `node --test scripts/__tests__/check-payload-hygiene.test.mjs` green incl. large-file case
- [x] Reviewer PASS

Unblocks the 3 cleanup beads (xtrm-fldz, xtrm-kuss, xtrm-of65) since the script must actually run to validate them.