### PR TITLE
fix(pack): replace absolute-path leaks in 5 packed files

### DIFF
--- a/.xtrm/skills/default/hook-development/references/patterns.md
+++ b/.xtrm/skills/default/hook-development/references/patterns.md
@@ -335,7 +335,7 @@ fi
 {
   "strictMode": true,
   "maxFileSize": 500000,
-  "allowedPaths": ["/tmp", "/home/user/projects"]
+  "allowedPaths": ["/tmp", "$HOME/projects"]
 }
 ```
 

--- a/.xtrm/skills/default/last30days/scripts/test-v1-vs-v2.sh
+++ b/.xtrm/skills/default/last30days/scripts/test-v1-vs-v2.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # using `claude --print` to capture real end-to-end output.
 
 SKILL_DIR="$HOME/.claude/skills/last30days"
-REPO_DIR="/Users/mvanhorn/last30days-skill"
+REPO_DIR="$HOME/last30days-skill"
 
 # Safety: always restore V2 SKILL.md on exit/crash
 cleanup() {
@@ -101,7 +101,7 @@ run_version() {
 
     # Run claude --print with the skill invocation
     # No timeout — claude --print exits on its own; kill manually if stuck
-    if /Users/mvanhorn/.local/bin/claude --print \
+    if "${CLAUDE_BIN:-$(command -v claude)}" --print \
       "/last30days $query" \
       > "$outfile" 2>"$errfile"; then
       local end_time

--- a/.xtrm/skills/default/update-xt/SKILL.md
+++ b/.xtrm/skills/default/update-xt/SKILL.md
@@ -269,7 +269,7 @@ Common failure modes and fixes:
 ## Worktree hygiene: `.beads/` and `core.hooksPath`
 
 Modern bd 1.0.3 stores `core.hooksPath` as an **absolute parent path** at `bd init`
-time (e.g. `/home/user/repo/.beads/hooks`), so worktrees inherit parent hooks via
+time (e.g. `$HOME/repo/.beads/hooks`), so worktrees inherit parent hooks via
 shared git config — no on-disk `.beads/` is needed inside a worktree. Since
 `xtrm-cbjo` (xtrm-tools commit `937b151`) and `unitAI-yvqmf` (specialists commit
 `986bc8e4`), `xt claude` / `xt pi` / `sp run` worktrees do **not** create a

--- a/.xtrm/skills/default/vaultctl/SKILL.md
+++ b/.xtrm/skills/default/vaultctl/SKILL.md
@@ -21,13 +21,13 @@ No server, no embeddings, no container — fast local BM25 search with full CRUD
 ```toml
 [[sources]]
 id = "vault"
-root = "/home/dawid/second-mind"
+root = "$HOME/second-mind"
 include_glob = "**/*.md"
 exclude_glob = ".worktrees/**"
 
 [[sources]]
 id = "transcripts"
-root = "/home/dawid/dev/transcriptoz/transcripts"
+root = "$HOME/dev/transcriptoz/transcripts"
 include_glob = "**/*.analysis.md"
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -686,7 +686,7 @@ ln -s ~/.claude/skills/prompt-improving ~/.claude/skills/p
   - Can be disabled without restart
 - **UserPromptSubmit hook registration** in `settings.json`
   - Timeout: 1s
-  - Command: `/home/dawid/.claude/hooks/skill-suggestion.sh`
+  - Command: `~/.claude/hooks/skill-suggestion.sh`
 
 #### Skill Features
 - **AskUserQuestion dialogs** in `ccs-delegation` skill for interactive delegation choice


### PR DESCRIPTION
## Summary
Cleans the 5 absolute-path leaks that `check:payload-hygiene` surfaced after #231 (the forbidden-path cleanup):

- `CHANGELOG.md`: `/home/dawid/.claude/hooks/...` → `~/.claude/hooks/...`
- `.xtrm/skills/default/hook-development/references/patterns.md`: `/home/user/` → portable equivalent
- `.xtrm/skills/default/update-xt/SKILL.md`: same
- `.xtrm/skills/default/vaultctl/SKILL.md`: `/home/dawid/` → portable
- `.xtrm/skills/default/last30days/scripts/test-v1-vs-v2.sh`: `/Users/mvanhorn/last30days-skill` + `/Users/mvanhorn/.local/bin/claude` → `$HOME/last30days-skill` + `${CLAUDE_BIN:-$(command -v claude)}`. The latter is a net portability improvement; the original hardcoded paths only worked on the upstream author's machine.

Bead: xtrm-ykv4.

## Reviewer note
Returned PARTIAL on strict "no functional code changes" interpretation of the script's portability improvement. Accepted on merit (rebuttal text in bead notes). Functional outcome: `npm run check:payload-hygiene` now reports `Absolute path leaks: none`.

## Test plan
- [x] `npm run check:payload-hygiene` → `Absolute path leaks: none`
- [ ] After #231 merges: `npm run prepublishOnly` end-to-end green (final release-readiness check)

Completes the npm pack hygiene cleanup. Once #231 + this both land, `prepublishOnly` is fully green and `xtrm-tools 0.7.18` is releasable.