### PR TITLE
perf(pi-runtime): cache npm root resolution across managed package loop

### DIFF
--- a/cli/dist/index.cjs
+++ b/cli/dist/index.cjs
@@ -54551,13 +54551,11 @@ async function ensureAlwaysGlobalPiPackages(dryRun, log, agentDir = PI_AGENT_DIR
   return { installed, failed };
 }
 async function assureXtManagedPiPackages(dryRun, log, agentDir = PI_AGENT_DIR, installRunner = runPiPackageInstall, versionProvider) {
-  const resolvedVersionProvider = versionProvider ?? (async (_piPackageId, npmPackageName) => {
-    const npmRootDir = await resolveGlobalNpmRootDir();
-    return {
-      installedVersion: await getInstalledPiPackageVersion(agentDir, npmPackageName, npmRootDir ?? void 0),
-      expectedVersion: await getExpectedPiPackageVersion(npmPackageName)
-    };
-  });
+  const npmRootDir = await resolveGlobalNpmRootDir();
+  const resolvedVersionProvider = versionProvider ?? (async (_piPackageId, npmPackageName) => ({
+    installedVersion: await getInstalledPiPackageVersion(agentDir, npmPackageName, npmRootDir ?? void 0),
+    expectedVersion: await getExpectedPiPackageVersion(npmPackageName)
+  }));
   const statuses = await getManagedPiPackageFreshness(resolvedVersionProvider);
   const missing = statuses.filter((status) => status.state === "missing");
   const outdated = statuses.filter((status) => status.state === "outdated");
@@ -54588,11 +54586,13 @@ async function assureXtManagedPiPackages(dryRun, log, agentDir = PI_AGENT_DIR, i
   }
   return { statuses, missing, outdated, installed, refreshed, failed };
 }
-async function getXtManagedPiPackageDoctorReport(versionProvider = async (_piPackageId, npmPackageName) => ({
-  installedVersion: await getInstalledPiPackageVersion(PI_AGENT_DIR, npmPackageName, await resolveGlobalNpmRootDir() ?? void 0),
-  expectedVersion: await getExpectedPiPackageVersion(npmPackageName)
-})) {
-  const statuses = await getManagedPiPackageFreshness(versionProvider, getXtManagedPiPackages());
+async function getXtManagedPiPackageDoctorReport(versionProvider) {
+  const npmRootDir = await resolveGlobalNpmRootDir();
+  const resolvedVersionProvider = versionProvider ?? (async (_piPackageId, npmPackageName) => ({
+    installedVersion: await getInstalledPiPackageVersion(PI_AGENT_DIR, npmPackageName, npmRootDir ?? void 0),
+    expectedVersion: await getExpectedPiPackageVersion(npmPackageName)
+  }));
+  const statuses = await getManagedPiPackageFreshness(resolvedVersionProvider, getXtManagedPiPackages());
   const issues = statuses.filter((status) => status.state !== "current").map((status) => ({
     ...status,
     remediation: status.state === "version-unknown" ? "check network/npm registry, then rerun xt doctor" : "pi install " + status.pkg.id

--- a/cli/src/core/pi-runtime.ts
+++ b/cli/src/core/pi-runtime.ts
@@ -738,13 +738,11 @@ export async function assureXtManagedPiPackages(
     installRunner: PiPackageInstallRunner = runPiPackageInstall,
     versionProvider?: PiPackageVersionProvider,
 ): Promise<PiPackageAssuranceResult> {
-    const resolvedVersionProvider = versionProvider ?? (async (_piPackageId, npmPackageName) => {
-        const npmRootDir = await resolveGlobalNpmRootDir();
-        return {
-            installedVersion: await getInstalledPiPackageVersion(agentDir, npmPackageName, npmRootDir ?? undefined),
-            expectedVersion: await getExpectedPiPackageVersion(npmPackageName),
-        };
-    });
+    const npmRootDir = await resolveGlobalNpmRootDir();
+    const resolvedVersionProvider = versionProvider ?? (async (_piPackageId, npmPackageName) => ({
+        installedVersion: await getInstalledPiPackageVersion(agentDir, npmPackageName, npmRootDir ?? undefined),
+        expectedVersion: await getExpectedPiPackageVersion(npmPackageName),
+    }));
 
     const statuses = await getManagedPiPackageFreshness(resolvedVersionProvider);
     const missing = statuses.filter((status) => status.state === 'missing');
@@ -782,12 +780,15 @@ export async function assureXtManagedPiPackages(
 }
 
 export async function getXtManagedPiPackageDoctorReport(
-    versionProvider: PiPackageVersionProvider = async (_piPackageId, npmPackageName) => ({
-        installedVersion: await getInstalledPiPackageVersion(PI_AGENT_DIR, npmPackageName, (await resolveGlobalNpmRootDir()) ?? undefined),
-        expectedVersion: await getExpectedPiPackageVersion(npmPackageName),
-    }),
+    versionProvider?: PiPackageVersionProvider,
 ): Promise<XtManagedPiPackageDoctorReport> {
-    const statuses = await getManagedPiPackageFreshness(versionProvider, getXtManagedPiPackages());
+    const npmRootDir = await resolveGlobalNpmRootDir();
+    const resolvedVersionProvider = versionProvider ?? (async (_piPackageId, npmPackageName) => ({
+        installedVersion: await getInstalledPiPackageVersion(PI_AGENT_DIR, npmPackageName, npmRootDir ?? undefined),
+        expectedVersion: await getExpectedPiPackageVersion(npmPackageName),
+    }));
+
+    const statuses = await getManagedPiPackageFreshness(resolvedVersionProvider, getXtManagedPiPackages());
     const issues = statuses
         .filter((status) => status.state !== 'current')
         .map((status) => ({


### PR DESCRIPTION
## Summary
- PR #226 introduced `resolveGlobalNpmRootDir()` (shells `npm root -g`). The default `versionProvider` invoked it once per package, and the freshness loop iterates ~8 managed packages serially → 8× `npm root -g` subprocess spawns per `xt update` / `xt doctor`.
- Hoists the call out of the per-package closure in `assureXtManagedPiPackages` and `getXtManagedPiPackageDoctorReport`. Result: 1× per command.

Bead: xtrm-w6ey (Codex finding on PR #226). Reviewer PASS.

## Test plan
- [x] Diff inspection — only cli/src/core/pi-runtime.ts
- [x] Reviewer PASS
- [ ] Manual smoke: `time xt doctor --json` (should be noticeably faster on slow-`npm`-startup machines)