### PR TITLE
fix(ci): install Bun in smoke workflows (specialists sp prereq) (xtrm-ss0j)

### DIFF
--- a/.github/workflows/fresh-machine-smoke.yml
+++ b/.github/workflows/fresh-machine-smoke.yml
@@ -42,6 +42,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      # Bun is required by @jaggerxtrm/specialists (sp binary uses
+      # `#!/usr/bin/env bun`). Documented in specialists package.json
+      # engines.bun >= 1.0.0.
+      - name: Use Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Isolate npm cache
         shell: bash
         run: |

--- a/.github/workflows/install-order-matrix.yml
+++ b/.github/workflows/install-order-matrix.yml
@@ -37,6 +37,12 @@ jobs:
         with:
           python-version: "3.11"
 
+      # Bun is required by @jaggerxtrm/specialists (sp shebang).
+      - name: Use Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Pack xtrm-tools
         run: |
           set -euo pipefail

--- a/docs/release.md
+++ b/docs/release.md
@@ -208,6 +208,10 @@ The three previously-deferred items are all closed as of `xtrm-lhqy`:
 - **xtrm-5k0o (PATH cache) fixed.** `checkDep` in `cli/src/core/machine-bootstrap.ts` extends `process.env.PATH` with `~/.local/bin`, `/usr/local/bin`, and `/opt/homebrew/bin` on module load, so `spawnSync` finds binaries that were just installed in the same process.
 - **`pre-publish-readiness.yml` is a real dry-run.** Rewritten as a 3-job DAG (resolve_ref → fresh_machine_smoke → publish_dry_run) that runs the exact same gate chain as `publish.yml` minus `npm publish`. Use it to confirm the chain is green before tagging.
 
+### Runtime prerequisites for `sp`
+
+`@jaggerxtrm/specialists` ships its `sp` binary with `#!/usr/bin/env bun` and declares `engines.bun >= 1.0.0`. Any environment running `sp init` / `sp doctor` / `sp list` must have Bun on PATH. CI workflows (`fresh-machine-smoke.yml`, `install-order-matrix.yml`) install Bun via `oven-sh/setup-bun@v2`. Local operators need `curl -fsSL https://bun.sh/install | bash` or equivalent.
+
 ### install-order-matrix scope clarification
 
 `install-order-matrix.yml` stays `workflow_dispatch`-only by design — not because of a bug we can fix. The legs install third-party packages (`@beads/bd`, `oh-pi`, `dolt`, `bv`, etc.) whose bin layouts and post-install download behavior vary across environments. `@beads/bd` is a binary-downloader that drops the real `bd` into `~/.local/bin` via a postinstall script; `oh-pi` exposes only `oh-pi` (the `pi` command on dev machines is a separately-installed `@mariozechner/pi-coding-agent`). Validating those is upstream packaging concerns, not release-contract concerns. Run the matrix manually before tagging when you want a regression catcher; the actual release gating happens in `publish.yml` → `fresh_machine_smoke` which exercises the full `xt init` + `sp init` flow against the vendored mirror.


### PR DESCRIPTION
## Summary

Re-running pre-publish-readiness on main surfaced `/usr/bin/env: 'bun': No such file or directory` — specialists' `sp` binary requires Bun (shebang `#!/usr/bin/env bun`, `engines.bun >= 1.0.0`). Smoke workflows install Node + Python but not Bun.

## Change

- `oven-sh/setup-bun@v2` step in fresh-machine-smoke.yml and install-order-matrix.yml.
- docs/release.md documents the runtime prereq.

## Test plan

- [ ] After merge: `gh workflow run pre-publish-readiness.yml` → expect green (or surface a real release-contract failure).

Bead: xtrm-ss0j (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)