### PR TITLE
fix(ci): resolve_ref prefers immutable resolved_sha (xtrm-8uox)

### DIFF
--- a/.github/workflows/fresh-machine-smoke.yml
+++ b/.github/workflows/fresh-machine-smoke.yml
@@ -42,6 +42,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      # Bun is required by @jaggerxtrm/specialists (sp binary uses
+      # `#!/usr/bin/env bun`). Documented in specialists package.json
+      # engines.bun >= 1.0.0.
+      - name: Use Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Isolate npm cache
         shell: bash
         run: |

--- a/.github/workflows/install-order-matrix.yml
+++ b/.github/workflows/install-order-matrix.yml
@@ -37,6 +37,12 @@ jobs:
         with:
           python-version: "3.11"
 
+      # Bun is required by @jaggerxtrm/specialists (sp shebang).
+      - name: Use Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Pack xtrm-tools
         run: |
           set -euo pipefail

--- a/.github/workflows/pre-publish-readiness.yml
+++ b/.github/workflows/pre-publish-readiness.yml
@@ -29,17 +29,21 @@ jobs:
         env:
           INPUT_REF: ${{ inputs.specialists_ref }}
         run: |
+          # Prefer the immutable resolved_sha (matches the mirror by
+          # construction) unless the operator passed an explicit override.
           if [ -n "$INPUT_REF" ]; then
-            ref="$INPUT_REF"
+            resolved="$INPUT_REF"
           else
-            ref="$(jq -er '.source.ref' .xtrm/specialists-source.json)"
+            sha="$(jq -r '.source.resolved_sha // empty' .xtrm/specialists-source.json)"
+            ref="$(jq -r '.source.ref // empty' .xtrm/specialists-source.json)"
+            resolved="${sha:-$ref}"
           fi
-          if [ -z "$ref" ] || [ "$ref" = "null" ]; then
+          if [ -z "$resolved" ]; then
             echo "::error::could not resolve specialists ref" >&2
             exit 1
           fi
-          echo "specialists_ref=$ref" >> "$GITHUB_OUTPUT"
-          echo "Resolved specialists ref: $ref"
+          echo "specialists_ref=$resolved" >> "$GITHUB_OUTPUT"
+          echo "Resolved specialists ref: $resolved"
 
   fresh_machine_smoke:
     needs: resolve_ref

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,19 @@ jobs:
         id: resolve
         shell: bash
         run: |
-          ref="$(jq -er '.source.ref' .xtrm/specialists-source.json)"
-          if [ -z "$ref" ] || [ "$ref" = "null" ]; then
-            echo "::error::.xtrm/specialists-source.json missing source.ref" >&2
+          # Prefer the immutable resolved_sha (what we vendored against)
+          # over the moving ref (e.g. 'master'). This guarantees the
+          # specialists tarball used by fresh-machine-smoke matches the
+          # mirror in .xtrm/skills/default by construction.
+          sha="$(jq -r '.source.resolved_sha // empty' .xtrm/specialists-source.json)"
+          ref="$(jq -r '.source.ref // empty' .xtrm/specialists-source.json)"
+          resolved="${sha:-$ref}"
+          if [ -z "$resolved" ]; then
+            echo "::error::.xtrm/specialists-source.json missing both source.resolved_sha and source.ref" >&2
             exit 1
           fi
-          echo "specialists_ref=$ref" >> "$GITHUB_OUTPUT"
-          echo "Resolved specialists ref: $ref"
+          echo "specialists_ref=$resolved" >> "$GITHUB_OUTPUT"
+          echo "Resolved specialists ref: $resolved (sha=$sha ref=$ref)"
 
   fresh_machine_smoke:
     needs: resolve_ref

--- a/docs/release.md
+++ b/docs/release.md
@@ -208,6 +208,10 @@ The three previously-deferred items are all closed as of `xtrm-lhqy`:
 - **xtrm-5k0o (PATH cache) fixed.** `checkDep` in `cli/src/core/machine-bootstrap.ts` extends `process.env.PATH` with `~/.local/bin`, `/usr/local/bin`, and `/opt/homebrew/bin` on module load, so `spawnSync` finds binaries that were just installed in the same process.
 - **`pre-publish-readiness.yml` is a real dry-run.** Rewritten as a 3-job DAG (resolve_ref → fresh_machine_smoke → publish_dry_run) that runs the exact same gate chain as `publish.yml` minus `npm publish`. Use it to confirm the chain is green before tagging.
 
+### Runtime prerequisites for `sp`
+
+`@jaggerxtrm/specialists` ships its `sp` binary with `#!/usr/bin/env bun` and declares `engines.bun >= 1.0.0`. Any environment running `sp init` / `sp doctor` / `sp list` must have Bun on PATH. CI workflows (`fresh-machine-smoke.yml`, `install-order-matrix.yml`) install Bun via `oven-sh/setup-bun@v2`. Local operators need `curl -fsSL https://bun.sh/install | bash` or equivalent.
+
 ### install-order-matrix scope clarification
 
 `install-order-matrix.yml` stays `workflow_dispatch`-only by design — not because of a bug we can fix. The legs install third-party packages (`@beads/bd`, `oh-pi`, `dolt`, `bv`, etc.) whose bin layouts and post-install download behavior vary across environments. `@beads/bd` is a binary-downloader that drops the real `bd` into `~/.local/bin` via a postinstall script; `oh-pi` exposes only `oh-pi` (the `pi` command on dev machines is a separately-installed `@mariozechner/pi-coding-agent`). Validating those is upstream packaging concerns, not release-contract concerns. Run the matrix manually before tagging when you want a regression catcher; the actual release gating happens in `publish.yml` → `fresh_machine_smoke` which exercises the full `xt init` + `sp init` flow against the vendored mirror.


### PR DESCRIPTION
## Summary

Smoke-test on main surfaced a real drift detected by sp doctor: `2 drifted files between specialists package live and .xtrm/skills/default`. Cause: `resolve_ref` returned `.source.ref = master` (moving), fresh-machine-smoke checked out specialists at master HEAD, which had moved past the SHA we vendored against.

## Change

`resolve_ref` in publish.yml and pre-publish-readiness.yml now prefers `.source.resolved_sha` (immutable, captured at vendor time) over `.source.ref`. Live specialists tarball used by fresh_machine_smoke matches the vendored mirror by construction.

## Test plan

- [ ] After merge: `gh workflow run pre-publish-readiness.yml` → expect green.

Bead: xtrm-8uox (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)