### PR TITLE
fix(pi): installer adds ~/.xtrm/skills/default as fallback skills path (xtrm-4h6u)

### DIFF
--- a/cli/dist/index.cjs
+++ b/cli/dist/index.cjs
@@ -54194,6 +54194,7 @@ async function resolveGlobalNpmRootDir() {
 }
 var PROJECT_EXTENSIONS_ENTRY = "../.xtrm/extensions";
 var PROJECT_SKILLS_ENTRY = "../.xtrm/skills/active";
+var USER_DEFAULT_SKILLS_ENTRY = "~/.xtrm/skills/default";
 var PROJECT_EXTENSION_PACKAGE_ID = "npm:@jaggerxtrm/pi-extensions";
 var PROJECT_EXTENSION_PACKAGE = {
   id: PROJECT_EXTENSION_PACKAGE_ID,
@@ -54820,8 +54821,9 @@ async function updatePiSettings(projectRoot, dryRun, log) {
   if (!existingPackages.includes(PROJECT_EXTENSION_PACKAGE_ID)) {
     existingPackages.push(PROJECT_EXTENSION_PACKAGE_ID);
   }
-  const existingSkills = normalizeStringArray(existingSettings.skills).filter((entry) => entry !== PROJECT_SKILLS_ENTRY);
+  const existingSkills = normalizeStringArray(existingSettings.skills).filter((entry) => entry !== PROJECT_SKILLS_ENTRY && entry !== USER_DEFAULT_SKILLS_ENTRY);
   existingSkills.unshift(PROJECT_SKILLS_ENTRY);
+  existingSkills.push(USER_DEFAULT_SKILLS_ENTRY);
   const existingExtensions = normalizeStringArray(existingSettings.extensions).filter((entry) => !LEGACY_PROJECT_EXTENSION_ENTRIES.has(entry));
   const nextSettings = {
     ...existingSettings,
@@ -54830,7 +54832,7 @@ async function updatePiSettings(projectRoot, dryRun, log) {
     packages: existingPackages
   };
   await import_fs_extra8.default.writeJson(piSettingsPath, nextSettings, { spaces: 2 });
-  log?.(kleur_default.dim(`Updated .pi/settings.json \u2192 ${PROJECT_EXTENSION_PACKAGE_ID} + ${PROJECT_SKILLS_ENTRY}`));
+  log?.(kleur_default.dim(`Updated .pi/settings.json \u2192 ${PROJECT_EXTENSION_PACKAGE_ID} + ${PROJECT_SKILLS_ENTRY} + ${USER_DEFAULT_SKILLS_ENTRY}`));
 }
 async function executePiSync(plan, sourceDir, targetDir, opts = {}) {
   const {

--- a/cli/src/core/pi-runtime.ts
+++ b/cli/src/core/pi-runtime.ts
@@ -80,6 +80,11 @@ async function resolveGlobalNpmRootDir(): Promise<string | null> {
 }
 const PROJECT_EXTENSIONS_ENTRY = '../.xtrm/extensions';
 const PROJECT_SKILLS_ENTRY = '../.xtrm/skills/active';
+// User-level fallback: skills installed at user scope live under
+// ~/.xtrm/skills/default/ and must resolve when a project doesn't
+// vendor a copy (xtrm-4h6u). Pi resolves entries in order, so project
+// active always wins; user default is the last-chance fallback.
+const USER_DEFAULT_SKILLS_ENTRY = '~/.xtrm/skills/default';
 const PROJECT_EXTENSION_PACKAGE_ID = 'npm:@jaggerxtrm/pi-extensions';
 const PROJECT_EXTENSION_PACKAGE: ManagedPackage = {
     id: PROJECT_EXTENSION_PACKAGE_ID,
@@ -1099,7 +1104,7 @@ async function cleanupConflictingPiPackageSettings(
     );
 }
 
-async function updatePiSettings(
+export async function updatePiSettings(
     projectRoot: string,
     dryRun: boolean,
     log?: (message: string) => void,
@@ -1129,9 +1134,17 @@ async function updatePiSettings(
         existingPackages.push(PROJECT_EXTENSION_PACKAGE_ID);
     }
 
+    // Skills resolution order:
+    //   1. PROJECT_SKILLS_ENTRY (../.xtrm/skills/active) — project-local
+    //   2. (user-added entries preserved here in middle)
+    //   3. USER_DEFAULT_SKILLS_ENTRY (~/.xtrm/skills/default) — fallback
+    // Pi picks the first match per skill name; without #3, specialists
+    // that reference skills not vendored into the project fail to resolve
+    // (xtrm-4h6u).
     const existingSkills = normalizeStringArray(existingSettings.skills)
-        .filter((entry) => entry !== PROJECT_SKILLS_ENTRY);
+        .filter((entry) => entry !== PROJECT_SKILLS_ENTRY && entry !== USER_DEFAULT_SKILLS_ENTRY);
     existingSkills.unshift(PROJECT_SKILLS_ENTRY);
+    existingSkills.push(USER_DEFAULT_SKILLS_ENTRY);
 
     const existingExtensions = normalizeStringArray(existingSettings.extensions)
         .filter((entry) => !LEGACY_PROJECT_EXTENSION_ENTRIES.has(entry));
@@ -1144,7 +1157,7 @@ async function updatePiSettings(
     };
 
     await fs.writeJson(piSettingsPath, nextSettings, { spaces: 2 });
-    log?.(kleur.dim(`Updated .pi/settings.json → ${PROJECT_EXTENSION_PACKAGE_ID} + ${PROJECT_SKILLS_ENTRY}`));
+    log?.(kleur.dim(`Updated .pi/settings.json → ${PROJECT_EXTENSION_PACKAGE_ID} + ${PROJECT_SKILLS_ENTRY} + ${USER_DEFAULT_SKILLS_ENTRY}`));
 }
 
 /**

--- a/cli/src/tests/pi-runtime-safeguards.test.ts
+++ b/cli/src/tests/pi-runtime-safeguards.test.ts
@@ -303,4 +303,65 @@ describe('pi runtime safeguards', () => {
     expect(result.remediated).toBe(true);
     expect(await fs.pathExists(overrideDir)).toBe(false);
   });
+
+  describe('updatePiSettings — pi skills resolution paths (xtrm-4h6u)', () => {
+    it('seeds both project active and user default into a fresh .pi/settings.json', async () => {
+      const { updatePiSettings } = await import('../core/pi-runtime.js');
+      const projectRoot = path.join(tempRoot, 'fresh-project');
+      await fs.ensureDir(projectRoot);
+
+      await updatePiSettings(projectRoot, false);
+
+      const settings = await fs.readJson(path.join(projectRoot, '.pi', 'settings.json'));
+      expect(settings.skills).toEqual([
+        '../.xtrm/skills/active',
+        '~/.xtrm/skills/default',
+      ]);
+    });
+
+    it('preserves user-added skill paths between the two managed entries', async () => {
+      const { updatePiSettings } = await import('../core/pi-runtime.js');
+      const projectRoot = path.join(tempRoot, 'with-user-paths');
+      await fs.ensureDir(path.join(projectRoot, '.pi'));
+
+      await fs.writeJson(path.join(projectRoot, '.pi', 'settings.json'), {
+        skills: ['./my-custom-skills', '/abs/team-skills'],
+      });
+
+      await updatePiSettings(projectRoot, false);
+
+      const settings = await fs.readJson(path.join(projectRoot, '.pi', 'settings.json'));
+      expect(settings.skills).toEqual([
+        '../.xtrm/skills/active',
+        './my-custom-skills',
+        '/abs/team-skills',
+        '~/.xtrm/skills/default',
+      ]);
+    });
+
+    it('is idempotent — a second run does not duplicate the managed entries', async () => {
+      const { updatePiSettings } = await import('../core/pi-runtime.js');
+      const projectRoot = path.join(tempRoot, 'idempotent');
+      await fs.ensureDir(projectRoot);
+
+      await updatePiSettings(projectRoot, false);
+      await updatePiSettings(projectRoot, false);
+
+      const settings = await fs.readJson(path.join(projectRoot, '.pi', 'settings.json'));
+      expect(settings.skills).toEqual([
+        '../.xtrm/skills/active',
+        '~/.xtrm/skills/default',
+      ]);
+    });
+
+    it('does not write in dry-run mode', async () => {
+      const { updatePiSettings } = await import('../core/pi-runtime.js');
+      const projectRoot = path.join(tempRoot, 'dry-run');
+      await fs.ensureDir(projectRoot);
+
+      await updatePiSettings(projectRoot, true);
+
+      expect(await fs.pathExists(path.join(projectRoot, '.pi', 'settings.json'))).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

P0 bug. `xt init` / `xt update` scaffolded `.pi/settings.json` with only the project-local skills path:
```json
"skills": ["../.xtrm/skills/active"]
```
Specialist configs that reference skills by canonical name (e.g. `.xtrm/skills/active/clean-code/SKILL.md`) failed to resolve in projects that don't vendor those skills under `.xtrm/skills/active/`. Pi's `validateBeforeRun` emitted warnings and specialists ran without their declared skills.

## Change

`updatePiSettings` now seeds two skills entries in resolution order:
```json
"skills": [
  "../.xtrm/skills/active",     // project-local, wins
  "~/.xtrm/skills/default"      // user-level fallback
]
```

User-added entries between the two managed ones are preserved. Idempotent across repeated `xt update` runs. Skipped in dry-run.

`updatePiSettings` is now exported for direct testability.

## Test plan

- [x] 4 new tests in `pi-runtime-safeguards.test.ts` cover: fresh scaffold, user-paths preservation, idempotency, dry-run.
- [x] `bunx vitest run` for the four new tests: all pass.
- [x] Pre-existing 2 unrelated test failures in same file remain unchanged (out of scope).

Bead: xtrm-4h6u (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)