### PR TITLE
fix(cli): upsertManagedBlock greedy match collapses duplicate blocks + orphan markers (xtrm-ya67)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - Ask for confirmation only when actions are destructive, irreversible, or high-risk (e.g. `rm`, history rewrite, mass deletes, credential rotation, prod-impacting ops).
 - Prefer concise clarifying questions only when requirements are genuinely ambiguous.
 
-## Active Gates (extensions enforce these — not optional)
+## Active Gates (hooks enforce these — not optional)
 
 | Gate | Trigger | Required action |
 |------|---------|-----------------|
@@ -145,114 +145,9 @@ bv --robot-insights | jq '.Cycles'               # Circular deps — must fix
 
 ## Worktree Sessions
 
+- `xt claude` — launch Claude Code in a sandboxed worktree
 - `xt pi` — launch Pi in a sandboxed worktree
 - `xt end` — close session: commit / push / PR / cleanup
-<!-- xtrm:end -->
-
-# XTRM Agent Workflow
-
-> Full reference: [XTRM-GUIDE.md](XTRM-GUIDE.md)
-
-## bd Command Reference
-
-```bash
-# Work discovery
-bd ready                               # Unblocked open issues
-bd show <id>                           # Full detail + deps + blockers
-bd list --status=in_progress           # Your active claims
-bd query "status=in_progress AND assignee=me"  # Complex filter
-bd search <text>                       # Full-text search across issues
-
-# Claiming & updating
-bd update <id> --claim                 # Claim (sets you as owner, status→in_progress)
-bd update <id> --notes "..."           # Append notes inline
-bd update <id> --status=blocked        # Mark blocked
-bd update                              # Update last-touched issue (no ID needed)
-
-# Creating
-bd create --title="..." --description="..." --type=task --priority=2
-# --deps "discovered-from:<parent-id>"  link follow-ups to source
-# priority: 0=critical  1=high  2=medium  3=low  4=backlog
-# types: task | bug | feature | epic | chore | decision
-
-# Closing
-bd close <id>                          # Close issue
-bd close <id> --reason="Done: ..."     # Close with context
-bd close <id1> <id2> <id3>            # Batch close
-
-# Dependencies
-bd dep add <issue> <depends-on>        # issue depends on depends-on (depends-on blocks issue)
-bd dep <blocker> --blocks <blocked>    # shorthand: blocker blocks blocked
-bd dep relate <a> <b>                  # non-blocking "relates to" link
-bd dep tree <id>                       # visualise dependency tree
-bd blocked                             # show all currently blocked issues
-
-# Persistent memory
-bd remember "<insight>"                # Store across sessions (project-scoped)
-bd memories <keyword>                  # Search stored memories
-bd recall <key>                        # Retrieve full memory by key
-bd forget <key>                        # Remove a memory
-
-# Health & pre-flight
-bd stats                               # Open/closed/blocked counts
-bd preflight --check                   # Pre-PR readiness (lint, tests, beads)
-bd doctor                              # Diagnose installation issues
-```
-
-# ... write code ...
-bd close <id> --reason="..."                 # closes issue
-xt end                                       # push, PR, merge, worktree cleanup
-```
-
-**Never** continue new work on a previously used branch.
-
-## bv — Graph-Aware Triage
-
-bv is a graph-aware triage engine for the beads issue board. Use it instead of `bd ready` when you need ranked picks, dependency-aware scheduling, or project health signals.
-
-> **CRITICAL: Use ONLY `--robot-*` flags. Bare `bv` launches an interactive TUI that blocks your session.**
-
-```bash
-bv --robot-triage             # THE entry point — ranked picks, quick wins, blockers, health
-bv --robot-next               # Single top pick + claim command (minimal output)
-bv --robot-triage --format toon  # Token-optimized output for lower context usage
-```
-
-**Scope boundary:** bv = *what to work on*. `bd` = creating, claiming, closing issues.
-
-### Planning & Analysis
-
-| Command | Returns |
-|---------|---------|
-| `--robot-plan` | Parallel execution tracks with unblocks lists |
-| `--robot-priority` | Priority misalignment detection |
-| `--robot-insights` | Full graph metrics: PageRank, betweenness, HITS, eigenvector, critical path, cycles |
-| `--robot-forecast <id\|all>` | ETA predictions with dependency-aware scheduling |
-| `--robot-alerts` | Stale issues, blocking cascades, priority mismatches |
-| `--robot-diff --diff-since <ref>` | Changes since ref: new/closed/modified, cycles introduced/resolved |
-
-### Scoping & Filtering
-
-```bash
-bv --robot-plan --label backend        # Scope to label's subgraph
-bv --recipe actionable --robot-plan    # Pre-filter: ready to work (no blockers)
-bv --recipe high-impact --robot-triage # Pre-filter: top PageRank scores
-bv --robot-triage --robot-triage-by-track  # Group by parallel work streams
-```
-
-### Understanding Output
-
-- `data_hash` — fingerprint of beads state (verify consistency across calls)
-- Phase 1 (instant): degree, topo sort, density
-- Phase 2 (async, 500ms): PageRank, betweenness, HITS, cycles — check `status` flags
-
-```bash
-bv --robot-triage | jq '.quick_ref'              # At-a-glance summary
-bv --robot-triage | jq '.recommendations[0]'     # Top recommendation
-bv --robot-plan | jq '.plan.summary.highest_impact'
-bv --robot-insights | jq '.Cycles'               # Circular deps — must fix
-```
-
 <!-- xtrm:end -->
 
 <!-- gitnexus:start -->

--- a/cli/dist/index.cjs
+++ b/cli/dist/index.cjs
@@ -58815,7 +58815,7 @@ ${normalizedBody}
 ${endMarker}`;
   const escapedStart = startMarker.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
   const escapedEnd = endMarker.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
-  const existingBlockPattern = new RegExp(`${escapedStart}[\\s\\S]*?${escapedEnd}`, "m");
+  const existingBlockPattern = new RegExp(`${escapedStart}[\\s\\S]*${escapedEnd}`, "m");
   if (existingBlockPattern.test(fileContent)) {
     return fileContent.replace(existingBlockPattern, managedBlock);
   }

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -275,7 +275,16 @@ export function upsertManagedBlock(
     const managedBlock = `${startMarker}\n${normalizedBody}\n${endMarker}`;
     const escapedStart = startMarker.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
     const escapedEnd = endMarker.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
-    const existingBlockPattern = new RegExp(`${escapedStart}[\\s\\S]*?${escapedEnd}`, 'm');
+
+    // Greedy match from the FIRST start marker to the LAST end marker so any
+    // duplicate-content + orphan-end-marker tail left behind by older lazy
+    // (`*?`) versions of this function gets swept into the replacement
+    // (xtrm-ya67). The lazy variant only consumed the first start..end pair,
+    // leaving a duplicated header block + a free-floating end marker after it.
+    // Markers are caller-supplied but pre-escaped via the replace() above; no
+    // ReDoS surface from end-user input here.
+    // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
+    const existingBlockPattern = new RegExp(`${escapedStart}[\\s\\S]*${escapedEnd}`, 'm');
 
     if (existingBlockPattern.test(fileContent)) {
         return fileContent.replace(existingBlockPattern, managedBlock);
@@ -336,7 +345,7 @@ function getScriptFilename(hook: any): string | null {
 /**
  * Prune hooks from settings.json that are NOT in the canonical config.
  * This removes stale entries from old versions before merging new ones.
- * 
+ *
  * @param existing Current settings.json hooks
  * @param canonical Canonical hooks config from hooks.json
  * @returns Pruned settings with stale hooks removed
@@ -974,5 +983,3 @@ function getProjectRoot(): string {
     }
     return path.resolve(result.stdout.trim());
 }
-
-

--- a/cli/src/tests/upsert-managed-block.test.ts
+++ b/cli/src/tests/upsert-managed-block.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { upsertManagedBlock } from '../commands/init.js';
+
+const START = '<!-- xtrm:start -->';
+const END = '<!-- xtrm:end -->';
+
+describe('upsertManagedBlock', () => {
+  it('prepends a managed block to an empty file', () => {
+    const out = upsertManagedBlock('', 'body content');
+    expect(out).toBe(`${START}\nbody content\n${END}\n`);
+  });
+
+  it('prepends a managed block to a file with existing user content', () => {
+    const existing = '# User header\n\nuser content here\n';
+    const out = upsertManagedBlock(existing, 'body content');
+    expect(out).toBe(`${START}\nbody content\n${END}\n\n${existing}`);
+  });
+
+  it('replaces an existing single managed block in place', () => {
+    const existing = [
+      `${START}`,
+      'old body',
+      `${END}`,
+      '',
+      'user tail',
+    ].join('\n');
+    const out = upsertManagedBlock(existing, 'new body');
+    expect(out).toBe([
+      `${START}`,
+      'new body',
+      `${END}`,
+      '',
+      'user tail',
+    ].join('\n'));
+  });
+
+  // xtrm-ya67 regression: a previous lazy-regex version of this function only
+  // replaced the first start..end pair, leaving a duplicate content block +
+  // orphan end marker behind. The greedy variant sweeps the entire span.
+  it('collapses duplicate managed-block content and trailing orphan end marker (xtrm-ya67)', () => {
+    const corrupted = [
+      `${START}`,                 // line 0 — legitimate managed block opens
+      '# XTRM Agent Workflow',
+      'old managed body',
+      `${END}`,                   // line 3 — legitimate managed block closes
+      '',
+      '# XTRM Agent Workflow',    // line 5 — duplicate content (no start)
+      'duplicated body',
+      `${END}`,                   // line 7 — orphan end marker
+      '',
+      'real user content here',   // line 9 — actual user tail
+    ].join('\n');
+
+    const out = upsertManagedBlock(corrupted, 'fresh body');
+
+    // Exactly one start, one end.
+    expect(out.match(new RegExp(START, 'g'))?.length).toBe(1);
+    expect(out.match(new RegExp(END, 'g'))?.length).toBe(1);
+    // Old + duplicated bodies removed.
+    expect(out).not.toContain('old managed body');
+    expect(out).not.toContain('duplicated body');
+    expect(out).not.toContain('# XTRM Agent Workflow');
+    // User tail preserved.
+    expect(out).toContain('real user content here');
+    // Output well-formed.
+    expect(out).toContain(`${START}\nfresh body\n${END}`);
+  });
+
+  it('is idempotent across repeated upserts with the same body', () => {
+    const initial = upsertManagedBlock('', 'stable body');
+    const second = upsertManagedBlock(initial, 'stable body');
+    expect(second).toBe(initial);
+  });
+
+  it('preserves user content tail across replacement', () => {
+    const existing = [
+      `${START}`,
+      'managed v1',
+      `${END}`,
+      '',
+      '# User notes',
+      'note A',
+      'note B',
+    ].join('\n');
+    const out = upsertManagedBlock(existing, 'managed v2');
+    expect(out).toContain('# User notes');
+    expect(out).toContain('note A');
+    expect(out).toContain('note B');
+    expect(out).toContain(`${START}\nmanaged v2\n${END}`);
+  });
+});


### PR DESCRIPTION
## Summary

Earlier lazy-regex versions of `upsertManagedBlock` (`startMarker[\s\S]*?endMarker`) only matched the **first** start..end pair when a file had stray duplicate content or orphan end markers. Every subsequent `xt install` / `xt update` preserved the corruption because the replacement only swapped that first pair.

Visible concretely in this repo's `AGENTS.md` until this PR:
- L1 `xtrm:start` → L150 `xtrm:end` (legit managed block)
- L152 duplicate `# XTRM Agent Workflow` header
- L256 orphan `xtrm:end` (no matching start)

## Change

Greedy match `startMarker[\s\S]*endMarker` consumes the entire span from the first start to the last end. The duplicate-content-with-orphan-end-tail case gets swept up automatically.

Also runs the fix against this repo's `AGENTS.md` as part of the PR — 378 → 273 lines, single managed block.

## Test plan

- [x] 6 cases in `cli/src/tests/upsert-managed-block.test.ts`: empty file, file with user content, in-place replace, regression for xtrm-ya67 corruption shape, idempotency, user-tail preservation.
- [x] `bunx vitest run` — all 6 pass.

**Not handled**: orphan end markers BEFORE the legitimate start (rare; no observed case). Filed as future hardening if it surfaces.

Bead: xtrm-ya67 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)