### PR TITLE
release: v0.7.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.19] - 2026-05-14
+
+### Fixed
+- `xt init`'s Project Bootstrap phase no longer leaves Skills Runtime in an `incomplete: active` state on a fresh repo. Bare `gitnexus analyze` (invoked by xt init) unconditionally writes 6 skills to `<project>/.claude/skills/gitnexus/<name>/SKILL.md`, and because xtrm makes `.claude/skills` a symlink to `.xtrm/skills/active/`, those writes landed as a non-symlink directory at `.xtrm/skills/active/gitnexus/` — breaking the flat-active-view invariant and tripping `hasOnlyValidSymlinkEntries` → `activeReady=false`. After `gitnexus analyze` returns, `runGitNexusInitForProject` now removes that polluting subdir (idempotent, try/catch wrapped). No functionality loss — the same gitnexus skills are already vendored as flat `gitnexus-cli`, `gitnexus-debugging`, etc. under `.xtrm/skills/default/` and symlinked into `active/`. Fresh-repo smoke now reports `✓ All phases verified successfully.` (5/5 green). (xtrm-wbfd / PR #252)
+
 ## [0.7.18] - 2026-05-14
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xtrm-cli",
   "private": true,
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "main": "./dist/index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xtrm-tools",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtrm-tools",
-      "version": "0.7.18",
+      "version": "0.7.19",
       "license": "MIT",
       "workspaces": [
         "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtrm-tools",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "license": "MIT",
   "type": "module",

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Patch release containing one fix on top of v0.7.18:

- **xtrm-wbfd / PR #252** — `xt init`'s Project Bootstrap no longer leaves Skills Runtime in an `incomplete: active` state on a fresh repo.

GitHub Release notes will carry the full v0.7.18 narrative for a single canonical entry point.

## Test plan

- [x] Same gate chain as v0.7.18 (all 6 publish gates + fresh_machine_smoke via workflow_call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)