### PR TITLE
chore(vendor): refresh specialists skills from canonical (specialists v3.16.0)

### DIFF
--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -848,7 +848,7 @@
           "version": "0.7.21"
         },
         "specialists-creator/SKILL.md": {
-          "hash": "250cd9376b818142d1ccca71b48198086723ab2453ebac1eb69c3ba6293e9721",
+          "hash": "f8951e41b20d03a1a5cb71cd79fc7a17f525aba7005cce893d2a4524fc5a169e",
           "version": "0.7.21"
         },
         "sync-docs/references/doc-structure.md": {
@@ -948,7 +948,7 @@
           "version": "0.7.21"
         },
         "using-specialists-v3/SKILL.md": {
-          "hash": "974cf171eb12a81414d0f8e6d88dade52b38518a7565fd3feb5483db292b6b11",
+          "hash": "034692ee7ce97984a587a9ac4a612c3b71e37e03fea6a4d23bf37e388ace6cca",
           "version": "0.7.21"
         },
         "using-specialists/SKILL.md": {
@@ -1333,9 +1333,9 @@
   "specialists_source": {
     "version": 1,
     "source": {
-      "kind": "ref",
+      "kind": "repo",
       "ref": "master",
-      "resolved_sha": "d8eb6933d88837aeacfa46a74300ba983973ed0c",
+      "resolved_sha": "275336d01955d006a11c176c8be9a6acdef4e7af",
       "repo_path": "../specialists",
       "source_path": "config/skills"
     },
@@ -1355,7 +1355,7 @@
         "scripts/audit-spec-uniformity.mjs": "cfc6aa6fc89f18c2e1ddf794047b309aa8cb0185617d84545eb5cb20135d5ac4",
         "scripts/scaffold-specialist.ts": "c1bfa3693d644072e6d387d2519e131624d99c5b85521ae638680d7485267403",
         "scripts/validate-specialist.ts": "3a5f5a3a77c50e98ecf9188634ff2882f8143b19d0f28a53aff5c42e1bd09dfa",
-        "SKILL.md": "250cd9376b818142d1ccca71b48198086723ab2453ebac1eb69c3ba6293e9721"
+        "SKILL.md": "f8951e41b20d03a1a5cb71cd79fc7a17f525aba7005cce893d2a4524fc5a169e"
       },
       "update-specialists": {
         "SKILL.md": "fdf8c680cf3e5dce80c9426f52b56c953f4f7f663c23a33a3378b2b6e4bab5a9"
@@ -1381,7 +1381,7 @@
       },
       "using-specialists-v3": {
         "evals/evals.json": "e77fb10567d67489a0b56700693cd6199a68fd830ee91c4c939aef0fe8fad4bd",
-        "SKILL.md": "974cf171eb12a81414d0f8e6d88dade52b38518a7565fd3feb5483db292b6b11"
+        "SKILL.md": "034692ee7ce97984a587a9ac4a612c3b71e37e03fea6a4d23bf37e388ace6cca"
       }
     }
   }

--- a/.xtrm/skills/default/specialists-creator/SKILL.md
+++ b/.xtrm/skills/default/specialists-creator/SKILL.md
@@ -5,8 +5,8 @@ description: >
   agent through writing a valid `.specialist.json`, choosing supported models,
   validating against the schema, and avoiding common specialist authoring
   mistakes.
-version: 1.2
-synced_at: 236ca5e6
+version: 1.3
+synced_at: 78a7883e
 ---
 
 # Specialist Author Guide
@@ -358,15 +358,34 @@ Typical use cases:
 - `gitnexus: false` for specialists that should not receive GitNexus graph tooling
 - set both `false` for constrained runs that need clean extension surface
 
+### Bare specialists
+
+Use `execution.bare: true` for non-coding LLM transforms that need a fresh canvas: research synthesis, document analysis, summarization, extraction, translation, or other tasks where specialist runtime framing adds noise instead of help.
+
+Bare mode disables all package-runner prompt injection beyond rendered `prompt.system` and `prompt.task_template`: Specialist Run Context, Output Style, GitNexus mandate, `STATIC_WORKFLOW_RULES_BLOCK`, memory injection, GitNexus pre-query snapshot, reviewer patch retrieval, output contract, and task-side mandatory rules / reviewer diff context.
+
+`execution.bare` is orthogonal to `prompt.system_prompt_mode`. Set `bare: true` without `system_prompt_mode: "replace"` when you want to keep pi's coding-agent base prompt but skip specialist runtime injections.
+
+Copy bare template from installed npm package, not repo clone:
+
+```bash
+cp "$(node -p \"require.resolve('@jaggerxtrm/specialists/package.json').replace(/package\\.json$/, '')\")config/specialists/bare.specialist.json" ".specialists/user/<your-name>.specialist.json"
+```
+
+Warning: bare mode bypasses `mandatory_rules` completely — template sets, inline rules, and global disables all skip runtime injection in bare runs.
+
 ### `specialist.prompt` (required)
 
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `task_template` | string | yes | Template string with `$variable` substitution |
 | `system` | string | no | System prompt / agents.md content |
+| `system_prompt_mode` | enum | no | `append` \| `replace` — see [System Prompt Mode](#system-prompt-mode) |
 | `skill_inherit` | string | no | Single skill folder/file injected via `pi --skill` (Agent Forge compat) |
 | `output_schema` | object | no | JSON schema for structured output — injected into system prompt by runner; post-run validation is warn-only |
 | `examples` | array | no | Few-shot examples |
+
+> **Replace mode warning:** `replace` removes pi's coding-agent base prompt. Teach every command, tool, convention, output format, and behavior explicitly in `prompt.system`; nothing implicit remains.
 
 **Output contract precedence (runner-injected):** `response_format` → `output_type` → `output_schema`.
 
@@ -396,6 +415,24 @@ Typical use cases:
 **`output_schema` guidance**: Add when output must be machine-readable by downstream consumers (beads notes, feed, orchestrators). The schema is injected into the system prompt and validated post-run with warn-only behavior (never hard-fail in v1).
 
 **Mandatory markdown+schema rule:** if `response_format: markdown` and `output_schema` is present, the output must include `## Machine-readable block` containing exactly one JSON object in a single ` ```json ` fenced block. That JSON object is canonical and must match the schema.
+
+### System Prompt Mode
+
+`prompt.system_prompt_mode` controls whether `prompt.system` replaces or appends to pi's base prompt.
+
+| Runner | Default when field absent | `append` sees | `replace` sees |
+|--------|---------------------------|---------------|----------------|
+| Package-class (`sp run` → `runner.ts` → `session.ts`) | `append` | pi coding-agent base prompt + specialist `agentsMd` | only specialist `agentsMd` |
+| Script-class (`sp script` / `sp serve` → `script-runner.ts`) | `replace` | only specialist `prompt.system` | only specialist `prompt.system` |
+
+| Combination | Agent sees |
+|-------------|------------|
+| Package × append | pi coding-agent base prompt + specialist `agentsMd` |
+| Package × replace | only specialist `agentsMd` |
+| Script × append | pi coding-agent base prompt + specialist `prompt.system` |
+| Script × replace | only specialist `prompt.system` |
+
+> **Replace mode warning:** use `replace` only when you intend to author full prompt surface yourself. No coding-agent defaults survive; teach commands, tools, conventions, output contract, and behavior explicitly. Best fit: non-coding transforms where base prompt adds noise.
 
 Standard schemas by specialist type (shown as the `output_schema` object value):
 
@@ -439,6 +476,48 @@ planner — epic result:
     "first_task": { "type": "string" }
   }
 }
+```
+
+### `specialist.mandatory_rules` (optional)
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `template_sets` | string[] | `[]` | Adds rule-set ids from `config/mandatory-rules/index.json` and local overlays |
+| `disable_default_globals` | boolean | `false` | Suppresses only inline `STATIC_WORKFLOW_RULES_BLOCK` (`Beads Workflow Quick Rules`) |
+| `inline_rules` | `MandatoryRule[]` | `[]` | Inline rules appended without file lookup |
+
+Runtime layering:
+
+1. `config/mandatory-rules/index.json.required_template_sets` — always loaded
+2. `config/mandatory-rules/index.json.default_template_sets` — also always loaded today; current quirk, not suppressed by `disable_default_globals`
+3. `specialist.mandatory_rules.template_sets`
+4. `specialist.mandatory_rules.inline_rules`
+
+`disable_default_globals` only removes the inline `STATIC_WORKFLOW_RULES_BLOCK`. It does **not** suppress index-driven sets. True user-rules-only runs need both `disable_default_globals: true` and a user overlay index in `.specialists/user/mandatory-rules/index.json` that clears required/default sets.
+
+Canonical set ids in `config/mandatory-rules/*.md`:
+`bead-id-verbatim`, `changelog-conventions`, `changelog-keeper-scope`, `code-quality-defaults`, `core-session-boundary`, `diagnose-loop`, `executor-delivery`, `explorer-readonly`, `git-workflow-safe`, `gitnexus-required`, `overthinker-4phase`, `per-turn-handoff-schema`, `research-tool-routing`, `researcher-source-discipline`, `reviewer-verdict-format`, `security-review-defaults`, `serena-cheatsheet`, `sync-docs-scope-discipline`, `test-runner-execution-scope`.
+
+Minimal user-rules-only spec:
+
+```json
+{
+  "specialist": {
+    "mandatory_rules": {
+      "disable_default_globals": true,
+      "inline_rules": [
+        { "id": "user-rule-1", "level": "error", "text": "Use local policy only." },
+        { "id": "user-rule-2", "level": "warn", "text": "Prefer repo overlay index.", "when": "overlay exists" }
+      ]
+    }
+  }
+}
+```
+
+Inline rule shape:
+
+```json
+{ "id": "rule-id", "level": "error", "text": "Rule text", "when": "optional condition" }
 ```
 
 ### `specialist.skills` (optional)
@@ -794,3 +873,41 @@ specialists run my-specialist --prompt "ping" --no-beads
 ```
 
 If you need the underlying implementation, read `config/skills/specialists-creator/scripts/validate-specialist.ts`. It is a thin Bun/TypeScript wrapper over `parseSpecialist()` from `src/specialist/schema.ts`, which keeps the helper cross-platform for Windows, macOS, and Linux.
+
+---
+
+## Script-Class vs Package-Class Runtime
+
+Two runtime classes exist:
+
+- **Package-class**: `sp run` → `runner.ts` → `session.ts`
+- **Script-class**: `sp script` / `sp serve` → `script-runner.ts`
+
+| Runner | Injected into system prompt |
+|--------|----------------------------|
+| Package-class | `prompt.system` + Specialist Run Context + caveman output style + GitNexus mandate (if `.gitnexus` exists) + `STATIC_WORKFLOW_RULES_BLOCK` + memory injection + mandatory rules + skills inheritance + output contract + reviewer patch retrieval (reviewer reuse only) |
+| Script-class | `prompt.system` only |
+
+Pi flags:
+
+| Runner | Pi flags |
+|--------|----------|
+| Package-class | `--no-extensions`, then re-enable quality-gates/service-skills/caveman/gitnexus/serena |
+| Script-class | `--no-extensions --no-tools --offline --no-context-files --no-prompt-templates --no-themes` and `--no-skills` when `skills.paths` is empty |
+
+Settings that silently do nothing on script-class:
+
+- `mandatory_rules` (all fields)
+- beads injection
+- GitNexus mandate
+- memory injection
+- output contract auto-generation
+
+Per-runner default for `prompt.system_prompt_mode`:
+
+- Package-class: `append`
+- Script-class: `replace`
+
+> **Script-class warning:** `mandatory_rules` never reaches script-class. If spec must rely on rule sets, it must run package-class.
+
+---

--- a/.xtrm/skills/default/using-specialists-v3/SKILL.md
+++ b/.xtrm/skills/default/using-specialists-v3/SKILL.md
@@ -349,6 +349,45 @@ Cross-repo consistency: keep this vocabulary aligned with the xtrm-tools `issue-
 
 What differs: orchestrator chooses edge type deliberately, so graph stays correct for chain execution, epic publish, duplicate cleanup, root-cause navigation, verification evidence, and follow-up traceability.
 
+## Swarm Validation For Epic Readiness
+
+Use `bd swarm` as graph-level readiness instrumentation for multi-chain epics. It does **not** replace specialists jobs, `sp epic status`, or `sp epic merge`; it validates and summarizes the bead DAG so you know whether the epic is shaped for parallel execution before spending specialist tokens.
+
+Command surface:
+
+```bash
+bd swarm validate <epic-id> [--verbose] [--json]
+bd swarm status <epic-or-swarm-id> [--json]
+bd swarm list [--json]
+bd swarm create <epic-id> [--coordinator=<addr>] [--force]
+```
+
+What each command is for:
+
+| Command | Use it when | Output / decision |
+| --- | --- | --- |
+| `bd swarm validate <epic>` | Before launching a multi-chain epic, after graph rewrites, and before `sp epic merge` | Finds dependency-direction mistakes, orphan/disconnected children, cycles, ready fronts, estimated worker sessions, and max parallelism |
+| `bd swarm status <epic-or-swarm>` | During orchestration | Shows computed completed / active / ready / blocked groups from live bead state |
+| `bd swarm list` | Operator wants all active swarm molecules | Inventory of swarm molecules with epic/progress summary |
+| `bd swarm create <epic>` | Operator explicitly wants a swarm molecule/coordinator handoff | Mutates board state; confirm first. If passed a task, bd may auto-wrap it in an epic. |
+
+Where it fits in orchestration:
+
+1. **After planning / before dispatch**: run `bd swarm validate <epic-id> --json` for epics with 3+ children or intended parallel execution. Treat warnings as graph-shaping feedback; fix relationship types or split/merge beads before launching specialists.
+2. **During execution**: use `bd swarm status <epic-id> --json` alongside `sp ps`. `sp ps` tells you job/runtime state; swarm status tells you issue-graph state (ready vs blocked fronts).
+3. **Before publication**: run `bd swarm validate <epic-id>` plus `bd dep cycles` and `sp epic status <epic-id>`. Do not `sp epic merge` if swarm validation reports cycles, disconnected graph, or suspicious dependency direction.
+4. **Optional coordinator handoff**: run `bd swarm create <epic-id> --coordinator=<addr>` only after operator confirmation. Creating a swarm molecule is a tracked mutation, not a default read-only check.
+
+Example gate before parallel dispatch:
+
+```bash
+bd dep cycles
+bd swarm validate <epic-id> --json > .triage/swarm-<epic-id>.json
+sp epic status <epic-id>
+```
+
+If validation says max parallelism is 1, do not pretend the epic is parallel; dispatch serially or fix the graph. If it reports multiple ready fronts, use that as the wave plan for specialist launches.
+
 ## Bead Contract By Bead Type
 
 Use shape that fits specialist.

--- a/.xtrm/specialists-source.json
+++ b/.xtrm/specialists-source.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
   "source": {
-    "kind": "ref",
+    "kind": "repo",
     "ref": "master",
-    "resolved_sha": "d8eb6933d88837aeacfa46a74300ba983973ed0c",
+    "resolved_sha": "275336d01955d006a11c176c8be9a6acdef4e7af",
     "repo_path": "../specialists",
     "source_path": "config/skills"
   },
@@ -23,7 +23,7 @@
       "scripts/audit-spec-uniformity.mjs": "cfc6aa6fc89f18c2e1ddf794047b309aa8cb0185617d84545eb5cb20135d5ac4",
       "scripts/scaffold-specialist.ts": "c1bfa3693d644072e6d387d2519e131624d99c5b85521ae638680d7485267403",
       "scripts/validate-specialist.ts": "3a5f5a3a77c50e98ecf9188634ff2882f8143b19d0f28a53aff5c42e1bd09dfa",
-      "SKILL.md": "250cd9376b818142d1ccca71b48198086723ab2453ebac1eb69c3ba6293e9721"
+      "SKILL.md": "f8951e41b20d03a1a5cb71cd79fc7a17f525aba7005cce893d2a4524fc5a169e"
     },
     "update-specialists": {
       "SKILL.md": "fdf8c680cf3e5dce80c9426f52b56c953f4f7f663c23a33a3378b2b6e4bab5a9"
@@ -49,7 +49,7 @@
     },
     "using-specialists-v3": {
       "evals/evals.json": "e77fb10567d67489a0b56700693cd6199a68fd830ee91c4c939aef0fe8fad4bd",
-      "SKILL.md": "974cf171eb12a81414d0f8e6d88dade52b38518a7565fd3feb5483db292b6b11"
+      "SKILL.md": "034692ee7ce97984a587a9ac4a612c3b71e37e03fea6a4d23bf37e388ace6cca"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Vendored specialists skills from `@jaggerxtrm/specialists@v3.16.0` (commit 275336d0 on master).
- Refreshed `.xtrm/skills/default/specialists-creator/SKILL.md` with new sections: System Prompt Mode, specialist.mandatory_rules, Script-Class vs Package-Class Runtime, Bare specialists.
- Refreshed `.xtrm/skills/default/using-specialists-v3/SKILL.md`.
- Regenerated `.xtrm/registry.json` and `.xtrm/specialists-source.json` via `scripts/gen-registry.mjs`.

## Why
Specialists v3.16.0 ships `execution.bare` + `prompt.system_prompt_mode` schema features that need to flow through to the xtrm-tools consumer-side skill mirror so downstream repos pick them up via `xt update --apply`.

## Test plan
- [x] `node scripts/vendor-specialists-skills.mjs` ran cleanly against source at master
- [x] `node scripts/gen-registry.mjs` rewrote registry hashes
- [x] `diff -q` between vendored copies and canonical sources returns identical
- [x] `xt update --root ~/dev --apply` + `xt update --root ~/projects --apply` successfully propagated to 15 xtrm-managed repos with `grep "Bare specialists"` confirming new content

🤖 Generated with [Claude Code](https://claude.com/claude-code)