### PR TITLE
release: xtrm-tools v0.8.3 (service-skills reliability fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.8.3] — 2026-06-01
+
+Service-skills reliability hardening: makes the v2 drift/sync machinery actually fire in consumers and tier drift **semantically** instead of silently degrading to mtime. The critical fix (lg9km) repairs `drift_detector sync` so it stamps `last_sync_ref` — without it semantic tiering was dead in every consumer. Plus the dormant-hooks reconcile on `xt update`, post-merge drift automation, and gitnexus-mandatory librarian verdicts. Publish root `xtrm-tools` from this release commit/tag.
+
+### `xtrm-tools` v0.8.3 — 2026-06-01
+
+#### Fixed
+
+- **`drift_detector.py sync` now stamps `last_sync_ref` to HEAD.** The CLI path (`drift_detector.py sync <id>`) passed `project_root=None` straight to `_git_head` → `git -C None …` raised → `last_sync_ref` was always `""`, forcing `gitnexus_status=no_ref` → mtime fallback for *every* service permanently. Semantic drift tiering over the committed range `last_sync_ref..HEAD` now works for all service repos — the mechanical root of the long-standing mtime-fallback behavior. (xtrm-lg9km, #277)
+- **`xt update --apply` now wires xtrm-managed hooks into the consumer's existing `.claude/settings.json`** via a focused, idempotent `reconcileProjectClaudeHooks`. Previously the settings-hooks reconcile was skipped on update (only reached when `registryChanges>0`), so the 0.8.2 service-skills hooks (SessionStart cataloger · PreToolUse activator · PostToolUse drift) stayed **dormant** in existing consumers. A hook-only change now flips already-current → refreshed; non-hook keys (model/permissions) are preserved. (xtrm-0p7bp, #274)
+
+#### Added
+
+- **Post-merge drift automation.** A managed `post-merge` git hook (`post_merge_drift_sweep.py`) is wired on the foolproof path (`xt update --apply` / `xt init`, via the installer's `--hooks-only` mode). On a default-branch merge it runs a cost-bounded `scan_drift` since each service's `last_sync_ref`, surfaces drift, and drops a pending marker at `.xtrm/.service-skills-drift-pending`. It never auto-runs a model-backed specialist — reconcile stays agent-driven via `/updating-service-skills`. (xtrm-jcmub, #275)
+
+#### Changed
+
+- **Service-skills librarian: gitnexus-mandatory triage + verdict taxonomy.** String-only "unchanged" verdicts are forbidden: `audited-and-unchanged` now requires a cited gitnexus signal; a `drift_detector` tooling failure means *repair gitnexus then re-triage* (never grep-only); a genuine gitnexus outage downgrades to the weaker `synced (string-level only)` verdict. Updated `references/updating.md` (Step-1 fallback + new Verdict Taxonomy section + mandatory Verdict/Triage output lines) and the cross-repo `service-skills-sync` specialist contract. (xtrm-q7436, #276)
+
 ## [v0.8.2] — 2026-05-31
 
 Service Skills v2: the five separate service-skills (`creating-`, `scoping-`, `updating-`, `using-service-skills` + the `service-skills-set` bundle) are consolidated into **one umbrella `service-skills` skill**, with a per-repo generated `<repo>-services` umbrella and a hard-cut layout migrator. Upgrading is foolproof — a normal `xt update --apply` (or `xt init`) auto-migrates any old-layout pack and self-wires the Claude hooks; repos without a service-registry are unaffected. Publish root `xtrm-tools` from this release commit/tag.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xtrm-cli",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "main": "./dist/index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xtrm-tools",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtrm-tools",
-      "version": "0.8.1",
+      "version": "0.8.3",
       "license": "MIT",
       "workspaces": [
         "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtrm-tools",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "license": "MIT",
   "type": "module",

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Bumps **0.8.2 → 0.8.3** + CHANGELOG. Ships the four service-skills reliability fixes already merged to `main`:

- **lg9km** (#277) — `drift_detector sync` stamps `last_sync_ref` → semantic drift tiering works again (was mtime-fallback everywhere). *Critical: this is the field-breaking one.*
- **0p7bp** (#274) — `xt update --apply` wires service-skills hooks into existing consumers' `.claude/settings.json` (were dormant after 0.8.2).
- **jcmub** (#275) — post-merge drift sweep automation.
- **q7436** (#276) — gitnexus-mandatory librarian verdicts.

Version bump only (no `cli/src` logic change here; dist unchanged). **No tag in this PR** — per repo procedure, squash-merge then tag the merge commit on `main` and `gh release create v0.8.3` to fire `publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)