### PR TITLE
fix(service-skills): worktree gitnexus repo, catalog≠sync drift masking, migrator body refs (xtrm-vvhfs/008tr/8ike5)

### DIFF
--- a/.xtrm/skills/default/service-skills/scripts/bootstrap.py
+++ b/.xtrm/skills/default/service-skills/scripts/bootstrap.py
@@ -311,8 +311,36 @@ if __name__ == "__main__":
         sys.exit(1)
 
 def _gitnexus_repo_name(project_root: str | None = None) -> str:
+    """Resolve the repo label gitnexus indexed under — the MAIN worktree's basename.
+
+    In a linked git worktree ``get_project_root()`` returns the worktree dir, whose basename
+    (e.g. ``market-data-uh1r-service-skills-sync``) gitnexus has NOT indexed; injecting it as
+    ``--repo`` makes every gitnexus call fail → drift silently degrades to mtime-only tiering.
+    The service-skills-sync librarian ALWAYS runs in such an auto-provisioned worktree, so it
+    would otherwise never get semantic enrichment. ``git rev-parse --git-common-dir`` points at
+    the shared (main) ``.git``; its parent is the indexed checkout (xtrm-vvhfs). Falls back to the
+    local basename on any git failure. ``GITNEXUS_REPO`` still wins when explicitly set.
+    """
+    env = os.environ.get("GITNEXUS_REPO")
+    if env:
+        return env
     root = Path(project_root or get_project_root())
-    return os.environ.get("GITNEXUS_REPO") or root.name
+    try:
+        result = subprocess.run(  # nosec B603 B607
+            ["git", "-C", str(root), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, check=True, timeout=5,
+        )
+        common = result.stdout.strip()
+        if common:
+            common_path = Path(common)
+            if not common_path.is_absolute():
+                common_path = root / common_path
+            main_root = common_path.resolve().parent
+            if main_root.name:
+                return main_root.name
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return root.name
 
 
 def _gitnexus_tool_name(args: list[str]) -> str | None:

--- a/.xtrm/skills/default/service-skills/scripts/bootstrap.py
+++ b/.xtrm/skills/default/service-skills/scripts/bootstrap.py
@@ -29,7 +29,6 @@ import os
 import re
 import subprocess  # nosec B404
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -240,12 +239,20 @@ def register_service(
     registry = load_registry(project_root)
     if "services" not in registry:
         registry["services"] = {}
+    # Registration is CATALOGUING, not a verified sync. Deliberately do NOT stamp
+    # ``last_sync`` here: claiming "synced as of now" without auditing the SKILL.md
+    # against code is the exact "timestamp-only sync without evidence" anti-pattern the
+    # librarian's own prompt forbids — and when done in bulk it set every service's
+    # last_sync=now with no last_sync_ref, so the drift scan's mtime pre-filter returned
+    # 0 candidates and masked real drift (xtrm-008tr). Only a verified audit
+    # (drift_detector.update_sync_time) may stamp last_sync, and it stamps last_sync_ref
+    # atomically alongside. A catalogued-but-never-synced service is surfaced as drift by
+    # scan_drift (needs initial verified sync) rather than appearing falsely clean.
     registry["services"][service_id] = {
         "name": name,
         "territory": territory,
         "skill_path": skill_path,
         "description": description,
-        "last_sync": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     }
     save_registry(registry, project_root)
 

--- a/.xtrm/skills/default/service-skills/scripts/drift_detector.py
+++ b/.xtrm/skills/default/service-skills/scripts/drift_detector.py
@@ -194,16 +194,22 @@ def scan_drift(project_root: str | None = None, enrich_with_gitnexus: bool = Fal
     drifted = []
     for service_id, service in registry.get("services", {}).items():
         last_sync_str = service.get("last_sync", "")
-        if not last_sync_str:
-            continue
         try:
-            sync_time = datetime.fromisoformat(last_sync_str.replace("Z", "+00:00"))
+            sync_time = datetime.fromisoformat(last_sync_str.replace("Z", "+00:00")) if last_sync_str else None
         except ValueError:
-            continue
+            sync_time = None
+        # A service with no (or unparseable, e.g. the "never" sentinel) last_sync has been
+        # CATALOGUED but never verified-synced. Surface its WHOLE territory as drift (needs an
+        # initial verified sync) instead of skipping — skipping is exactly how a bulk
+        # timestamp-less catalog masked real drift: the mtime pre-filter returned 0 and every
+        # service looked clean (xtrm-008tr). Compare against the epoch so every tracked file
+        # counts; the git-tracked filter + enrichment cap below keep the candidate set bounded.
+        never_synced = sync_time is None
+        floor = sync_time if sync_time is not None else datetime.fromtimestamp(0, tz=timezone.utc)
         for pattern in service.get("territory", []):
             for fp in root.glob(pattern):
-                if fp.is_file() and datetime.fromtimestamp(fp.stat().st_mtime, tz=timezone.utc) > sync_time:
-                    drifted.append({"service_id": service_id, "service_name": service.get("name", service_id), "file_path": str(fp.relative_to(root)), "last_sync": last_sync_str, "last_sync_ref": _service_last_sync_ref(service)})
+                if fp.is_file() and datetime.fromtimestamp(fp.stat().st_mtime, tz=timezone.utc) > floor:
+                    drifted.append({"service_id": service_id, "service_name": service.get("name", service_id), "file_path": str(fp.relative_to(root)), "last_sync": last_sync_str, "last_sync_ref": _service_last_sync_ref(service), "never_synced": never_synced})
     if not drifted:
         return []
     # Respect .gitignore: drop candidates that are not git-tracked (build/vendor/cache trees

--- a/.xtrm/skills/default/service-skills/scripts/drift_detector.py
+++ b/.xtrm/skills/default/service-skills/scripts/drift_detector.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 # bootstrap.py is a sibling in this consolidated scripts/ dir (no cross-skill hop).
 sys.path.insert(0, str(Path(__file__).parent))
-from bootstrap import RootResolutionError, find_service_for_path, get_project_root, get_registry_path, get_service, is_gitnexus_available, load_registry, run_gitnexus_json, save_registry  # type: ignore[import-not-found]  # noqa: E402
+from bootstrap import RootResolutionError, _gitnexus_repo_name, find_service_for_path, get_project_root, get_registry_path, get_service, is_gitnexus_available, load_registry, run_gitnexus_json, save_registry  # type: ignore[import-not-found]  # noqa: E402
 
 # Hard cap on per-item gitnexus enrichment: beyond this many drifted candidates the scan
 # falls back to mtime instead of fanning out a gitnexus subprocess per file (which OOMs the
@@ -238,7 +238,7 @@ def scan_drift(project_root: str | None = None, enrich_with_gitnexus: bool = Fal
     out = []
     for item in drifted:
         try:
-            out.append(_enrich_item(item, project_root, Path(project_root).name, item.get("last_sync_ref")))
+            out.append(_enrich_item(item, project_root, _gitnexus_repo_name(project_root), item.get("last_sync_ref")))
         except Exception as exc:
             item["gitnexus_status"] = "cli_error"
             item["tier_source"] = "mtime"

--- a/.xtrm/skills/default/service-skills/scripts/layout_migrator.py
+++ b/.xtrm/skills/default/service-skills/scripts/layout_migrator.py
@@ -24,10 +24,16 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
 from typing import Any
+
+# A legacy in-body reference: ".claude/skills/<segment>" where <segment> is a service-id
+# (self-ref) or a registry 'container' name (container-named self/cross-ref). The trailing
+# "/scripts/...", "/SKILL.md", or nothing (e.g. `make -C .claude/skills/<seg>`) is preserved.
+_CLAUDE_SKILLS_REF = re.compile(r"\.claude/skills/([a-z0-9][a-z0-9_-]*)")
 
 # Sibling imports (consolidated scripts/ dir).
 sys.path.insert(0, str(Path(__file__).parent))
@@ -55,6 +61,42 @@ def _new_skill_path_str(project_root: Path, pack: Path, service_id: str) -> str:
         return str(new_md).replace(os.sep, "/")
 
 
+def _new_skill_dir_str(project_root: Path, pack: Path, service_id: str) -> str:
+    """Project-relative POSIX path to a service's NEW skill *directory* (no /SKILL.md), used
+    as the rewrite target for legacy in-body ``.claude/skills/<alias>`` references."""
+    new_dir = pack / "service-skills" / "services" / service_id
+    try:
+        return str(new_dir.resolve(strict=False).relative_to(project_root.resolve())).replace(os.sep, "/")
+    except ValueError:
+        return str(new_dir).replace(os.sep, "/")
+
+
+def _rewrite_claude_refs(body: str, new_dir_for: Any) -> tuple[str, int, set[str]]:
+    """Rewrite legacy ``.claude/skills/<alias>`` refs in a moved SKILL.md body to the new
+    ``.xtrm/.../service-skills/services/<service-id>`` dir.
+
+    ``new_dir_for(alias)`` returns the new dir path for a known alias, or ``None`` to leave the
+    ref untouched (and report it as unmapped). The migrator MOVES SKILL.md bodies verbatim, so
+    self-refs (``.claude/skills/<service-id>/scripts/...``, ``make -C .claude/skills/<container>``)
+    and umbrella cross-refs are left pointing at the dead flat path unless rewritten here
+    (xtrm-8ike5). Returns ``(new_body, rewritten_count, unmapped_segments)``.
+    """
+    unmapped: set[str] = set()
+    rewrites = 0
+
+    def _repl(m: "re.Match[str]") -> str:
+        nonlocal rewrites
+        alias = m.group(1)
+        new_dir = new_dir_for(alias)
+        if new_dir is None:
+            unmapped.add(alias)
+            return m.group(0)
+        rewrites += 1
+        return new_dir
+
+    return _CLAUDE_SKILLS_REF.sub(_repl, body), rewrites, unmapped
+
+
 def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, Any]:
     """Migrate one pack. Returns a result dict with per-service outcomes.
 
@@ -72,6 +114,28 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
         return {"pack": pack.name, "status": "no-registry", "services": {}}
     registry: dict[str, Any] = json.loads(reg_src.read_text(encoding="utf-8"))
     services: dict[str, Any] = registry.get("services", {})
+
+    # Alias map for in-body ref rewriting: every legacy ".claude/skills/<segment>" segment is
+    # either a service-id (self-ref / umbrella cross-ref) or a service's registry 'container'
+    # name (container-named self-ref). Map both to the service-id so the new dir resolves.
+    alias_to_service: dict[str, str] = {}
+    for sid, info in services.items():
+        alias_to_service[sid] = sid
+        container = info.get("container")
+        if isinstance(container, str) and container:
+            alias_to_service.setdefault(container, sid)
+    _dir_cache: dict[str, str] = {}
+
+    def _new_dir_for(alias: str) -> str | None:
+        sid = alias_to_service.get(alias)
+        if sid is None:
+            return None
+        if sid not in _dir_cache:
+            _dir_cache[sid] = _new_skill_dir_str(project_root, pack, sid)
+        return _dir_cache[sid]
+
+    refs_rewritten = 0
+    stale_refs: set[str] = set()
 
     outcomes: dict[str, str] = {}
     for service_id, info in services.items():
@@ -98,6 +162,19 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
 
         info["skill_path"] = _new_skill_path_str(project_root, pack, service_id)
 
+        # Rewrite legacy in-body ".claude/skills/<alias>/..." refs in the moved SKILL.md so
+        # Data-Inspection / Diagnostic-Scripts / `make -C` blocks point at the new services/
+        # path instead of the dead flat one (xtrm-8ike5). Idempotent: a re-run finds no
+        # ".claude/skills" refs and is a no-op.
+        moved_md = new_dir / "SKILL.md"
+        if moved_md.exists():
+            body = moved_md.read_text(encoding="utf-8")
+            rewritten, n, unmapped = _rewrite_claude_refs(body, _new_dir_for)
+            if n:
+                moved_md.write_text(rewritten, encoding="utf-8")
+                refs_rewritten += n
+            stale_refs |= unmapped
+
     # Relocate the registry under the umbrella with rewritten skill_paths.
     umbrella_dir.mkdir(parents=True, exist_ok=True)
     new_registry.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
@@ -113,6 +190,8 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
         "services": outcomes,
         "umbrella_written": umbrella_changed,
         "registry": str(new_registry),
+        "refs_rewritten": refs_rewritten,
+        "stale_refs": sorted(stale_refs),
     }
 
 
@@ -168,6 +247,14 @@ def main() -> None:
         print(f"{prefix}: {sid} ({outcome})")
     print(f"registry: {result['registry']}")
     print(f"umbrella: {'written' if result['umbrella_written'] else 'unchanged'}")
+    if result.get("refs_rewritten"):
+        print(f"refs: rewrote {result['refs_rewritten']} legacy .claude/skills path(s) in SKILL.md bodies")
+    for seg in result.get("stale_refs", []):
+        print(
+            f"WARNING: unmapped .claude/skills/{seg} ref left as-is "
+            f"(no matching service-id or registry container) — review manually",
+            file=sys.stderr,
+        )
     for note in demote_shadowing_registries(project_root):
         print(note)
     sys.exit(0)

--- a/skills/service-skills/scripts/bootstrap.py
+++ b/skills/service-skills/scripts/bootstrap.py
@@ -311,8 +311,36 @@ if __name__ == "__main__":
         sys.exit(1)
 
 def _gitnexus_repo_name(project_root: str | None = None) -> str:
+    """Resolve the repo label gitnexus indexed under — the MAIN worktree's basename.
+
+    In a linked git worktree ``get_project_root()`` returns the worktree dir, whose basename
+    (e.g. ``market-data-uh1r-service-skills-sync``) gitnexus has NOT indexed; injecting it as
+    ``--repo`` makes every gitnexus call fail → drift silently degrades to mtime-only tiering.
+    The service-skills-sync librarian ALWAYS runs in such an auto-provisioned worktree, so it
+    would otherwise never get semantic enrichment. ``git rev-parse --git-common-dir`` points at
+    the shared (main) ``.git``; its parent is the indexed checkout (xtrm-vvhfs). Falls back to the
+    local basename on any git failure. ``GITNEXUS_REPO`` still wins when explicitly set.
+    """
+    env = os.environ.get("GITNEXUS_REPO")
+    if env:
+        return env
     root = Path(project_root or get_project_root())
-    return os.environ.get("GITNEXUS_REPO") or root.name
+    try:
+        result = subprocess.run(  # nosec B603 B607
+            ["git", "-C", str(root), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, check=True, timeout=5,
+        )
+        common = result.stdout.strip()
+        if common:
+            common_path = Path(common)
+            if not common_path.is_absolute():
+                common_path = root / common_path
+            main_root = common_path.resolve().parent
+            if main_root.name:
+                return main_root.name
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return root.name
 
 
 def _gitnexus_tool_name(args: list[str]) -> str | None:

--- a/skills/service-skills/scripts/bootstrap.py
+++ b/skills/service-skills/scripts/bootstrap.py
@@ -29,7 +29,6 @@ import os
 import re
 import subprocess  # nosec B404
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -240,12 +239,20 @@ def register_service(
     registry = load_registry(project_root)
     if "services" not in registry:
         registry["services"] = {}
+    # Registration is CATALOGUING, not a verified sync. Deliberately do NOT stamp
+    # ``last_sync`` here: claiming "synced as of now" without auditing the SKILL.md
+    # against code is the exact "timestamp-only sync without evidence" anti-pattern the
+    # librarian's own prompt forbids — and when done in bulk it set every service's
+    # last_sync=now with no last_sync_ref, so the drift scan's mtime pre-filter returned
+    # 0 candidates and masked real drift (xtrm-008tr). Only a verified audit
+    # (drift_detector.update_sync_time) may stamp last_sync, and it stamps last_sync_ref
+    # atomically alongside. A catalogued-but-never-synced service is surfaced as drift by
+    # scan_drift (needs initial verified sync) rather than appearing falsely clean.
     registry["services"][service_id] = {
         "name": name,
         "territory": territory,
         "skill_path": skill_path,
         "description": description,
-        "last_sync": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     }
     save_registry(registry, project_root)
 

--- a/skills/service-skills/scripts/drift_detector.py
+++ b/skills/service-skills/scripts/drift_detector.py
@@ -194,16 +194,22 @@ def scan_drift(project_root: str | None = None, enrich_with_gitnexus: bool = Fal
     drifted = []
     for service_id, service in registry.get("services", {}).items():
         last_sync_str = service.get("last_sync", "")
-        if not last_sync_str:
-            continue
         try:
-            sync_time = datetime.fromisoformat(last_sync_str.replace("Z", "+00:00"))
+            sync_time = datetime.fromisoformat(last_sync_str.replace("Z", "+00:00")) if last_sync_str else None
         except ValueError:
-            continue
+            sync_time = None
+        # A service with no (or unparseable, e.g. the "never" sentinel) last_sync has been
+        # CATALOGUED but never verified-synced. Surface its WHOLE territory as drift (needs an
+        # initial verified sync) instead of skipping — skipping is exactly how a bulk
+        # timestamp-less catalog masked real drift: the mtime pre-filter returned 0 and every
+        # service looked clean (xtrm-008tr). Compare against the epoch so every tracked file
+        # counts; the git-tracked filter + enrichment cap below keep the candidate set bounded.
+        never_synced = sync_time is None
+        floor = sync_time if sync_time is not None else datetime.fromtimestamp(0, tz=timezone.utc)
         for pattern in service.get("territory", []):
             for fp in root.glob(pattern):
-                if fp.is_file() and datetime.fromtimestamp(fp.stat().st_mtime, tz=timezone.utc) > sync_time:
-                    drifted.append({"service_id": service_id, "service_name": service.get("name", service_id), "file_path": str(fp.relative_to(root)), "last_sync": last_sync_str, "last_sync_ref": _service_last_sync_ref(service)})
+                if fp.is_file() and datetime.fromtimestamp(fp.stat().st_mtime, tz=timezone.utc) > floor:
+                    drifted.append({"service_id": service_id, "service_name": service.get("name", service_id), "file_path": str(fp.relative_to(root)), "last_sync": last_sync_str, "last_sync_ref": _service_last_sync_ref(service), "never_synced": never_synced})
     if not drifted:
         return []
     # Respect .gitignore: drop candidates that are not git-tracked (build/vendor/cache trees

--- a/skills/service-skills/scripts/drift_detector.py
+++ b/skills/service-skills/scripts/drift_detector.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 # bootstrap.py is a sibling in this consolidated scripts/ dir (no cross-skill hop).
 sys.path.insert(0, str(Path(__file__).parent))
-from bootstrap import RootResolutionError, find_service_for_path, get_project_root, get_registry_path, get_service, is_gitnexus_available, load_registry, run_gitnexus_json, save_registry  # type: ignore[import-not-found]  # noqa: E402
+from bootstrap import RootResolutionError, _gitnexus_repo_name, find_service_for_path, get_project_root, get_registry_path, get_service, is_gitnexus_available, load_registry, run_gitnexus_json, save_registry  # type: ignore[import-not-found]  # noqa: E402
 
 # Hard cap on per-item gitnexus enrichment: beyond this many drifted candidates the scan
 # falls back to mtime instead of fanning out a gitnexus subprocess per file (which OOMs the
@@ -238,7 +238,7 @@ def scan_drift(project_root: str | None = None, enrich_with_gitnexus: bool = Fal
     out = []
     for item in drifted:
         try:
-            out.append(_enrich_item(item, project_root, Path(project_root).name, item.get("last_sync_ref")))
+            out.append(_enrich_item(item, project_root, _gitnexus_repo_name(project_root), item.get("last_sync_ref")))
         except Exception as exc:
             item["gitnexus_status"] = "cli_error"
             item["tier_source"] = "mtime"

--- a/skills/service-skills/scripts/layout_migrator.py
+++ b/skills/service-skills/scripts/layout_migrator.py
@@ -24,10 +24,16 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
 from typing import Any
+
+# A legacy in-body reference: ".claude/skills/<segment>" where <segment> is a service-id
+# (self-ref) or a registry 'container' name (container-named self/cross-ref). The trailing
+# "/scripts/...", "/SKILL.md", or nothing (e.g. `make -C .claude/skills/<seg>`) is preserved.
+_CLAUDE_SKILLS_REF = re.compile(r"\.claude/skills/([a-z0-9][a-z0-9_-]*)")
 
 # Sibling imports (consolidated scripts/ dir).
 sys.path.insert(0, str(Path(__file__).parent))
@@ -55,6 +61,42 @@ def _new_skill_path_str(project_root: Path, pack: Path, service_id: str) -> str:
         return str(new_md).replace(os.sep, "/")
 
 
+def _new_skill_dir_str(project_root: Path, pack: Path, service_id: str) -> str:
+    """Project-relative POSIX path to a service's NEW skill *directory* (no /SKILL.md), used
+    as the rewrite target for legacy in-body ``.claude/skills/<alias>`` references."""
+    new_dir = pack / "service-skills" / "services" / service_id
+    try:
+        return str(new_dir.resolve(strict=False).relative_to(project_root.resolve())).replace(os.sep, "/")
+    except ValueError:
+        return str(new_dir).replace(os.sep, "/")
+
+
+def _rewrite_claude_refs(body: str, new_dir_for: Any) -> tuple[str, int, set[str]]:
+    """Rewrite legacy ``.claude/skills/<alias>`` refs in a moved SKILL.md body to the new
+    ``.xtrm/.../service-skills/services/<service-id>`` dir.
+
+    ``new_dir_for(alias)`` returns the new dir path for a known alias, or ``None`` to leave the
+    ref untouched (and report it as unmapped). The migrator MOVES SKILL.md bodies verbatim, so
+    self-refs (``.claude/skills/<service-id>/scripts/...``, ``make -C .claude/skills/<container>``)
+    and umbrella cross-refs are left pointing at the dead flat path unless rewritten here
+    (xtrm-8ike5). Returns ``(new_body, rewritten_count, unmapped_segments)``.
+    """
+    unmapped: set[str] = set()
+    rewrites = 0
+
+    def _repl(m: "re.Match[str]") -> str:
+        nonlocal rewrites
+        alias = m.group(1)
+        new_dir = new_dir_for(alias)
+        if new_dir is None:
+            unmapped.add(alias)
+            return m.group(0)
+        rewrites += 1
+        return new_dir
+
+    return _CLAUDE_SKILLS_REF.sub(_repl, body), rewrites, unmapped
+
+
 def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, Any]:
     """Migrate one pack. Returns a result dict with per-service outcomes.
 
@@ -72,6 +114,28 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
         return {"pack": pack.name, "status": "no-registry", "services": {}}
     registry: dict[str, Any] = json.loads(reg_src.read_text(encoding="utf-8"))
     services: dict[str, Any] = registry.get("services", {})
+
+    # Alias map for in-body ref rewriting: every legacy ".claude/skills/<segment>" segment is
+    # either a service-id (self-ref / umbrella cross-ref) or a service's registry 'container'
+    # name (container-named self-ref). Map both to the service-id so the new dir resolves.
+    alias_to_service: dict[str, str] = {}
+    for sid, info in services.items():
+        alias_to_service[sid] = sid
+        container = info.get("container")
+        if isinstance(container, str) and container:
+            alias_to_service.setdefault(container, sid)
+    _dir_cache: dict[str, str] = {}
+
+    def _new_dir_for(alias: str) -> str | None:
+        sid = alias_to_service.get(alias)
+        if sid is None:
+            return None
+        if sid not in _dir_cache:
+            _dir_cache[sid] = _new_skill_dir_str(project_root, pack, sid)
+        return _dir_cache[sid]
+
+    refs_rewritten = 0
+    stale_refs: set[str] = set()
 
     outcomes: dict[str, str] = {}
     for service_id, info in services.items():
@@ -98,6 +162,19 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
 
         info["skill_path"] = _new_skill_path_str(project_root, pack, service_id)
 
+        # Rewrite legacy in-body ".claude/skills/<alias>/..." refs in the moved SKILL.md so
+        # Data-Inspection / Diagnostic-Scripts / `make -C` blocks point at the new services/
+        # path instead of the dead flat one (xtrm-8ike5). Idempotent: a re-run finds no
+        # ".claude/skills" refs and is a no-op.
+        moved_md = new_dir / "SKILL.md"
+        if moved_md.exists():
+            body = moved_md.read_text(encoding="utf-8")
+            rewritten, n, unmapped = _rewrite_claude_refs(body, _new_dir_for)
+            if n:
+                moved_md.write_text(rewritten, encoding="utf-8")
+                refs_rewritten += n
+            stale_refs |= unmapped
+
     # Relocate the registry under the umbrella with rewritten skill_paths.
     umbrella_dir.mkdir(parents=True, exist_ok=True)
     new_registry.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
@@ -113,6 +190,8 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
         "services": outcomes,
         "umbrella_written": umbrella_changed,
         "registry": str(new_registry),
+        "refs_rewritten": refs_rewritten,
+        "stale_refs": sorted(stale_refs),
     }
 
 
@@ -168,6 +247,14 @@ def main() -> None:
         print(f"{prefix}: {sid} ({outcome})")
     print(f"registry: {result['registry']}")
     print(f"umbrella: {'written' if result['umbrella_written'] else 'unchanged'}")
+    if result.get("refs_rewritten"):
+        print(f"refs: rewrote {result['refs_rewritten']} legacy .claude/skills path(s) in SKILL.md bodies")
+    for seg in result.get("stale_refs", []):
+        print(
+            f"WARNING: unmapped .claude/skills/{seg} ref left as-is "
+            f"(no matching service-id or registry container) — review manually",
+            file=sys.stderr,
+        )
     for note in demote_shadowing_registries(project_root):
         print(note)
     sys.exit(0)

--- a/skills/service-skills/tests/test_bootstrap_registry_path.py
+++ b/skills/service-skills/tests/test_bootstrap_registry_path.py
@@ -65,6 +65,10 @@ def test_run_gitnexus_json_omits_json_flag_and_uses_repo(tmp_path: Path, monkeyp
 
     monkeypatch.setattr(bootstrap.subprocess, "Popen", FakeProc)
     monkeypatch.setattr(bootstrap, "get_project_root", lambda: str(tmp_path))
+    # Isolate from the repo-name resolver: _gitnexus_repo_name now shells out via
+    # subprocess.run (git --git-common-dir, xtrm-vvhfs), which would collide with the
+    # FakeProc Popen stub. This test only asserts run_gitnexus_json's flag/-repo wiring.
+    monkeypatch.setattr(bootstrap, "_gitnexus_repo_name", lambda project_root=None: "mock-repo")
     assert bootstrap.run_gitnexus_json(["detect_changes", "--scope", "unstaged"]) == {"output": "No changes detected"}
     assert "--json" not in captured["cmd"]
     assert "--repo" in captured["cmd"]

--- a/skills/service-skills/tests/test_catalog_vs_synced.py
+++ b/skills/service-skills/tests/test_catalog_vs_synced.py
@@ -1,0 +1,80 @@
+"""Catalogued != verified-synced (xtrm-008tr).
+
+Two invariants the field incident (mercury-market-data: 16 services bulk-stamped
+last_sync=now with no last_sync_ref -> drift scan returned 0 despite 20+ changed files)
+proves are required:
+
+  1. register_service MUST NOT stamp last_sync. Registration catalogues a service; only a
+     verified audit (drift_detector.update_sync_time) may claim a sync, and it stamps
+     last_sync_ref atomically alongside.
+  2. scan_drift MUST surface a service that has never been verified-synced (no/sentinel
+     last_sync) as drift (needs initial sync) rather than silently skipping it — skipping is
+     exactly how the timestamp-less bulk catalog masked real drift.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import bootstrap
+import drift_detector
+
+
+def test_register_service_does_not_stamp_last_sync(tmp_path: Path):
+    bootstrap.register_service("svc", "Svc", ["src/**/*"], "skills/svc/SKILL.md",
+                               project_root=str(tmp_path))
+    svc = bootstrap.get_service("svc", str(tmp_path))
+    assert svc is not None
+    # Catalogued, not synced: neither field is faked at registration.
+    assert "last_sync" not in svc, "registration must not claim a sync"
+    assert "last_sync_ref" not in svc
+
+
+def _repo_with_service(d: str, *, last_sync) -> Path:
+    """git repo + a tracked src file + a registry service whose last_sync is `last_sync`
+    (None => key omitted entirely, mimicking a freshly catalogued service)."""
+    root = Path(d)
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    for k, v in (("user.email", "t@t.t"), ("user.name", "t")):
+        subprocess.run(["git", "-C", str(root), "config", k, v], check=True)
+    (root / "src").mkdir()
+    (root / "src/app.py").write_text("x = 1\n", encoding="utf-8")
+    svc: dict = {"name": "Alpha", "territory": ["src/**/*"], "skill_path": "skills/alpha/SKILL.md"}
+    if last_sync is not None:
+        svc["last_sync"] = last_sync
+    (root / "service-registry.json").write_text(
+        json.dumps({"version": "1.0", "services": {"alpha": svc}}), encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", "src/app.py", "service-registry.json"], check=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "init"], check=True)
+    return root
+
+
+def test_scan_surfaces_service_with_no_last_sync():
+    """No last_sync at all (catalogued-only) -> the whole territory is surfaced as drift."""
+    with TemporaryDirectory() as d:
+        root = _repo_with_service(d, last_sync=None)
+        out = drift_detector.scan_drift(project_root=str(root), use_gitnexus=False)
+        hits = {i["file_path"]: i for i in out}
+        assert "src/app.py" in hits, f"never-synced service must surface, not be skipped: {hits}"
+        assert hits["src/app.py"]["never_synced"] is True
+
+
+def test_scan_surfaces_never_sentinel_service():
+    """The 'never' string sentinel is also never-synced -> surfaced, not skipped."""
+    with TemporaryDirectory() as d:
+        root = _repo_with_service(d, last_sync="never")
+        out = drift_detector.scan_drift(project_root=str(root), use_gitnexus=False)
+        assert any(i["file_path"] == "src/app.py" and i["never_synced"] for i in out), \
+            "the 'never' sentinel must be treated as needing an initial sync"
+
+
+def test_scan_respects_a_real_future_sync():
+    """Sanity: a genuine verified sync in the future is NOT never-synced and masks nothing
+    falsely — a file committed before that sync does not drift, and never_synced is False."""
+    with TemporaryDirectory() as d:
+        root = _repo_with_service(d, last_sync="2999-01-01T00:00:00Z")
+        out = drift_detector.scan_drift(project_root=str(root), use_gitnexus=False)
+        assert out == [], f"file older than a future sync must not drift: {out}"

--- a/skills/service-skills/tests/test_gitnexus_repo_name.py
+++ b/skills/service-skills/tests/test_gitnexus_repo_name.py
@@ -1,0 +1,68 @@
+"""_gitnexus_repo_name must resolve the indexed (main-worktree) repo label, not the
+per-worktree basename (xtrm-vvhfs).
+
+The service-skills-sync librarian ALWAYS runs in an sp-auto-provisioned linked worktree.
+Before the fix, get_project_root() -> worktree dir -> basename injected as gitnexus --repo,
+which gitnexus never indexed -> every gitnexus call failed -> drift fell back to mtime-only
+for the one specialist that most needs semantic tiering.
+"""
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import bootstrap
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(["git", "-C", str(root), *args],
+                          capture_output=True, text=True, check=True).stdout.strip()
+
+
+def _init_main(d: str) -> Path:
+    main = Path(d) / "market-data"
+    main.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=main, check=True)
+    _git(main, "config", "user.email", "t@t.t")
+    _git(main, "config", "user.name", "t")
+    (main / "f.txt").write_text("x\n", encoding="utf-8")
+    _git(main, "add", "f.txt")
+    _git(main, "commit", "-qm", "init")
+    return main
+
+
+def test_main_checkout_returns_repo_basename(monkeypatch):
+    monkeypatch.delenv("GITNEXUS_REPO", raising=False)
+    with TemporaryDirectory() as d:
+        main = _init_main(d)
+        assert bootstrap._gitnexus_repo_name(str(main)) == "market-data"
+
+
+def test_worktree_resolves_to_main_basename_not_worktree_dir(monkeypatch):
+    """The crux: from inside a linked worktree, the label is the MAIN repo basename."""
+    monkeypatch.delenv("GITNEXUS_REPO", raising=False)
+    with TemporaryDirectory() as d:
+        main = _init_main(d)
+        wt = Path(d) / "market-data-uh1r-service-skills-sync"
+        _git(main, "worktree", "add", "-q", str(wt))
+        # Sanity: the naive basename would be the worktree dir name.
+        assert wt.name != main.name
+        assert bootstrap._gitnexus_repo_name(str(wt)) == "market-data", \
+            "worktree must resolve to the indexed main-repo label, not its own dir name"
+
+
+def test_gitnexus_repo_env_override_wins(monkeypatch):
+    monkeypatch.setenv("GITNEXUS_REPO", "explicit-label")
+    with TemporaryDirectory() as d:
+        main = _init_main(d)
+        assert bootstrap._gitnexus_repo_name(str(main)) == "explicit-label"
+
+
+def test_non_git_dir_falls_back_to_basename(monkeypatch):
+    monkeypatch.delenv("GITNEXUS_REPO", raising=False)
+    with TemporaryDirectory() as d:
+        plain = Path(d) / "loose-checkout"
+        plain.mkdir()
+        assert bootstrap._gitnexus_repo_name(str(plain)) == "loose-checkout"

--- a/skills/service-skills/tests/test_layout_migrator_refs.py
+++ b/skills/service-skills/tests/test_layout_migrator_refs.py
@@ -1,0 +1,92 @@
+"""layout_migrator must rewrite legacy in-body .claude/skills/<alias> refs (xtrm-8ike5).
+
+The migrator MOVES each service's SKILL.md verbatim, so self-refs (by service-id OR by the
+registry 'container' name) and umbrella cross-refs kept pointing at the dead flat path
+.claude/skills/<name>/scripts/... . Incident (mercury-market-data): 27 stale refs across 8
+skills, all fixed by hand. These tests pin the automatic rewrite + the unmapped-ref warning.
+"""
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import layout_migrator as lm  # noqa: E402
+
+
+def _flat_pack(root: Path, pack_name: str, services: dict[str, dict]) -> Path:
+    """services: {sid: {"body": str, "container": str|None}} -> flat-layout pack on disk."""
+    pack = root / ".xtrm" / "skills" / "user" / "packs" / pack_name
+    reg: dict = {"version": "1.0", "services": {}}
+    for sid, spec in services.items():
+        d = pack / sid
+        (d / "scripts").mkdir(parents=True)
+        (d / "SKILL.md").write_text(spec["body"], encoding="utf-8")
+        (d / "scripts" / "health_probe.py").write_text("# probe\n", encoding="utf-8")
+        entry = {"name": sid, "territory": [f"src/{sid}/**"],
+                 "skill_path": f".claude/skills/{sid}/SKILL.md", "last_sync": "never"}
+        if spec.get("container"):
+            entry["container"] = spec["container"]
+        reg["services"][sid] = entry
+    (pack / "service-registry.json").write_text(json.dumps(reg, indent=2), encoding="utf-8")
+    return pack
+
+
+class TestRewriteClaudeRefs(unittest.TestCase):
+    def test_rewrites_self_container_and_cross_refs(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            base = ".xtrm/skills/user/packs/market-data/service-skills/services"
+            pack = _flat_pack(root, "market-data", {
+                "ingesting-ohlcv": {
+                    "container": "mmd-data-feed",
+                    "body": (
+                        "# feed\n"
+                        "Run: .claude/skills/ingesting-ohlcv/scripts/health_probe.py\n"  # self by id
+                        "make -C .claude/skills/mmd-data-feed test\n"                     # self by container
+                        "See .claude/skills/serving-market-api/SKILL.md\n"               # cross by id
+                    ),
+                },
+                "serving-market-api": {"container": "mmd-api", "body": "# api\n"},
+            })
+            res = lm.migrate_pack(root, pack, "market-data")
+            self.assertEqual(res["status"], "ok")
+            self.assertEqual(res["refs_rewritten"], 3)
+            self.assertEqual(res["stale_refs"], [])
+
+            moved = (pack / "service-skills/services/ingesting-ohlcv/SKILL.md").read_text()
+            self.assertNotIn(".claude/skills", moved)
+            self.assertIn(f"{base}/ingesting-ohlcv/scripts/health_probe.py", moved)        # self by id
+            self.assertIn(f"make -C {base}/ingesting-ohlcv test", moved)                   # container -> id dir
+            self.assertIn(f"{base}/serving-market-api/SKILL.md", moved)                    # cross-ref
+
+    def test_idempotent_second_run_rewrites_nothing(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            pack = _flat_pack(root, "p", {
+                "svc-a": {"body": "x .claude/skills/svc-a/scripts/probe.py\n"},
+            })
+            r1 = lm.migrate_pack(root, pack, "p")
+            self.assertEqual(r1["refs_rewritten"], 1)
+            r2 = lm.migrate_pack(root, pack, "p")
+            self.assertEqual(r2["refs_rewritten"], 0)
+            self.assertNotIn(".claude/skills", (pack / "service-skills/services/svc-a/SKILL.md").read_text())
+
+    def test_unmapped_ref_left_intact_and_reported(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            pack = _flat_pack(root, "p", {
+                "svc-a": {"body": "look .claude/skills/ghost-service/scripts/x.py\n"},
+            })
+            res = lm.migrate_pack(root, pack, "p")
+            moved = (pack / "service-skills/services/svc-a/SKILL.md").read_text()
+            # Unknown segment is preserved (never silently corrupted) and surfaced for review.
+            self.assertIn(".claude/skills/ghost-service/scripts/x.py", moved)
+            self.assertIn("ghost-service", res["stale_refs"])
+            self.assertEqual(res["refs_rewritten"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three independent service-skills machinery bugs, all surfaced from the same mercury-market-data field incident. Follow-ups discovered while reviewing the xtrm-08i0b OOM fix (#280, merged). The territory-glob sibling (xtrm-br179) is intentionally excluded — it is already covered by #280's git-tracked filter.

## xtrm-vvhfs (P1) — gitnexus `--repo` resolved to the worktree basename
`bootstrap._gitnexus_repo_name()` returned `Path(project_root).name`. In an sp-auto-provisioned **linked worktree** that is the worktree dir name (e.g. `market-data-uh1r-service-skills-sync`), which gitnexus never indexed → `--repo` injection fails → `is_gitnexus_available=False` → drift silently degrades to mtime-only. The **service-skills-sync librarian always runs in a worktree**, so it never got semantic enrichment.

- Resolve the indexed label via `git rev-parse --git-common-dir` (the shared/main `.git`; its parent is the indexed checkout); fall back to the local basename; `GITNEXUS_REPO` still wins.
- **Two sites:** also fixed a hardcoded `Path(project_root).name` passed into `_enrich_item` in `scan_drift`.
- Test: `test_gitnexus_repo_name.py` (real git worktree).

## xtrm-008tr (P1) — catalog ≠ verified-sync; never-synced drift was masked
`register_service` stamped `last_sync=now` with no `last_sync_ref`. Done in bulk it set every service's `last_sync` to now, so the drift scan's mtime pre-filter returned 0 candidates and masked real drift (20+ changed files reported clean).

- **Fix A:** `register_service` no longer stamps `last_sync` — registration catalogues; only a verified audit (`update_sync_time`) may claim a sync, stamping `last_sync_ref` atomically alongside.
- **Fix B (essential pair):** `scan_drift` no longer *skips* a service with missing/sentinel `last_sync` — it surfaces the whole territory as drift (`never_synced=True`), i.e. needs an initial verified sync. Without B, dropping the fake timestamp would just move the masking from false-clean to silently-skipped. Bounded by #280's git-tracked filter + enrichment cap.
- Test: `test_catalog_vs_synced.py`.

## xtrm-8ike5 (P2) — migrator left stale `.claude/skills/<old>` refs in moved bodies
`layout_migrator` moves each SKILL.md verbatim, so in-body self/cross refs kept pointing at the dead flat path `.claude/skills/<name>/scripts/...` (27 stale refs across 8 skills, hand-fixed in the field).

- After each move, rewrite every `.claude/skills/<segment>` (preserving trailing `/scripts/...`, `/SKILL.md`, or bare `make -C` dir arg) to the new `.xtrm/.../service-skills/services/<service-id>` dir. Alias map from the registry: segment is a service-id (self/cross-ref) or a service's `container` field. Unmapped segments are left intact and reported (`stale_refs` + stderr warning). Idempotent.
- Test: `test_layout_migrator_refs.py`.

## Validation
- 52/52 service-skills pytest green (3 new test files, 1 updated mock).
- registry↔pack parity 330/330; `.xtrm/skills/default/service-skills/` mirror synced.
- Pre-existing E701/pyright in the terse drift_detector one-liners + `find_service_for_path` left untouched (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)