### PR TITLE
feat(service-skills): validate-territories lint for gitignored glob sweep (xtrm-br179)

### DIFF
--- a/.xtrm/skills/default/service-skills/scripts/drift_detector.py
+++ b/.xtrm/skills/default/service-skills/scripts/drift_detector.py
@@ -179,6 +179,45 @@ def _service_last_sync_ref(service: dict[str, Any]) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def territory_gitignore_report(project_root: str | None = None) -> list[dict]:
+    """Per (service, territory pattern), report filesystem-glob matches that are NOT git-tracked
+    — i.e. gitignored build/vendor/cache files a glob sweeps in (xtrm-br179).
+
+    Read-only. Returns one entry per pattern with a nonzero ignored-delta (empty if git is
+    unavailable or no registry). These files are already dropped at scan time by the
+    ``_git_tracked_files`` filter (xtrm-08i0b), so this is an advisory lint: a flagged pattern is
+    matching the filesystem rather than git and should be narrowed (e.g. ``dir/**/*`` ->
+    ``dir/**/*.py``) so the territory tracks only real source.
+    """
+    if project_root is None:
+        try:
+            project_root = get_project_root()
+        except RootResolutionError:
+            return []
+    project_root = cast(str, project_root)
+    root = Path(project_root)
+    if not get_registry_path(project_root).exists():
+        return []
+    tracked = _git_tracked_files(project_root)
+    if tracked is None:
+        return []
+    registry = load_registry(project_root)
+    report: list[dict] = []
+    for service_id, service in registry.get("services", {}).items():
+        for pattern in service.get("territory", []):
+            fs = [str(p.relative_to(root)) for p in root.glob(pattern) if p.is_file()]
+            if not fs:
+                continue
+            ignored = sorted(f for f in fs if f not in tracked)
+            if ignored:
+                report.append({
+                    "service_id": service_id, "pattern": pattern, "fs": len(fs),
+                    "tracked": len(fs) - len(ignored), "ignored": len(ignored),
+                    "samples": ignored[:3],
+                })
+    return report
+
+
 def scan_drift(project_root: str | None = None, enrich_with_gitnexus: bool = False, use_gitnexus: bool = True) -> list[dict]:
     if project_root is None:
         try:
@@ -216,7 +255,15 @@ def scan_drift(project_root: str | None = None, enrich_with_gitnexus: bool = Fal
     # swept in by filesystem globs) before any gitnexus enrichment (xtrm-08i0b).
     tracked = _git_tracked_files(project_root)
     if tracked is not None:
+        before = len(drifted)
         drifted = [d for d in drifted if d["file_path"] in tracked]
+        dropped = before - len(drifted)
+        if dropped:
+            # Advisory: a territory glob is matching gitignored build/vendor/cache files. They are
+            # safely excluded here (xtrm-08i0b), but the pattern should be narrowed (xtrm-br179).
+            print(f"drift_detector: dropped {dropped} gitignored candidate(s) swept in by territory "
+                  f"globs; run 'drift_detector.py validate-territories' to find which to narrow.",
+                  file=sys.stderr)
         if not drifted:
             return []
     # Hard cap: an unbounded candidate set fans out one gitnexus subprocess per file and OOMs
@@ -267,6 +314,21 @@ def main() -> None:
         print(r["message"] if r.get("drift") else f"No drift: {r.get('reason', 'OK')}")
     elif cmd == "sync" and len(args) > 1:
         sys.exit(0 if update_sync_time(args[1]) else 1)
+    elif cmd == "validate-territories":
+        report = territory_gitignore_report()
+        if not report:
+            print("Territory validation: no gitignored files swept in by any territory glob "
+                  "(or git/registry unavailable).")
+            return
+        total = sum(r["ignored"] for r in report)
+        print(f"Territory validation: {len(report)} pattern(s) sweep in {total} gitignored file(s). "
+              "These are dropped at scan time but indicate the glob should be narrowed:")
+        for r in report:
+            print(f"  [{r['service_id']}] '{r['pattern']}': {r['fs']} fs / {r['tracked']} tracked / "
+                  f"{r['ignored']} ignored")
+            print(f"      e.g. {r['samples']}")
+        print("Tip: narrow recursive globs (e.g. 'dir/**/*' -> 'dir/**/*.py') so the territory "
+              "tracks only real source.")
     elif cmd == "scan":
         d = scan_drift(enrich_with_gitnexus=enrich, use_gitnexus=not no_gitnexus)
         if not d:

--- a/skills/service-skills/scripts/drift_detector.py
+++ b/skills/service-skills/scripts/drift_detector.py
@@ -179,6 +179,45 @@ def _service_last_sync_ref(service: dict[str, Any]) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def territory_gitignore_report(project_root: str | None = None) -> list[dict]:
+    """Per (service, territory pattern), report filesystem-glob matches that are NOT git-tracked
+    — i.e. gitignored build/vendor/cache files a glob sweeps in (xtrm-br179).
+
+    Read-only. Returns one entry per pattern with a nonzero ignored-delta (empty if git is
+    unavailable or no registry). These files are already dropped at scan time by the
+    ``_git_tracked_files`` filter (xtrm-08i0b), so this is an advisory lint: a flagged pattern is
+    matching the filesystem rather than git and should be narrowed (e.g. ``dir/**/*`` ->
+    ``dir/**/*.py``) so the territory tracks only real source.
+    """
+    if project_root is None:
+        try:
+            project_root = get_project_root()
+        except RootResolutionError:
+            return []
+    project_root = cast(str, project_root)
+    root = Path(project_root)
+    if not get_registry_path(project_root).exists():
+        return []
+    tracked = _git_tracked_files(project_root)
+    if tracked is None:
+        return []
+    registry = load_registry(project_root)
+    report: list[dict] = []
+    for service_id, service in registry.get("services", {}).items():
+        for pattern in service.get("territory", []):
+            fs = [str(p.relative_to(root)) for p in root.glob(pattern) if p.is_file()]
+            if not fs:
+                continue
+            ignored = sorted(f for f in fs if f not in tracked)
+            if ignored:
+                report.append({
+                    "service_id": service_id, "pattern": pattern, "fs": len(fs),
+                    "tracked": len(fs) - len(ignored), "ignored": len(ignored),
+                    "samples": ignored[:3],
+                })
+    return report
+
+
 def scan_drift(project_root: str | None = None, enrich_with_gitnexus: bool = False, use_gitnexus: bool = True) -> list[dict]:
     if project_root is None:
         try:
@@ -216,7 +255,15 @@ def scan_drift(project_root: str | None = None, enrich_with_gitnexus: bool = Fal
     # swept in by filesystem globs) before any gitnexus enrichment (xtrm-08i0b).
     tracked = _git_tracked_files(project_root)
     if tracked is not None:
+        before = len(drifted)
         drifted = [d for d in drifted if d["file_path"] in tracked]
+        dropped = before - len(drifted)
+        if dropped:
+            # Advisory: a territory glob is matching gitignored build/vendor/cache files. They are
+            # safely excluded here (xtrm-08i0b), but the pattern should be narrowed (xtrm-br179).
+            print(f"drift_detector: dropped {dropped} gitignored candidate(s) swept in by territory "
+                  f"globs; run 'drift_detector.py validate-territories' to find which to narrow.",
+                  file=sys.stderr)
         if not drifted:
             return []
     # Hard cap: an unbounded candidate set fans out one gitnexus subprocess per file and OOMs
@@ -267,6 +314,21 @@ def main() -> None:
         print(r["message"] if r.get("drift") else f"No drift: {r.get('reason', 'OK')}")
     elif cmd == "sync" and len(args) > 1:
         sys.exit(0 if update_sync_time(args[1]) else 1)
+    elif cmd == "validate-territories":
+        report = territory_gitignore_report()
+        if not report:
+            print("Territory validation: no gitignored files swept in by any territory glob "
+                  "(or git/registry unavailable).")
+            return
+        total = sum(r["ignored"] for r in report)
+        print(f"Territory validation: {len(report)} pattern(s) sweep in {total} gitignored file(s). "
+              "These are dropped at scan time but indicate the glob should be narrowed:")
+        for r in report:
+            print(f"  [{r['service_id']}] '{r['pattern']}': {r['fs']} fs / {r['tracked']} tracked / "
+                  f"{r['ignored']} ignored")
+            print(f"      e.g. {r['samples']}")
+        print("Tip: narrow recursive globs (e.g. 'dir/**/*' -> 'dir/**/*.py') so the territory "
+              "tracks only real source.")
     elif cmd == "scan":
         d = scan_drift(enrich_with_gitnexus=enrich, use_gitnexus=not no_gitnexus)
         if not d:

--- a/skills/service-skills/tests/test_territory_validation.py
+++ b/skills/service-skills/tests/test_territory_validation.py
@@ -1,0 +1,77 @@
+"""territory_gitignore_report flags territory globs that sweep in gitignored files (xtrm-br179).
+
+scan_drift already DROPS gitignored candidates (xtrm-08i0b) so drift is correct, but a glob like
+'dir/**/*' silently matching build/cache trees (__pycache__, target/, node_modules) is a footgun
+worth surfacing so the operator narrows the pattern. This is the read-only lint behind the
+'validate-territories' CLI.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import drift_detector
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True, text=True)
+
+
+def _repo(d: str, territory: list[str]) -> Path:
+    root = Path(d)
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    _git(root, "config", "user.email", "t@t.t")
+    _git(root, "config", "user.name", "t")
+    (root / "src").mkdir()
+    (root / "src/app.py").write_text("x = 1\n", encoding="utf-8")        # tracked source
+    (root / "src/__pycache__").mkdir()
+    (root / "src/__pycache__/app.pyc").write_text("bytecode\n", encoding="utf-8")  # gitignored
+    (root / ".gitignore").write_text("__pycache__/\n", encoding="utf-8")
+    (root / "service-registry.json").write_text(json.dumps({"version": "1.0", "services": {
+        "alpha": {"name": "Alpha", "territory": territory,
+                  "skill_path": "skills/alpha/SKILL.md", "last_sync": "2024-01-01T00:00:00Z"}}}),
+        encoding="utf-8")
+    _git(root, "add", "src/app.py", ".gitignore", "service-registry.json")
+    _git(root, "commit", "-qm", "init")
+    return root
+
+
+def test_recursive_glob_flags_gitignored_pyc():
+    with TemporaryDirectory() as d:
+        root = _repo(d, ["src/**/*"])
+        report = drift_detector.territory_gitignore_report(str(root))
+        assert len(report) == 1, report
+        r = report[0]
+        assert r["service_id"] == "alpha" and r["pattern"] == "src/**/*"
+        assert r["ignored"] == 1 and r["tracked"] == 1
+        assert any("__pycache__/app.pyc" in s for s in r["samples"])
+
+
+def test_narrow_glob_is_clean():
+    """A pattern that only matches tracked source produces no finding."""
+    with TemporaryDirectory() as d:
+        root = _repo(d, ["src/**/*.py"])
+        assert drift_detector.territory_gitignore_report(str(root)) == []
+
+
+def test_non_git_dir_returns_empty():
+    with TemporaryDirectory() as d:
+        plain = Path(d) / "loose"
+        plain.mkdir()
+        (plain / "service-registry.json").write_text('{"version":"1.0","services":{}}', encoding="utf-8")
+        assert drift_detector.territory_gitignore_report(str(plain)) == []
+
+
+def test_cli_validate_territories_reports_finding():
+    with TemporaryDirectory() as d:
+        root = _repo(d, ["src/**/*"])
+        out = subprocess.run([sys.executable, str(SCRIPTS / "drift_detector.py"), "validate-territories"],
+                             cwd=str(root), capture_output=True, text=True)
+        assert out.returncode == 0, out.stderr
+        assert "1 pattern(s) sweep in 1 gitignored file(s)" in out.stdout
+        assert "src/**/*" in out.stdout


### PR DESCRIPTION
Closes the optional half of **xtrm-br179**. The core risk — territory globs matching the filesystem (`Path.glob`) and sweeping gitignored build/vendor/cache trees into the drift candidate set — was already neutralized at scan time by the xtrm-08i0b `git ls-files` filter (#280). This adds the operator-facing surface so a sloppy glob gets flagged instead of silently tolerated.

## What's added
- **`territory_gitignore_report(project_root)`** — read-only; per `(service, territory pattern)` reports filesystem-glob matches that are NOT git-tracked (the gitignored delta) with samples. Returns `[]` if git/registry unavailable.
- **`drift_detector.py validate-territories`** CLI — prints flagged patterns (`fs / tracked / ignored` counts + samples) and a narrow-the-glob tip. Advisory, exit 0.
- **`scan_drift` stderr advisory** — when it drops gitignored candidates, it now says how many and points at `validate-territories` (was silent).

## Verified live on mercury/market-data
```
Territory validation: 2 pattern(s) sweep in 107 gitignored file(s).
  [serving-mcp-tools] 'api/docstrings/**/*': 49 fs / 24 tracked / 25 ignored
  [migrating-schema]  'alembic/**/*':       130 fs / 48 tracked / 82 ignored
```
All narrow patterns (`*.py`, `rust_ingestor/src/**/*.rs`, specific files) are clean. The glob-vs-`git ls-files` delta is both the verification method and the lint.

## Validation
- 56/56 service-skills pytest (new `test_territory_validation.py`: recursive glob flags `.pyc`, narrow glob clean, non-git `[]`, CLI smoke).
- registry↔pack parity 330/330; mirror synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)