### PR TITLE
fix(service-skills): sync PACK.json + rebuild active view after migration (xtrm-x8b5g)

### DIFF
--- a/.xtrm/skills/default/service-skills/scripts/layout_migrator.py
+++ b/.xtrm/skills/default/service-skills/scripts/layout_migrator.py
@@ -71,6 +71,39 @@ def _new_skill_dir_str(project_root: Path, pack: Path, service_id: str) -> str:
         return str(new_dir).replace(os.sep, "/")
 
 
+def _sync_pack_json(pack: Path) -> str | None:
+    """Sync ``PACK.json`` ``skills[]`` to the post-migration filesystem (xtrm-x8b5g).
+
+    The active-view materializer validates a pack's ``PACK.json`` ``skills[]`` against the
+    filesystem: an entry is a *direct child dir of the pack that contains a SKILL.md* (dir name
+    is the identity). After migration the moved per-service dirs live under
+    ``service-skills/services/`` (no longer direct children) and the new ``service-skills``
+    umbrella is a direct child — so a stale ``PACK.json`` lists ghost services (metadata-only) and
+    omits the umbrella (filesystem-only), tripping ``PACK_METADATA_MISMATCH`` which BLOCKS the
+    active-view rebuild. Recompute ``skills[]`` from the filesystem (idempotent). Returns a note,
+    or None when there is no ``PACK.json`` or it is already in sync.
+    """
+    pack_json = pack / "PACK.json"
+    if not pack_json.exists():
+        return None
+    try:
+        data = json.loads(pack_json.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    fs_skills = sorted(
+        child.name for child in pack.iterdir()
+        if child.is_dir() and (child / "SKILL.md").exists()
+    )
+    if data.get("skills") == fs_skills:
+        return None
+    data["skills"] = fs_skills
+    try:
+        pack_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        return None
+    return f"pack-json: synced PACK.json skills -> {', '.join(fs_skills) or '(none)'}"
+
+
 def _rewrite_claude_refs(body: str, new_dir_for: Any) -> tuple[str, int, set[str]]:
     """Rewrite legacy ``.claude/skills/<alias>`` refs in a moved SKILL.md body to the new
     ``.xtrm/.../service-skills/services/<service-id>`` dir.
@@ -184,6 +217,10 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
     # Generate the umbrella (preserves any existing SEMANTIC block).
     umbrella_changed = write_umbrella(umbrella_dir / "SKILL.md", registry, repo_name)
 
+    # Sync PACK.json AFTER the umbrella exists + services have moved, so the recomputed
+    # skills[] reflects the final layout (umbrella in, ghost services out) — xtrm-x8b5g.
+    pack_json_note = _sync_pack_json(pack)
+
     return {
         "pack": pack.name,
         "status": "ok",
@@ -192,6 +229,7 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
         "registry": str(new_registry),
         "refs_rewritten": refs_rewritten,
         "stale_refs": sorted(stale_refs),
+        "pack_json_note": pack_json_note,
     }
 
 
@@ -247,6 +285,8 @@ def main() -> None:
         print(f"{prefix}: {sid} ({outcome})")
     print(f"registry: {result['registry']}")
     print(f"umbrella: {'written' if result['umbrella_written'] else 'unchanged'}")
+    if result.get("pack_json_note"):
+        print(result["pack_json_note"])
     if result.get("refs_rewritten"):
         print(f"refs: rewrote {result['refs_rewritten']} legacy .claude/skills path(s) in SKILL.md bodies")
     for seg in result.get("stale_refs", []):

--- a/cli/dist/index.cjs
+++ b/cli/dist/index.cjs
@@ -56974,6 +56974,15 @@ async function ensureServiceSkills(projectRoot, opts) {
       }
     }
   }
+  if (migratedPacks.length > 0) {
+    try {
+      const skillsRoot = import_node_path9.default.join(projectRoot, ".xtrm", "skills");
+      const views = await rebuildAllRuntimeActiveViews(skillsRoot);
+      notes.push(`service-skills: active view rebuilt after migration (${views[0]?.discoveredSkillCount ?? 0} skills).`);
+    } catch (error51) {
+      notes.push(`service-skills: active-view rebuild after migration skipped \u2014 ${error51 instanceof Error ? error51.message : String(error51)}`);
+    }
+  }
   await ensurePostMergeDriftHook(projectRoot, notes);
   return { applicable: true, migratedPacks, alreadyCurrent: migratedPacks.length === 0, notes };
 }

--- a/cli/src/core/service-skills-ensure.ts
+++ b/cli/src/core/service-skills-ensure.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import fs from 'fs-extra';
+import { rebuildAllRuntimeActiveViews } from './skills-materializer.js';
 
 /**
  * Registry-gated, idempotent service-skills migration runner.
@@ -116,6 +117,23 @@ export async function ensureServiceSkills(
       if (line.startsWith('migrated:') || line.startsWith('umbrella:') || line.startsWith('registry:') || line.includes('WARNING')) {
         notes.push(`service-skills: ${line.trim()}`);
       }
+    }
+  }
+
+  // Rebuild the runtime active view AFTER a migration (xtrm-x8b5g). The migrator just
+  // moved services into the umbrella and synced PACK.json; but the active-view rebuild in
+  // the normal flow is gated (update: only when registry files drifted; init: Phase 6b runs
+  // *before* this migration), so a migration-only pass would leave .xtrm/skills/active frozen
+  // — the consumer would never see the new `service-skills` machinery + `<repo>-services`
+  // umbrella. Rebuild here, scoped to an actual migration. Idempotent (atomic swap) and
+  // best-effort: a failure is noted, never aborts the update.
+  if (migratedPacks.length > 0) {
+    try {
+      const skillsRoot = path.join(projectRoot, '.xtrm', 'skills');
+      const views = await rebuildAllRuntimeActiveViews(skillsRoot);
+      notes.push(`service-skills: active view rebuilt after migration (${views[0]?.discoveredSkillCount ?? 0} skills).`);
+    } catch (error) {
+      notes.push(`service-skills: active-view rebuild after migration skipped — ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 

--- a/cli/test/service-skills-ensure.test.ts
+++ b/cli/test/service-skills-ensure.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ensureServiceSkills, hasServiceRegistry } from '../src/core/service-skills-ensure.js';
+import { setRuntimeEnabledPacks } from '../src/core/skills-state.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCRIPTS_SRC = path.resolve(__dirname, '..', '..', 'skills', 'service-skills', 'scripts');
@@ -70,6 +71,43 @@ describe('ensureServiceSkills — foolproof registry-gated migration (xtrm-u54wt
     expect(second.applicable).toBe(true);
     expect(second.alreadyCurrent).toBe(true);
     expect(second.migratedPacks).toEqual([]);
+  });
+
+  it('syncs PACK.json and rebuilds the active view (umbrella) after migration (xtrm-x8b5g)', async () => {
+    const repo = await makeRepo();
+    await seedFlatPack(repo, ['serving-mcp-tools', 'db-expert']);
+    const skillsRoot = path.join(repo, '.xtrm', 'skills');
+    const pack = path.join(skillsRoot, 'user', 'packs', 'market-data');
+    // a regular (non-service) skill that must survive in PACK.json
+    await fs.ensureDir(path.join(pack, 'using-tdd-guard'));
+    await fs.writeFile(path.join(pack, 'using-tdd-guard', 'SKILL.md'), '# tdd\n', 'utf8');
+    // a STALE PACK.json: lists the flat services + regular, omits the umbrella
+    await fs.writeJson(path.join(pack, 'PACK.json'), {
+      schemaVersion: '1', name: 'market-data', version: '1.0.0',
+      description: 'User-created skill pack',
+      skills: ['db-expert', 'serving-mcp-tools', 'using-tdd-guard'],
+    }, { spaces: 2 });
+    await setRuntimeEnabledPacks(skillsRoot, 'claude', ['market-data']);
+
+    const result = await ensureServiceSkills(repo, { apply: true });
+    expect(result.migratedPacks).toContain('market-data');
+
+    // Part 1: PACK.json synced to the post-migration filesystem — ghost services dropped,
+    // 'service-skills' umbrella added, regular skill kept.
+    const packJson = await fs.readJson(path.join(pack, 'PACK.json'));
+    expect(packJson.skills).toEqual(['service-skills', 'using-tdd-guard']);
+
+    // Part 2: the active view is rebuilt after migration — both the regular pack skill and
+    // the generated '<repo>-services' umbrella now appear as symlinks. They would be absent if
+    // the rebuild were skipped on a migration-only pass (the bug). The umbrella's runtime name
+    // derives from the repo basename, so read it from the generated frontmatter.
+    const active = path.join(skillsRoot, 'active');
+    expect((await fs.lstat(path.join(active, 'using-tdd-guard'))).isSymbolicLink()).toBe(true);
+    const umbrellaName = (await fs.readFile(path.join(pack, 'service-skills', 'SKILL.md'), 'utf8'))
+      .match(/^name:\s*(.+)$/m)?.[1]?.trim();
+    expect(umbrellaName).toBeTruthy();
+    expect((await fs.lstat(path.join(active, umbrellaName!))).isSymbolicLink()).toBe(true);
+    expect(result.notes.some(n => n.includes('active view rebuilt'))).toBe(true);
   });
 
   it('dry-run does not migrate', async () => {

--- a/skills/service-skills/scripts/layout_migrator.py
+++ b/skills/service-skills/scripts/layout_migrator.py
@@ -71,6 +71,39 @@ def _new_skill_dir_str(project_root: Path, pack: Path, service_id: str) -> str:
         return str(new_dir).replace(os.sep, "/")
 
 
+def _sync_pack_json(pack: Path) -> str | None:
+    """Sync ``PACK.json`` ``skills[]`` to the post-migration filesystem (xtrm-x8b5g).
+
+    The active-view materializer validates a pack's ``PACK.json`` ``skills[]`` against the
+    filesystem: an entry is a *direct child dir of the pack that contains a SKILL.md* (dir name
+    is the identity). After migration the moved per-service dirs live under
+    ``service-skills/services/`` (no longer direct children) and the new ``service-skills``
+    umbrella is a direct child — so a stale ``PACK.json`` lists ghost services (metadata-only) and
+    omits the umbrella (filesystem-only), tripping ``PACK_METADATA_MISMATCH`` which BLOCKS the
+    active-view rebuild. Recompute ``skills[]`` from the filesystem (idempotent). Returns a note,
+    or None when there is no ``PACK.json`` or it is already in sync.
+    """
+    pack_json = pack / "PACK.json"
+    if not pack_json.exists():
+        return None
+    try:
+        data = json.loads(pack_json.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    fs_skills = sorted(
+        child.name for child in pack.iterdir()
+        if child.is_dir() and (child / "SKILL.md").exists()
+    )
+    if data.get("skills") == fs_skills:
+        return None
+    data["skills"] = fs_skills
+    try:
+        pack_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        return None
+    return f"pack-json: synced PACK.json skills -> {', '.join(fs_skills) or '(none)'}"
+
+
 def _rewrite_claude_refs(body: str, new_dir_for: Any) -> tuple[str, int, set[str]]:
     """Rewrite legacy ``.claude/skills/<alias>`` refs in a moved SKILL.md body to the new
     ``.xtrm/.../service-skills/services/<service-id>`` dir.
@@ -184,6 +217,10 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
     # Generate the umbrella (preserves any existing SEMANTIC block).
     umbrella_changed = write_umbrella(umbrella_dir / "SKILL.md", registry, repo_name)
 
+    # Sync PACK.json AFTER the umbrella exists + services have moved, so the recomputed
+    # skills[] reflects the final layout (umbrella in, ghost services out) — xtrm-x8b5g.
+    pack_json_note = _sync_pack_json(pack)
+
     return {
         "pack": pack.name,
         "status": "ok",
@@ -192,6 +229,7 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
         "registry": str(new_registry),
         "refs_rewritten": refs_rewritten,
         "stale_refs": sorted(stale_refs),
+        "pack_json_note": pack_json_note,
     }
 
 
@@ -247,6 +285,8 @@ def main() -> None:
         print(f"{prefix}: {sid} ({outcome})")
     print(f"registry: {result['registry']}")
     print(f"umbrella: {'written' if result['umbrella_written'] else 'unchanged'}")
+    if result.get("pack_json_note"):
+        print(result["pack_json_note"])
     if result.get("refs_rewritten"):
         print(f"refs: rewrote {result['refs_rewritten']} legacy .claude/skills path(s) in SKILL.md bodies")
     for seg in result.get("stale_refs", []):

--- a/skills/service-skills/tests/test_layout_migrator_packjson.py
+++ b/skills/service-skills/tests/test_layout_migrator_packjson.py
@@ -1,0 +1,86 @@
+"""layout_migrator must sync PACK.json skills[] after migration (xtrm-x8b5g).
+
+The active-view materializer validates a pack's PACK.json skills[] against the filesystem (a
+skill = a direct-child dir of the pack containing a SKILL.md, identified by dir name). After
+migration the moved per-service dirs live under service-skills/services/ (no longer direct
+children) and the new service-skills umbrella IS a direct child — so a stale PACK.json lists
+ghost services + omits the umbrella, tripping PACK_METADATA_MISMATCH which blocks the rebuild.
+"""
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import layout_migrator as lm  # noqa: E402
+
+
+def _flat_pack_with_packjson(root: Path, pack_name: str, services: list[str],
+                             regular_skills: list[str]) -> Path:
+    """Flat-layout pack with a PACK.json listing the OLD (pre-migration) skills:
+    the flat service dirs + any regular (non-service) skill dirs."""
+    pack = root / ".xtrm" / "skills" / "user" / "packs" / pack_name
+    reg = {"version": "1.0", "services": {}}
+    for sid in services:
+        (pack / sid).mkdir(parents=True)
+        (pack / sid / "SKILL.md").write_text(f"# {sid}\n", encoding="utf-8")
+        reg["services"][sid] = {"name": sid, "territory": [f"src/{sid}/**"],
+                                "skill_path": f".claude/skills/{sid}/SKILL.md", "last_sync": "never"}
+    for sk in regular_skills:
+        (pack / sk).mkdir(parents=True)
+        (pack / sk / "SKILL.md").write_text(f"# {sk}\n", encoding="utf-8")
+    (pack / "service-registry.json").write_text(json.dumps(reg, indent=2), encoding="utf-8")
+    # Stale PACK.json: lists the flat services + regulars, no 'service-skills' umbrella.
+    (pack / "PACK.json").write_text(json.dumps({
+        "schemaVersion": "1", "name": pack_name, "version": "1.0.0",
+        "description": "User-created skill pack",
+        "skills": sorted(services + regular_skills),
+    }, indent=2), encoding="utf-8")
+    return pack
+
+
+def _pack_skills(pack: Path) -> list[str]:
+    return json.loads((pack / "PACK.json").read_text())["skills"]
+
+
+class TestPackJsonSync(unittest.TestCase):
+    def test_pack_json_synced_after_migration(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            pack = _flat_pack_with_packjson(
+                root, "market-data",
+                services=["auth-service", "db-expert"],
+                regular_skills=["using-tdd-guard"])
+            res = lm.migrate_pack(root, pack, "market-data")
+            self.assertEqual(res["status"], "ok")
+            # Ghost services dropped (now under service-skills/services/), umbrella added,
+            # regular skill kept. Matches the materializer's direct-child-with-SKILL.md rule.
+            self.assertEqual(_pack_skills(pack), ["service-skills", "using-tdd-guard"])
+            self.assertIsNotNone(res["pack_json_note"])
+
+    def test_idempotent_second_run_leaves_pack_json_untouched(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            pack = _flat_pack_with_packjson(
+                root, "p", services=["svc-a"], regular_skills=[])
+            lm.migrate_pack(root, pack, "p")
+            self.assertEqual(_pack_skills(pack), ["service-skills"])
+            res2 = lm.migrate_pack(root, pack, "p")
+            self.assertIsNone(res2["pack_json_note"])  # already in sync
+            self.assertEqual(_pack_skills(pack), ["service-skills"])
+
+    def test_no_pack_json_is_noop(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            # Build a flat pack but remove the PACK.json the helper writes.
+            pack = _flat_pack_with_packjson(root, "p", services=["svc-a"], regular_skills=[])
+            (pack / "PACK.json").unlink()
+            res = lm.migrate_pack(root, pack, "p")
+            self.assertEqual(res["status"], "ok")
+            self.assertIsNone(res["pack_json_note"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Migrated consumers (darth-feedor, treasury-cb, market-data on 0.8.2) ended up **without the new `service-skills` skill in their active view** — two compounding bugs in the v2 migration path.

## 1. `layout_migrator` didn't update `PACK.json`
After moving per-service dirs into `service-skills/services/` and generating the `<repo>-services` umbrella, `PACK.json` still listed the (now-nested) services and omitted the umbrella → `PACK_METADATA_MISMATCH` (`diffPackMetadataSkills`), which **blocks** the active-view rebuild invariant.

**Fix:** `_sync_pack_json(pack)` recomputes `skills[]` = sorted **direct-child dirs containing `SKILL.md`** (the materializer's dir-name identity rule) — umbrella in, ghost services out, regular skills kept. Idempotent; runs after the umbrella is generated.

## 2. Active view never rebuilt on a migration-only pass
`update` only rebuilds the active view when registry files drifted (`runInstall` gated on `registryChanges`), and `init`'s Phase 6b rebuild runs *before* `ensureServiceSkills`. So a 2nd-apply / package-current-but-old-layout repo migrated but `.xtrm/skills/active` stayed frozen → consumer never saw the new machinery + umbrella.

**Fix:** `ensureServiceSkills` now calls `rebuildAllRuntimeActiveViews(<root>/.xtrm/skills)` after a migration (`migratedPacks.length > 0`) — best-effort, idempotent atomic swap — so **both** init and update reflect the new layout.

## Validation
- `test_layout_migrator_packjson.py` (Python): PACK.json synced / idempotent / no-PACK.json no-op.
- New end-to-end case in `service-skills-ensure.test.ts`: runs the **real migrator** and asserts PACK.json is synced *and* the umbrella appears as a symlink in the rebuilt active view.
- Full Python (59) + ensure/skills-migration/skills-runtime-sync/init/update suites green; registry↔pack parity 330/330.
- 3 pre-existing `pi-runtime` global-package test failures are environmental (verified identical on clean main), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)