### PR TITLE
release: v0.8.5 — service-skills migration active-view fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.8.5] — 2026-06-03
+
+Service-skills migration now *sticks* in a consumer. Repos migrated to the v2 umbrella layout on 0.8.2–0.8.4 could end up without the `service-skills` skill in their active view; this release heals them on the next `xt update --apply`. Publish root `xtrm-tools` from this release commit/tag.
+
+### `xtrm-tools` v0.8.5 — 2026-06-03
+
+#### Fixed
+
+- **`layout_migrator` syncs `PACK.json` after migration.** Moving per-service dirs into `service-skills/services/` and generating the `<repo>-services` umbrella left `PACK.json` listing the now-nested services and omitting the umbrella → `PACK_METADATA_MISMATCH`, which blocked the active-view rebuild invariant. `PACK.json` `skills[]` is now recomputed from the filesystem (direct-child dirs containing `SKILL.md`) — umbrella in, ghost services out, regular skills kept; idempotent. (xtrm-x8b5g, #284)
+- **Active view is rebuilt after a migration.** `xt update` only rebuilt the runtime active view when registry files drifted, and `xt init` rebuilds *before* the migration step — so a migration-only pass (2nd apply, or a package-current repo on the old layout) migrated the data but left `.xtrm/skills/active` frozen, and the consumer never saw the new `service-skills` machinery + `<repo>-services` umbrella. `ensureServiceSkills` now forces `rebuildAllRuntimeActiveViews` after a migration (best-effort, idempotent) so both `init` and `update` reflect the new layout. (xtrm-x8b5g, #284)
+
 ## [v0.8.4] — 2026-06-03
 
 Service-skills field-hardening: the v2 drift/sync machinery met real consumer repos (mercury-market-data) and this release fixes the adaptation gaps that surfaced — an unbounded gitnexus fan-out that could OOM the host, a worktree-blind gitnexus label that silenced the librarian's semantic tiering, a registration path that faked `last_sync` and masked drift, a layout migration that left dead `.claude/skills` refs, and territory globs that quietly swept gitignored build trees. Reference docs are also reconciled to the consolidated v2 skill. Publish root `xtrm-tools` from this release commit/tag.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xtrm-cli",
   "private": true,
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "main": "./dist/index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xtrm-tools",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtrm-tools",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "workspaces": [
         "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtrm-tools",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "license": "MIT",
   "type": "module",

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Cuts **v0.8.5**. Version bumped 0.8.4 → 0.8.5; CHANGELOG promoted. No `cli/src` changes beyond what's already on main — docs + version only.

Ships #284 (xtrm-x8b5g): `layout_migrator` syncs PACK.json + `ensureServiceSkills` rebuilds the active view after migration. Heals mercury consumers migrated on 0.8.2–0.8.4 (darth-feedor/treasury-cb/market-data) on their next `xt update --apply`.

After merge: tag the merge commit, `gh release create v0.8.5` → publish.yml, then propagate (`npm i -g xtrm-tools@latest` + `xt update --apply --root ~/projects/mercury`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)