### PR TITLE
session report: 2026-06-03 service-skills field-hardening (0.8.3→0.8.5)

### DIFF
--- a/.xtrm/reports/2026-06-03-744db777.md
+++ b/.xtrm/reports/2026-06-03-744db777.md
@@ -1,0 +1,110 @@
+---
+session_date: 2026-06-03
+branch: main
+commits: 6
+issues_closed: 7
+issues_filed: 2
+specialist_dispatches: 0
+models_used: []
+handoff_bead: xtrm-drdg6
+---
+
+# Session Report — 2026-06-03
+
+## Summary
+
+Service-skills field-hardening campaign, end-to-end: took the v2 drift/sync machinery from "works in theory" to "verified healed in the field," cut two patch releases, and propagated both fleet-wide. Closed seven beads across six merged PRs. The work began as follow-ups discovered reviewing the xtrm-08i0b OOM fix (PR #280, merged this session): **xtrm-vvhfs** (gitnexus `--repo` resolved the worktree basename, not the indexed main-worktree label — silently muted the librarian's semantic tiering, since it *always* runs in a worktree), **xtrm-008tr** (registration faked `last_sync` with no `last_sync_ref`, and `scan_drift` *skipped* never-synced services — so bulk cataloguing masked all drift), and **xtrm-8ike5** (the layout migrator moved SKILL.md bodies verbatim, leaving dead `.claude/skills/<old>` refs) shipped as PR #281. **xtrm-br179** added a `validate-territories` lint surfacing territory globs that sweep gitignored build trees (PR #282) — verified live on market-data (2 globs, 107 `.pyc`). Cut **v0.8.4** (PR #283) and propagated. Then **xtrm-x8b5g** (PR #284): the migrator never updated `PACK.json` (→ `PACK_METADATA_MISMATCH` blocking the active-view rebuild) and a migration-only `xt update`/`xt init` pass never rebuilt the active view — so migrated consumers (darth-feedor, treasury-cb, market-data) had the new `service-skills` skill in `default/` but absent from `active/`. Cut **v0.8.5** (PR #285) and propagated; **verified all three previously-broken repos are now healed** (clean PACK.json + `<repo>-services` umbrella materialized in the active view). On the design side: confirmed forensic telemetry v1 is already implemented+merged in specialists (`forensic-events.ts` + `prometheus-projection.ts`), corrected my earlier mis-statement; clarified the service-skills specialist model (one librarian `service-skills-sync` today; "bookkeeper" = the deterministic machinery, not a second LLM; the real split worth making is adopt-vs-reconcile). A vault coordination board was drafted and then **removed at operator request** (it was a 4th tracker = more confusion, not less). Design thread (xtrm-24gjf) paused per operator.
+
+## Issues Closed (7)
+
+### Service-skills machinery bugs (field-hardening)
+| ID | Title | Wave | Close context |
+|----|-------|------|---------------|
+| xtrm-vvhfs | gitnexus `--repo` resolved worktree basename → librarian got no gitnexus | direct (PR #281) | `_gitnexus_repo_name` now resolves the indexed label via `git rev-parse --git-common-dir` (main worktree); also fixed a second hardcoded `Path(project_root).name` in `scan_drift`. Test: `test_gitnexus_repo_name.py`. |
+| xtrm-008tr | registration faked last_sync, masking all drift | direct (PR #281) | `register_service` no longer stamps `last_sync` (catalog ≠ verified-sync); `scan_drift` surfaces never-synced services as drift instead of skipping. Essential pair. Test: `test_catalog_vs_synced.py`. |
+| xtrm-8ike5 | migrator left stale `.claude/skills/<old>` body refs | direct (PR #281) | `_rewrite_claude_refs` rewrites in-body refs (alias = service-id or registry `container`) to the new `.xtrm/.../services/<id>` dir; unmapped left + reported. Test: `test_layout_migrator_refs.py`. |
+| xtrm-br179 | territory globs match filesystem not git | direct (PR #282) | Core already neutralized by #280's git-tracked filter; added `validate-territories` lint + `scan_drift` stderr advisory. Verified live on market-data. Test: `test_territory_validation.py`. |
+| xtrm-x8b5g | migrator must update PACK.json + rebuild active view | direct (PR #284) | `_sync_pack_json` recomputes `skills[]` from filesystem (umbrella in, ghost services out); `ensureServiceSkills` forces `rebuildAllRuntimeActiveViews` after migration. Tests: `test_layout_migrator_packjson.py` + extended `service-skills-ensure.test.ts` (end-to-end via real migrator). |
+
+### Releases (cut + published + propagated)
+| ID | Title | Close context |
+|----|-------|---------------|
+| xtrm-r53mv | Release v0.8.4 — service-skills field-hardening | Shipped #278/#280/#281/#282. Published npm `latest`=0.8.4, fleet propagated; verified markers across 12 repos. |
+| xtrm-y51cb | Release v0.8.5 — migration active-view fix | Shipped #284. Published `latest`=0.8.5, fleet propagated; verified the three migrated repos healed. |
+
+(PR #280 / xtrm-08i0b was authored in the prior session and **merged** this session as the foundation these follow-ups build on.)
+
+## Issues Filed (2)
+
+| ID | P | Type | Title | Why |
+|----|---|------|-------|-----|
+| xtrm-n74m8 | P2 | chore | Remove stale pre-v2 service-skills trinity lingering in consumers | Verifying the 0.8.5 propagation revealed every consumer's active view still carries the 4 old trinity skills (`creating-/scoping-/updating-/using-service-skills`) consolidated away in v2 (xtrm-b86y5) but never removed — `xt update` copies new files but never prunes files dropped from the registry. Vestigial dead weight + drift from the single-skill model. Filed `discovered-from:xtrm-x8b5g` so the prune-gap is tracked, not rediscovered. |
+| xtrm-drdg6 | P1 | task | Session handoff 2026-06-03 | SSOT handoff pointer into the board (this report). |
+
+## Problems Encountered
+
+| Problem | Root Cause | Resolution |
+|---------|-----------|------------|
+| OOM-test failed after the vvhfs rewrite (`FakeProc not a context manager`) | `_gitnexus_repo_name` now shells out via `subprocess.run` (which uses `with Popen`), colliding with the test's `Popen` monkeypatch | Isolated that test by stubbing `_gitnexus_repo_name`; its intent (run_gitnexus_json flag/-repo wiring) preserved. |
+| x8b5g active-view test asserted `market-data-services` symlink — ENOENT | The umbrella runtime name derives from the **repo basename** (random tmp dir in the test), not the pack name | Read the generated umbrella name from frontmatter + assert the deterministic regular-skill symlink instead. |
+| Full CLI suite: 3 failures in `pi-runtime*` | Environmental — this machine has the global Pi packages installed, so the "needs install" planner returns `[]` not `[8]` | Confirmed identical failures on clean main (stashed); unrelated to the change. CI (fresh tree) passes them. |
+| `bd remember` mangled `make -C` fragment | Backticks in a double-quoted bash string triggered command substitution (`` `make -C` `` executed) | Re-saved the 8ike5 memory with single quotes. Pattern noted: never put backticks in `bd remember` args. |
+| Drafted vault `board.md` rejected by operator | Added a 4th tracker note to an already-mature vault (MOC + ordine + temp_roadmap) — more confusion, not less | Removed `board.md`; reaffirmed the existing 3-layer model (MOC=map, ordine=narrative, beads=work). |
+
+## Code Changes
+
+Six merged PRs (#280 merged + #281–#285 authored). All in the service-skills surface; no `cli/src` logic change in the two release PRs (version + CHANGELOG only).
+
+- **Python machinery** (`skills/service-skills/scripts/`, mirrored to `.xtrm/skills/default/...`):
+  - `bootstrap.py` — `_gitnexus_repo_name` git-common-dir resolution (vvhfs); `register_service` dropped `last_sync` + removed now-unused `datetime` import (008tr).
+  - `drift_detector.py` — second repo-name site fixed (vvhfs); `scan_drift` never-synced surfacing (008tr); `territory_gitignore_report` + `validate-territories` CLI + drop-advisory (br179); imported `_gitnexus_repo_name`.
+  - `layout_migrator.py` — `_rewrite_claude_refs` body-ref rewrite + alias map (8ike5); `_sync_pack_json` PACK.json sync after migration (x8b5g).
+- **TypeScript CLI**: `cli/src/core/service-skills-ensure.ts` — forces `rebuildAllRuntimeActiveViews` after a migration so init+update reflect the new layout (x8b5g). `cli/dist` rebuilt from canonical root.
+- **Tests** (5 new + 1 extended): `test_gitnexus_repo_name.py`, `test_catalog_vs_synced.py`, `test_layout_migrator_refs.py`, `test_territory_validation.py`, `test_layout_migrator_packjson.py`; extended `cli/test/service-skills-ensure.test.ts` (end-to-end PACK.json + active-view assertion via the real migrator). Updated `test_bootstrap_registry_path.py` mock.
+- **Release**: CHANGELOG v0.8.4 + v0.8.5 sections; version bumps (root/cli/pi-extensions package.json).
+
+## Documentation Updates
+
+- CHANGELOG.md: v0.8.4 (field-hardening) + v0.8.5 (migration active-view fix) sections — owned by the release flow (Step 6 satisfied; no separate `[Unreleased]` work needed).
+- 5 `bd remember` insights saved (see Memories Saved).
+- Vault: drafted then removed `~/second-mind/1-projects/xtrm/board.md` per operator; no net vault change.
+- Service-skills SKILL.md docs were **not** edited this session — only scripts/machinery + tests. No `/updating-service-skills` run needed (the changes are to the machinery itself, not to per-service skill content).
+
+## Open Issues with Context
+
+### Ready for next session
+| ID | P | Title | Context / Suggestions |
+|----|---|-------|----------------------|
+| xtrm-24gjf | P1 | Design: specialists consuming service-skills | **The paused design thread.** Precondition now cleared (x8b5g — migration actually sticks, so a clean migrated repo is testable). Decision bead with candidate mechanisms already enumerated (skills.paths / pre-script injector / specialists extension / per-role flag). Decide: which roles get context (editors yes, read-only/meta probably no), granularity (umbrella vs territory-matched vs none), gating (registry-only). Folds in the adopt-vs-reconcile librarian split. Reuse `bootstrap.find_service_for_path` / `get_umbrella_dir`. |
+| xtrm-n74m8 | P2 | Remove stale pre-v2 trinity in consumers | Discovered this session, fleet-wide. First step: determine if the 4 trinity skills are still in the package registry (re-installed each update) or orphaned in consumer `default/`. Check `.xtrm/registry.json` + `docs/skills-ownership.json`. Likely needs a registry-driven prune step (install copies new, never removes dropped). `discovered-from:xtrm-x8b5g`. |
+| xtrm-pan6c | P1 | Roll out bd auto-stage patch across ~/dev and ~/projects | Standing P1; partially advanced by today's `xt update --apply` runs (which call `ensureBdAutoStagePatch`). Verify coverage across the non-mercury repos. |
+
+### Backlog (not touched this session — title-level context)
+| ID | P | Title | Note |
+|----|---|-------|------|
+| xtrm-ai9xl | P1 | Epic: xtrm-native spec framework for beads/specialists | Larger epic; unrelated to today's service-skills thread. |
+| xtrm-9xg2.2/.3/.4/.5 | P2 | flat active-layout CI guards + doctor/update/init alignment | Test/CI hardening cluster for the flat active view (relevant background to x8b5g/n74m8). |
+| xtrm-4ud5 / xtrm-o0eu | P2 | Package rename/deprecation (@jaggerxtrm/xtrm) | Release-stream migration; independent. |
+| xtrm-yb0u | P2 | Dolt server crash / journal corruption (friction) | Note: this session's `sp ps` flagged 4 dolt servers + 22 orphans machine-wide — related friction; not addressed. |
+| xtrm-yep0f | P3 | Tighten gitnexus compare parser + per-service base_ref | In `drift_detector` — natural follow-up to this session's drift work. |
+| xtrm-kye9 | P3 | Managed GitNexus post-commit analyze hook | Keeps the index fresh; relevant to drift tiering reliability. |
+| xtrm-drkk / xtrm-wwa3 / xtrm-qylnf / xtrm-cfidk / xtrm-eg5nb | P2–P3 | triage skill / bd surface docs / workboard ext / xtrm-ui rows / gate message | Unrelated backlog. |
+
+## Memories Saved
+
+| Key | Content |
+|-----|---------|
+| `service-skills-gitnexus-repo-resolution-must-use-the` | gitnexus `--repo` must resolve the main-worktree basename via `git --git-common-dir`; two sites; librarian always runs in a worktree (vvhfs). |
+| `service-skills-registration-is-cataloguing-never-a-verified` | registration ≠ verified sync; never-synced services must be surfaced, not skipped — the essential pair (008tr). |
+| `service-skills-layout-migrator-now-rewrites-legacy-in` | migrator rewrites in-body `.claude/skills/<alias>` refs via registry alias map (service-id or `container`); container-named refs only rewrite if the registry carries `container` (8ike5). |
+| `service-skills-drift-detector-got-a-validate-territories` | `validate-territories` lint; the verification method for this class = glob-vs-`git ls-files` delta on a real repo (br179). |
+| `service-skills-migration-pack-json-sync-forced-active` | PACK.json sync rule (direct-child dirs with SKILL.md = dir-name identity) + the active-view rebuild gating gap (update gated on drift; init Phase 6b runs before migration); umbrella runtime name derives from repo basename (x8b5g). |
+
+The release beads (r53mv, y51cb) were acked "nothing novel" — routine releases captured in CHANGELOG + the per-bug memories.
+
+## Suggested Next Priority
+
+1. **xtrm-24gjf** (P1, design) — the paused thread, now unblocked by x8b5g. Decide how specialists consume service-skills + whether the librarian splits into adopt/reconcile. Highest leverage: it defines the specialist side of the mature service-skills loop.
+2. **xtrm-n74m8** (P2) — clean the stale-trinity drift fleet-wide; it's the visible symptom of a real prune-gap in `xt update`/install that will recur for any consolidated skill. Quick root-cause + a registry-driven prune.
+3. **xtrm-pan6c** (P1) — finish the bd auto-stage rollout to the non-mercury repos; partially advanced today.
+4. **Release cadence** — #284 (x8b5g) shipped as 0.8.5; nothing pending. Next release only when 24gjf/n74m8 land observable changes.


### PR DESCRIPTION
Handoff report for the 2026-06-03 session. Closed 7 beads across 6 PRs (#280–#285), shipped v0.8.4 + v0.8.5, propagated fleet-wide, verified the migrated repos healed. Handoff bead: `xtrm-drdg6`. Design (`xtrm-24gjf`) paused; stale-trinity drift filed as `xtrm-n74m8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)