### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.9.0] — 2026-06-07
+
 ### Added
 
 - **`agent-docs-maintainer` skill** — compact `CLAUDE.md`/`AGENTS.md` audit and template guidance for keeping agent docs as routing docs, preserving beads, specialists, GitNexus, task planning, and canonical service-skills requirements without embedding full CLI manuals. (xtrm-ot9cy, xtrm-v8oa1)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xtrm-cli",
   "private": true,
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "main": "./dist/index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xtrm-tools",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtrm-tools",
-      "version": "0.8.5",
+      "version": "0.9.0",
       "license": "MIT",
       "workspaces": [
         "cli",
@@ -31,7 +31,7 @@
     },
     "cli": {
       "name": "xtrm-cli",
-      "version": "0.8.5",
+      "version": "0.9.0",
       "dependencies": {
         "boxen": "^8.0.1",
         "cli-table3": "^0.6.5",
@@ -4155,7 +4155,7 @@
     },
     "packages/pi-extensions": {
       "name": "@jaggerxtrm/pi-extensions",
-      "version": "0.8.5",
+      "version": "0.9.0",
       "license": "MIT"
     },
     "packages/pi-extensions/extensions/core": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtrm-tools",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "license": "MIT",
   "type": "module",

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- promote CHANGELOG [Unreleased] to v0.9.0
- bump root/workspace package versions to 0.9.0
- refresh root package-lock workspace versions

## Validation
- npm run build
- npm run typecheck
- npm test
- npm run check:registry-pack-parity
- npm run check:payload-hygiene
- npm run check:skills-symlinks
- npm run check:package
- npm run check:layout-guards
- npm run check:gitnexus-no-counter
- gitnexus_detect_changes (staged)
