### PR TITLE
feat(skills): add sre-triage default skill (devops-sre primitive)

### DIFF
--- a/skills/sre-triage/SKILL.md
+++ b/skills/sre-triage/SKILL.md
@@ -1,0 +1,476 @@
+---
+name: sre-triage
+description: >-
+  Cross-stack health verification with runtime-inferred routing. Queries
+  Prometheus + Grafana live via the `mcpq` CLI (sidecar registry lives in
+  `.mcpq.json` — `mcpq servers` lists them) to enumerate firing alerts, down
+  containers, and stale freshness feeds; matches each finding to a registered
+  service skill by listing the service-skills directory and matching container
+  prefix / `territory:` globs; emits a triage report and loads expert personas
+  for affected services. Also handles retroactive investigation of past alerts —
+  use when the user reports receiving a Telegram alert hours ago that has since
+  resolved. Invoke via /sre-triage for proactive checks, active incidents, or
+  past-alert triage. Falls back to per-repo SERVICE_HEALTH.md files only when
+  the mcpq sidecars are unreachable.
+allowed-tools: Bash(mcpq *), Bash(python3 *), Bash(docker *), Bash(ls *), Read
+---
+
+# SRE Triage ( /sre-triage )
+
+Verify every stack's health state **without touching the codebase**. If issues are
+found, route immediately to the correct expert skill(s) by **listing the service-skills
+directory and matching the offending container/alert label against service names or
+their `territory:` globs** — no frozen mapping tables to maintain.
+
+This skill is the first materialization of the `devops-sre` / monitor role from the
+xtrm devops canon (`~/dev/xtrm/docs/devops/devops-system.md` §5.1). The future
+`sre.specialist.json` inherits this body as its standing prompt.
+
+> **Examples below use a generic `example-project` placeholder name** — concrete
+> alert/container/feed names like `svc-data-feed`, `ExampleProjectFeedStarved`,
+> `example-feeds`, the `example_project_` tool prefix, and any
+> `~/projects/example-project/...` path are **illustrative**, not literal. In a
+> real project, replace them with your own conventions (discover the actual
+> mcpq tool prefix via `mcpq prometheus list-tools`). The methodology, the
+> `mcpq` invocation pattern, the universal PromQL probes (`up == 0`,
+> `ALERTS{alertstate="firing"}`, `node_*`, `container_*`), and the status taxonomy
+> are universal and need no replacement.
+
+## Trigger
+
+User types `/sre-triage` — or when any incident, alert, or "something is wrong" phrase
+appears in the conversation without a specific service being named yet.
+
+`/health` remains a colloquial alias during the deprecation window of the old
+`checking-stack-health` skill.
+
+---
+
+## Execution Flow
+
+### Step 1 — Live Health Probe via mcpq
+
+Run these three queries **immediately**, before any reasoning or file reads.
+They are the canonical live signals — Prometheus is the SSOT, the markdown
+files are a 2-minute cache.
+
+```bash
+# 1a. Which containers are down right now?
+mcpq prometheus call example_project_execute_query --arg query='up == 0' --json
+
+# 1b. Which alerts are firing right now?
+mcpq prometheus call example_project_execute_query --arg query='ALERTS{alertstate="firing"}' --json
+
+# 1c. Which fast/live freshness feeds are stale beyond their 10m SLO?
+# Cadence-aware: this intentionally checks only feeds expected inside 600s.
+# Do not apply the 600s SLO to daily/hourly feeds.
+mcpq prometheus call example_project_execute_query \
+  --arg query='time() - example_project_freshness_last_success_unix_seconds{feed_id=~"svc-data-feed|svc-snapshot-feed|example-multi-source-container"} > 600' --json
+```
+
+Read each result's `structuredContent.result` array. An empty array on all three
+means the fast-path health probe is clean. Otherwise, for each entry harvest the
+labels (`job`, `instance`, `alertname`, `severity`, `feed_id`, `data_class`) and
+route via the mapping tables further down this skill (Container → Service,
+Alert → Service).
+
+Freshness is cadence-aware: the 600s check is only for fast/live feeds whose
+operator SLO is minutes (`svc-data-feed`, `svc-snapshot-feed`,
+`example-multi-source-container`). Daily/hourly feeds can be inspected with
+`sort_desc(time() - example_project_freshness_last_success_unix_seconds)` for context,
+but do not mark the stack degraded solely because a daily or hourly feed is
+older than 600s. Use feed-specific alerts/runbooks for those cadences.
+
+Container → repo attribution comes from the regexes in `infra/scripts/service-map.json`
+(e.g. `svc-*` → market-data, `feed-*` → example-feeds, `example_econ_*` → example-economic,
+`treasury-*` / `example-fiscal-*` → example-treasury, `infra-*` → infra).
+
+**Fallback when mcpq is unreachable** — if both `mcpq` calls return errors
+mentioning `docker exec ... exited` or `connection refused`, the sidecars are
+down. Fall back to the file-cache path:
+
+```bash
+python3 ~/projects/example-project/infra/scripts/health_check.py
+```
+
+…and read the per-repo `SERVICE_HEALTH.md` files if even that fails. The cron
+that produces them is documented in `~/projects/example-project/infra/HEALTH_SYSTEM.md`.
+
+---
+
+### Step 1b — Resource Metrics Check
+
+Run alongside Step 1 whenever the user mentions high memory, high CPU, slow
+response, or when investigating `ContainerHighMemory` / `DiskUsageHigh` /
+`DiskUsageCritical`. Same pattern — live PromQL via mcpq:
+
+```bash
+# Host CPU% (1m avg)
+mcpq prometheus call example_project_execute_query \
+  --arg query='100 * (1 - avg(rate(node_cpu_seconds_total{mode="idle"}[1m])))' --json
+
+# Host memory used %
+mcpq prometheus call example_project_execute_query \
+  --arg query='100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)' --json
+
+# Host disk used % at /
+mcpq prometheus call example_project_execute_query \
+  --arg query='100 * (1 - node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"})' --json
+
+# Top-10 containers by 5m CPU
+mcpq prometheus call example_project_execute_query \
+  --arg query='topk(10, rate(container_cpu_usage_seconds_total{name!=""}[5m]) * 100)' --json
+
+# Top-10 containers by memory-vs-limit %
+mcpq prometheus call example_project_execute_query \
+  --arg query='topk(10, 100 * container_memory_working_set_bytes{name!=""} / container_spec_memory_limit_bytes{name!=""})' --json
+```
+
+Warn when host CPU > 80%, host memory > 85%, any container > 80% CPU, or any
+container > 85% memory-vs-limit. Use the offending container name to load the
+right service skill before diagnosing further.
+
+---
+
+### Step 2 — Classify Overall State
+
+Classify from the Step 1 query results:
+
+| Signal from Step 1 queries                                              | Overall status | Action                                          |
+|-------------------------------------------------------------------------|----------------|-------------------------------------------------|
+| All three queries return empty `result` arrays                          | `HEALTHY`      | Report clean — but see Step 2b for past alerts  |
+| `ALERTS` returns rows with `severity="warning"`, or a fast/live freshness feed breaches its cadence-aware 600s SLO | `DEGRADED` | Continue to Step 3 (warning track) |
+| `up == 0` returns rows, or `ALERTS` has `severity="critical"`           | `CRITICAL`     | Continue to Step 3 (incident track)             |
+| mcpq returned an error (sidecars unreachable) AND fallback also failed  | `UNKNOWN`      | Surface explicitly; load `grafana-mcp` + `prometheus-mcp` skills and fix the query surface before continuing |
+
+---
+
+### Step 2b — Retroactive Investigation (user reports a past alert)
+
+When the current health check is clean but the user mentions receiving a Telegram alert
+N hours ago, **do not run ad-hoc queries**. Use the dedicated scripts:
+
+Set the skill directory once, then use it throughout:
+```bash
+SKILL_DIR="$CLAUDE_PROJECT_DIR/.xtrm/skills/default/sre-triage"
+```
+
+**Phase A — Find what fired:**
+
+Derive `--hours` from what the user said (e.g. "3 hours ago" → `--hours 3`). Default to 6 if unspecified.
+```bash
+python3 $SKILL_DIR/scripts/alert_history.py --hours <N>
+```
+
+Options:
+```bash
+python3 $SKILL_DIR/scripts/alert_history.py --alert TraefikHighLatency  # filter to one alert
+python3 $SKILL_DIR/scripts/alert_history.py --json                       # machine-readable
+```
+
+Exit codes: `0` = nothing fired, `1` = at least one alert fired, `2` = Prometheus unreachable.
+
+**Phase B — Diagnose each alert that fired:**
+```bash
+python3 $SKILL_DIR/scripts/alert_investigator.py --alert <alertname> --hours <N>
+```
+
+The investigator:
+- Fetches the rule's PromQL expression and threshold from Prometheus
+- Re-evaluates the expression over the exact firing window
+- Reports peak metric values and which label dimensions breached the threshold
+- Applies known false-alert heuristics (WebSocket lifetime, market data feed gaps, etc.)
+- Emits a structured assessment and fix hint
+
+**Only fall back to raw PromQL or docker commands if both scripts fail** (exit code 2).
+
+After diagnosis, report the finding and proposed fix directly — no XML scope block needed
+for resolved alerts unless the root cause requires a code or config change.
+
+---
+
+### Step 3 — Emit XML Health Scope Block
+
+Emit this block **before loading any skills or running any docker commands**:
+
+```xml
+<health_scope>
+  <generated><!-- timestamp from script output --></generated>
+  <overall_status>DEGRADED|CRITICAL</overall_status>
+
+  <stacks>
+    <stack id="example-feeds" status="DEGRADED">
+      <alerts>
+        <alert severity="CRITICAL" name="ContainerCrashLoop" container="example-summarizer-container">
+          example-summarizer-container has restarted 3x in 1h
+        </alert>
+      </alerts>
+      <services_affected>
+        <service id="example-summarizer-skill" confidence="high">
+          <reason>example-summarizer-container container crash-looping (maps to example-summarizer-skill)</reason>
+          <skill>.claude/skills/example-summarizer-skill/SKILL.md</skill>
+          <load>now</load>
+        </service>
+      </services_affected>
+    </stack>
+  </stacks>
+
+  <workflow>
+    <phase order="1" name="load-skills">
+      Read every SKILL.md listed above. Adopt the expert persona, failure modes
+      table, and diagnostic scripts from each. Do not run docker commands yet.
+    </phase>
+    <phase order="2" name="diagnose">
+      For each affected service, run its health_probe.py and log_hunter.py scripts
+      before any ad-hoc docker commands. Use the failure modes table from the skill
+      to identify the root cause.
+    </phase>
+    <phase order="3" name="fix">
+      Apply targeted fix per service. Follow the skill's operational runbook.
+    </phase>
+    <phase order="4" name="verify">
+      Re-run health_check.py to confirm all stacks return to HEALTHY.
+      If a fix involved code logic: write a regression test alongside the fix.
+    </phase>
+  </workflow>
+</health_scope>
+```
+
+Adapt the `<services_affected>` block to what the script actually reported.
+
+---
+
+### Step 4 — Load Skills for Affected Services
+
+For every `<service>` with `<load>now</load>`, read the skill file immediately:
+
+```
+Read: .claude/skills/<service-id>/SKILL.md
+```
+
+**Do not proceed to diagnosis until all affected skills are loaded.**
+Adopt the failure modes table, diagnostic scripts, and runbook from each skill.
+
+If the affected service has no registered skill:
+1. Report: `"No registered skill for <service-id>."`
+2. Continue with general expert mode using docker logs and AGENT_MONITORING.md guidance.
+3. Offer: `"I can create a skill — use /creating-service-skills."`
+
+---
+
+### Step 5 — Diagnose Per Service
+
+For each affected service (in severity order — CRITICAL first):
+
+1. **Check the skill's failure modes table** — match the alert name or symptom.
+2. **Run the skill's diagnostic scripts** in this order:
+   - `health_probe.py` — current live state
+   - `log_hunter.py` — recent error patterns
+3. **Only then** run raw docker commands if scripts are insufficient:
+   ```bash
+   docker logs <container-name> --tail 100
+   docker compose -f ~/projects/example-project/<stack>/docker-compose.yml ps
+   ```
+
+---
+
+### Step 6 — Fix and Verify
+
+Apply the fix identified in Step 5. Then re-run the Step 1 queries:
+
+```bash
+mcpq prometheus call example_project_execute_query --arg query='up == 0' --json
+mcpq prometheus call example_project_execute_query --arg query='ALERTS{alertstate="firing"}' --json
+mcpq prometheus call example_project_execute_query \
+  --arg query='time() - example_project_freshness_last_success_unix_seconds{feed_id=~"svc-data-feed|svc-snapshot-feed|example-multi-source-container"} > 600' --json
+```
+
+All three `structuredContent.result` arrays must be empty (or no longer include
+the previously-failing entries) before closing the incident. For broad cached
+verification, run `python3 ~/projects/example-project/infra/scripts/health_check.py`;
+do not treat daily/hourly freshness rows as failures unless their feed-specific
+SLO or alert says they are late.
+
+**Regression test rule:** If the root cause was a code logic bug, write a test
+(see the Regression Test section below). If it was operational, extend or add a
+check in the service's `health_probe.py`.
+
+---
+
+## Container → Service Routing (runtime inference)
+
+**Do not consult a frozen table.** Derive the mapping at the moment of incident, by
+listing the service-skills directory tree and matching the offending container's label
+against the service-id or its `territory:` glob in the registry.
+
+```bash
+# 1. Enumerate registered services (across all packs in this repo)
+ls .xtrm/skills/user/packs/*/service-skills/services/
+
+# 2. For a container name like `infra-traefik`, the service-id is the
+#    longest matching prefix or exact match against a directory name above.
+#    (For Example Project today: `infra-*` → infra pack, `svc-*` → market-data,
+#    `feed-*` → example-feeds, `example_econ_*` → example-economic, `treasury-*` →
+#    example-treasury, `example_project_website*` → website. Cross-repo containers' service
+#    skills live in those sibling repos — `cd ~/projects/example-project/<repo>` then
+#    repeat the `ls`.)
+
+# 3. Read the matched skill to adopt expert persona:
+Read: .xtrm/skills/user/packs/<pack>/service-skills/services/<service-id>/SKILL.md
+
+# 4. If no match: report the container as `unrouted`. Do not invent a skill path.
+#    Offer to scaffold via /creating-service-skills.
+```
+
+The `service-registry.json` at each pack's root provides the authoritative
+`territory:` globs and `triggers:` keywords if the directory-listing heuristic
+needs disambiguation. Always prefer the registry over hand-matching when in
+doubt — it's the single source of truth.
+
+The two `-mcp` sidecars (`example-grafana-mcp`, `example-prometheus-mcp`) are
+read-only query surfaces. The mcpq wiring smoke is whatever the project ships —
+in example-project, it's `make verify-mcpq` from the infra repo root.
+
+---
+
+## Alert → Service Mapping Reference
+
+When an alert fires, use this table to identify the affected service and the
+Grafana dashboard to open for visual investigation.
+
+| Alert name                       | Severity | Likely service / container           | Dashboard to open                              |
+|----------------------------------|----------|--------------------------------------|------------------------------------------------|
+| `ContainerCrashLoop`             | CRITICAL | match `name` label in alert detail   | Containers — Resource Metrics (cAdvisor)       |
+| `ContainerHighMemory`            | WARNING  | match `name` label; run `--metrics`  | Containers — Resource Metrics (cAdvisor)       |
+| `ExampleProjectFeedStarved`   | CRITICAL | `svc-data-feed`                      | Market Data — Feed Health & Ingestion Pipeline |
+| `ExampleProjectSymbolStale`          | WARNING  | `svc-data-feed`                      | Market Data — Feed Health & Ingestion Pipeline |
+| `PostgresDown`                   | CRITICAL | `serving-example-api` or svc/treasury| PostgreSQL — Database Stats                    |
+| `PostgresTooManyConnections`     | WARNING  | `serving-example-api` or svc/treasury| PostgreSQL — Database Stats                    |
+| `RedisDown`                      | CRITICAL | `serving-example-api`, `collecting-events` | Redis — Cache Metrics               |
+| `RedisHighMemory`                | WARNING  | `serving-example-api`, `collecting-events` | Redis — Cache Metrics               |
+| `HighErrorRate`                  | WARNING  | `serving-example-api`                | Example Project — API & MCP Traffic (Traefik)          |
+| `TraefikHighLatency`             | WARNING  | `traefik`                            | Traefik — Routing & Proxy Metrics              |
+| `DiskUsageHigh`                  | WARNING  | all stacks (shared host)             | VPS — Host Metrics (Node Exporter)             |
+| `DiskUsageCritical`              | CRITICAL | all stacks — check Loki + volumes    | VPS — Node Exporter Full (Deep Dive)           |
+| `ServiceDown`                    | CRITICAL | match `instance` label in alert      | Containers — Resource Metrics (cAdvisor)       |
+
+### Market data alert context
+
+`ExampleProjectFeedStarved` and `ExampleProjectSymbolStale` are **suppressed outside
+Example Exchange trading hours** via `example_exchange_session_closed`. Before investigating:
+
+```bash
+# Check if market is open — 0 = open, 1 = closed
+curl -s "http://<prometheus-ip>:9090/api/v1/query?query=example_exchange_session_closed" \
+  | python3 -c "import json,sys; r=json.load(sys.stdin)['data']['result']; print('session closed:', r[0]['value'][1])"
+```
+
+If session is closed (`1`), the alert is expected noise — no action needed.
+If session is open (`0`) and the alert fires, open the Market Data dashboard and check:
+1. **Fresh symbol count** — should be ≥ 5 during active session
+2. **Per-symbol staleness table** — identify which symbols/asset classes are stale
+3. **Container restarts** — check if `svc-data-feed` or `svc-tick-ingestor-rust` crash-looped
+
+---
+
+## Grafana Dashboard Reference
+
+All dashboards are provisioned at `~/projects/example-project/infra/grafana/dashboards/`.
+Every alert rule maps to at least one dashboard.
+
+| Dashboard                                    | Covers                                  | Alert rules wired             |
+|----------------------------------------------|-----------------------------------------|-------------------------------|
+| Containers — Resource Metrics (cAdvisor)     | CPU, mem, network, disk per container   | `ContainerCrashLoop`, `ContainerHighMemory`, `ServiceDown` |
+| Market Data — Feed Health & Ingestion Pipeline | Symbol freshness, svc containers, TimescaleDB | `ExampleProjectFeedStarved`, `ExampleProjectSymbolStale` |
+| Example Project — API & MCP Traffic (Traefik)        | HTTP error rate, latency by service     | `HighErrorRate`, `TraefikHighLatency` |
+| Example Project Website — Nginx & Container          | nginx stats + website container         | `ServiceDown`, `ContainerCrashLoop` |
+| VPS — Host Metrics (Node Exporter)           | CPU, memory, disk, network (host)       | `DiskUsageHigh`, `DiskUsageCritical` |
+| VPS — Node Exporter Full (Deep Dive)         | 41-panel deep-dive host metrics         | `DiskUsageHigh`, `DiskUsageCritical` |
+| PostgreSQL — Database Stats                  | pg_up, connections, query stats         | `PostgresDown`, `PostgresTooManyConnections` |
+| Redis — Cache Metrics                        | redis_up, memory, hit rate              | `RedisDown`, `RedisHighMemory` |
+| Traefik — Routing & Proxy Metrics            | Entrypoint-level traffic and latency    | `TraefikHighLatency`, `HighErrorRate` |
+| Logs — Container Stream (Loki)               | All container logs (diagnostic)         | *(diagnosis only — no alert wired)* |
+| Data Pipeline Health — DB Direct             | TimescaleDB + QuestDB direct SQL freshness, ingestion lag, table sizes | *(diagnostic — DB cross-check for ingestion-family alerts)* |
+| Market Data — Direct                         | Direct-from-DB market data views (non-STIR via QuestDB after 2026-03-25 migration) | *(diagnostic — complements freshness alerts on `svc-data-feed`)* |
+
+---
+
+## Health State Interpretation
+
+| Status     | Meaning                                                                                  |
+|------------|------------------------------------------------------------------------------------------|
+| `HEALTHY`  | All three Step 1 fast-path queries returned empty `result` arrays                         |
+| `DEGRADED` | Firing `severity="warning"` alerts, or fast/live freshness feeds past their cadence-aware SLO |
+| `CRITICAL` | `up == 0` rows present, or firing `severity="critical"` alerts                           |
+| `UNKNOWN`  | mcpq sidecars unreachable AND `health_check.py` fallback also failed — query surface itself is down |
+
+When `UNKNOWN`, the priority is restoring the query surface before assessing
+anything else. Load both sidecar skills (`prometheus-mcp`, `grafana-mcp`) for
+their failure-mode tables, then inspect:
+
+```bash
+docker ps --filter name=example-prometheus-mcp --filter name=example-grafana-mcp
+docker logs --tail 50 example-prometheus-mcp
+docker logs --tail 50 example-grafana-mcp
+make verify-mcpq   # canonical smoke for the wiring
+```
+
+If the fallback `SERVICE_HEALTH.md` files are also missing, the file-cache cron
+is what's broken (independent failure mode — does not block live diagnosis once
+mcpq is back up):
+
+```bash
+crontab -l | grep health-report
+make health-report   # one-shot regenerate from infra/
+```
+
+---
+
+## Regression Test Binding
+
+When a fix has been applied for a code logic bug:
+
+```
+Is the bug in application code logic?
+  YES → write pytest/unit test in the service's test suite
+
+  NO  (operational / infra / config issue) →
+        Does the skill's health_probe.py already check this condition?
+          YES → extend the existing check function
+          NO  → add a new check function to health_probe.py
+                OR add a dedicated script to .claude/skills/<service>/scripts/
+```
+
+Name after the failure mode, not the fix:
+
+```python
+def check_summarizer_not_crash_looping():    # ✅
+def check_redis_eviction_not_exhausted():    # ✅
+def test_fix():                              # ❌
+```
+
+If `alert_investigator.py` identifies a **false-alert pattern** that is not yet in
+`FALSE_ALERT_PATTERNS`, add a new entry to the script:
+
+```python
+{
+    "match": lambda labels, expr: <condition on labels + expr string>,
+    "assessment": "FALSE ALERT — <one-line description>",
+    "explanation": "<why it fires spuriously>",
+    "fix": "<what to change in the alert rule>",
+},
+```
+
+---
+
+## Related Skills
+
+- `/scope "task"` — Route any non-health task to the right expert
+- `/using-service-skills` — Passive catalog at session start
+- `/creating-service-skills` — Scaffold new expert skill packages
+- `/updating-service-skills` — Sync skills after implementation drift
+
+## System Documentation
+
+Full architecture, maintenance guide, and Agent Forge migration path:
+`~/projects/example-project/infra/HEALTH_SYSTEM.md`

--- a/skills/sre-triage/scripts/alert_history.py
+++ b/skills/sre-triage/scripts/alert_history.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Retroactive alert history — shows every alert that fired in the past N hours.
+
+Queries the Prometheus TSDB directly. Useful when a user reports receiving a
+Telegram alert that has already resolved and the current health check is clean.
+
+Usage:
+  python3 alert_history.py                          # last 6h, all alerts
+  python3 alert_history.py --hours 12               # last 12h
+  python3 alert_history.py --alert TraefikHighLatency
+  python3 alert_history.py --json
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+
+PROMETHEUS_CONTAINER = "example-prometheus"
+PROMETHEUS_URL = "http://localhost:9090"
+
+# Build an opener that ONLY supports http/https. This makes file://, ftp://, etc.
+# structurally impossible regardless of what value PROMETHEUS_URL takes.
+_HTTP_OPENER = urllib.request.build_opener(
+    urllib.request.HTTPHandler,
+    urllib.request.HTTPSHandler,
+)
+STEP = 60  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Prometheus API
+# ---------------------------------------------------------------------------
+
+
+def prom_get(path: str, params: dict | None = None) -> dict:
+    """Fetch from Prometheus API. Tries direct HTTP, falls back to docker exec."""
+    qs = ("?" + urllib.parse.urlencode(params)) if params else ""
+    url = f"{PROMETHEUS_URL}{path}{qs}"
+
+    try:
+        # http/https only — see _HTTP_OPENER definition above
+        with _HTTP_OPENER.open(url, timeout=10) as r:
+            return json.loads(r.read())
+    except Exception:
+        pass
+
+    # Fallback: exec into the container
+    try:
+        result = subprocess.run(
+            ["docker", "exec", PROMETHEUS_CONTAINER, "wget", "-qO-", url],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return json.loads(result.stdout)
+    except Exception:
+        pass
+
+    raise RuntimeError(f"Cannot reach Prometheus at {url} (tried direct + docker exec)")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def ts_str(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def firing_windows(values: list) -> list[tuple[float, float]]:
+    """Convert raw (timestamp, value) pairs into contiguous firing [start, end] spans."""
+    windows: list[tuple[float, float]] = []
+    start: float | None = None
+    for ts, v in values:
+        ts = float(ts)
+        if v == "1":
+            if start is None:
+                start = ts
+        else:
+            if start is not None:
+                windows.append((start, ts))
+                start = None
+    if start is not None:
+        windows.append((start, float(values[-1][0])))
+    return windows
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def query_history(hours: float, alert_filter: str | None) -> dict:
+    now = time.time()
+    start = now - hours * 3600
+
+    selector = f'ALERTS{{alertname="{alert_filter}"}}' if alert_filter else "ALERTS"
+
+    data = prom_get(
+        "/api/v1/query_range",
+        {
+            "query": selector,
+            "start": int(start),
+            "end": int(now),
+            "step": STEP,
+        },
+    )
+
+    results = data.get("data", {}).get("result", [])
+    by_alert: dict[str, list[dict]] = {}
+
+    for series in results:
+        metric = series.get("metric", {})
+        name = metric.get("alertname", "?")
+        raw_values = series.get("values", [])
+
+        windows = firing_windows(raw_values)
+        if not windows:
+            continue
+
+        labels = {
+            k: v
+            for k, v in metric.items()
+            if k not in ("__name__", "alertstate", "alertname")
+        }
+
+        by_alert.setdefault(name, []).append(
+            {
+                "labels": labels,
+                "windows": windows,
+            }
+        )
+
+    return by_alert
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def print_human(by_alert: dict, hours: float) -> None:
+    now = time.time()
+    start = now - hours * 3600
+
+    if not by_alert:
+        print(f"No alerts fired in the past {hours}h.")
+        return
+
+    print(f"Alerts that fired in the past {hours}h  ({ts_str(start)} → {ts_str(now)})")
+    print("=" * 72)
+
+    for name, instances in sorted(by_alert.items()):
+        total_windows = sum(len(i["windows"]) for i in instances)
+        print(
+            f"\n  {name}  ({len(instances)} dimension(s), {total_windows} firing window(s))"
+        )
+
+        for inst in instances:
+            label_str = "  ".join(f"{k}={v}" for k, v in inst["labels"].items())
+            if label_str:
+                print(f"    [{label_str}]")
+            for w_start, w_end in inst["windows"]:
+                duration_min = max(1, int((w_end - w_start) / 60))
+                print(f"      {ts_str(w_start)} → {ts_str(w_end)}  ({duration_min}min)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Show alert firing history from Prometheus TSDB",
+    )
+    parser.add_argument(
+        "--hours", type=float, default=6, help="Look back N hours (default: 6)"
+    )
+    parser.add_argument("--alert", default=None, help="Filter to a specific alertname")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    try:
+        by_alert = query_history(args.hours, args.alert)
+    except RuntimeError as e:
+        print(f"[ERROR] {e}", file=sys.stderr)
+        sys.exit(2)
+
+    if args.as_json:
+        print(json.dumps(by_alert, indent=2))
+    else:
+        print_human(by_alert, args.hours)
+
+    sys.exit(0 if not by_alert else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/sre-triage/scripts/alert_investigator.py
+++ b/skills/sre-triage/scripts/alert_investigator.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Retroactive alert investigator — diagnoses the root cause of a past firing alert.
+
+Given an alert name and a look-back window, this script:
+  1. Finds the exact firing window(s) from TSDB
+  2. Fetches the rule's PromQL expression and threshold from Prometheus
+  3. Re-evaluates the metric expression over the firing window
+  4. Identifies which label dimensions peaked above the threshold
+  5. Applies known false-alert heuristics and emits a fix hint
+
+Usage:
+  python3 alert_investigator.py --alert TraefikHighLatency
+  python3 alert_investigator.py --alert TraefikHighLatency --hours 8
+  python3 alert_investigator.py --alert ContainerCrashLoop --hours 3
+  python3 alert_investigator.py --alert TraefikHighLatency --json
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+
+PROMETHEUS_CONTAINER = "example-prometheus"
+
+# Build an opener that ONLY supports http/https. This makes file://, ftp://, etc.
+# structurally impossible regardless of what value PROMETHEUS_URL takes.
+_HTTP_OPENER = urllib.request.build_opener(
+    urllib.request.HTTPHandler,
+    urllib.request.HTTPSHandler,
+)
+PROMETHEUS_URL = "http://localhost:9090"
+STEP = 60  # seconds
+
+# ---------------------------------------------------------------------------
+# Known false-alert patterns
+# Each entry: match(labels, expr) -> bool, plus human-readable fields.
+# ---------------------------------------------------------------------------
+
+FALSE_ALERT_PATTERNS = [
+    {
+        "match": lambda labels, expr: (
+            any(v == "websocket" for v in labels.values())
+            and "duration" in expr.lower()
+        ),
+        "assessment": "FALSE ALERT — WebSocket connection lifetime misread as request latency",
+        "explanation": (
+            "Traefik records a WebSocket 'duration' as the total connection lifetime, "
+            "not the response time. A dashboard user holding a connection open for "
+            "several seconds trivially exceeds any latency threshold."
+        ),
+        "fix": 'Add protocol!="websocket" to the bucket selector in the rule expression.\n'
+        "  Before: rate(traefik_service_request_duration_seconds_bucket[5m])\n"
+        '  After:  rate(traefik_service_request_duration_seconds_bucket{protocol!="websocket"}[5m])',
+    },
+    {
+        "match": lambda _labels, expr: (
+            "candles" in expr.lower() or "stale" in expr.lower()
+        ),
+        "assessment": "POSSIBLE DATA FEED GAP — market data freshness alert",
+        "explanation": (
+            "Market data freshness alerts fire when no candle updates arrive within "
+            "the staleness window. Common causes: exchange maintenance, network blip, "
+            "or feed connector restart."
+        ),
+        "fix": "Check the upstream data-feed container logs and exchange status page. "
+        "Run the matching service-skill's health_probe.py for live state.",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Prometheus API
+# ---------------------------------------------------------------------------
+
+
+def prom_get(path: str, params: dict | None = None) -> dict:
+    qs = ("?" + urllib.parse.urlencode(params)) if params else ""
+    url = f"{PROMETHEUS_URL}{path}{qs}"
+
+    try:
+        # http/https only — see _HTTP_OPENER definition above
+        with _HTTP_OPENER.open(url, timeout=10) as r:
+            return json.loads(r.read())
+    except Exception:
+        pass
+
+    try:
+        result = subprocess.run(
+            ["docker", "exec", PROMETHEUS_CONTAINER, "wget", "-qO-", url],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return json.loads(result.stdout)
+    except Exception:
+        pass
+
+    raise RuntimeError(f"Cannot reach Prometheus at {url} (tried direct + docker exec)")
+
+
+# ---------------------------------------------------------------------------
+# Rule resolution
+# ---------------------------------------------------------------------------
+
+
+def fetch_rule(alert_name: str) -> dict | None:
+    """Return the Prometheus rule object for the given alertname, or None."""
+    data = prom_get("/api/v1/rules")
+    for group in data.get("data", {}).get("groups", []):
+        for rule in group.get("rules", []):
+            if rule.get("type") == "alerting" and rule.get("name") == alert_name:
+                return rule
+    return None
+
+
+def parse_threshold(expr: str) -> tuple[str, str, float | None]:
+    """
+    Split 'some_expr > 2' into (metric_expr, operator, threshold).
+    Returns (expr, '', None) if no comparison operator found.
+    """
+    m = re.search(r"\s*([><=!]+)\s*([\d.]+)\s*$", expr.strip())
+    if m:
+        metric_expr = expr[: m.start()].strip()
+        return metric_expr, m.group(1), float(m.group(2))
+    return expr, "", None
+
+
+# ---------------------------------------------------------------------------
+# Firing window detection
+# ---------------------------------------------------------------------------
+
+
+def find_firing_windows(alert_name: str, start_ts: int, end_ts: int) -> list[dict]:
+    """
+    Returns a list of firing instances, each with:
+      - labels: dict of label key/values
+      - windows: list of (start_ts, end_ts) tuples
+    """
+    data = prom_get(
+        "/api/v1/query_range",
+        {
+            "query": f'ALERTS{{alertname="{alert_name}"}}',
+            "start": start_ts,
+            "end": end_ts,
+            "step": STEP,
+        },
+    )
+
+    instances = []
+    for series in data.get("data", {}).get("result", []):
+        metric = series.get("metric", {})
+        raw_values = series.get("values", [])
+
+        windows: list[tuple[float, float]] = []
+        w_start: float | None = None
+        for ts, v in raw_values:
+            ts = float(ts)
+            if v == "1":
+                if w_start is None:
+                    w_start = ts
+            else:
+                if w_start is not None:
+                    windows.append((w_start, ts))
+                    w_start = None
+        if w_start is not None:
+            windows.append((w_start, float(raw_values[-1][0])))
+
+        if windows:
+            labels = {
+                k: v
+                for k, v in metric.items()
+                if k not in ("__name__", "alertstate", "alertname")
+            }
+            instances.append({"labels": labels, "windows": windows})
+
+    return instances
+
+
+# ---------------------------------------------------------------------------
+# Metric re-evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_metric(metric_expr: str, start_ts: int, end_ts: int) -> list[dict]:
+    """
+    Re-evaluate the bare metric expression over the window.
+    Returns list of { metric: {labels}, peak_value: float, peak_ts: str }.
+    """
+    data = prom_get(
+        "/api/v1/query_range",
+        {
+            "query": metric_expr,
+            "start": start_ts,
+            "end": end_ts,
+            "step": STEP,
+        },
+    )
+
+    results = []
+    for series in data.get("data", {}).get("result", []):
+        metric = series.get("metric", {})
+        values = [
+            (float(t), float(v))
+            for t, v in series.get("values", [])
+            if v not in ("NaN", "Inf", "+Inf", "-Inf")
+        ]
+        if not values:
+            continue
+        peak_ts, peak_val = max(values, key=lambda x: x[1])
+        results.append(
+            {
+                "metric": {k: v for k, v in metric.items() if k != "__name__"},
+                "peak_value": peak_val,
+                "peak_ts": datetime.fromtimestamp(peak_ts, tz=timezone.utc).strftime(
+                    "%H:%M UTC"
+                ),
+                "samples": len(values),
+            }
+        )
+
+    return sorted(results, key=lambda x: x["peak_value"], reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Heuristic assessment
+# ---------------------------------------------------------------------------
+
+
+def assess(
+    instances: list[dict], metric_expr: str, _threshold: float | None
+) -> dict | None:
+    """Run false-alert heuristics against each instance. Returns first matching pattern.
+
+    _threshold is reserved for future heuristics that compare observed peaks
+    against the rule's firing threshold; current patterns only key off labels + expr.
+    """
+    for inst in instances:
+        for pattern in FALSE_ALERT_PATTERNS:
+            if pattern["match"](inst["labels"], metric_expr):
+                return pattern
+    return None
+
+
+def duration_note(windows: list[tuple]) -> str:
+    total_sec = sum(end - start for start, end in windows)
+    mins = max(1, int(total_sec / 60))
+    if mins < 15:
+        return f"{mins}min  (brief — possibly transient)"
+    return f"{mins}min"
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def ts_str(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def print_report(
+    alert_name: str,
+    rule: dict | None,
+    metric_expr: str,
+    operator: str,
+    threshold: float | None,
+    instances: list[dict],
+    peaks: list[dict],
+    assessment: dict | None,
+) -> None:
+    width = 72
+    print("=" * width)
+    print(f"  {alert_name} — Investigation Report")
+    print("=" * width)
+
+    if rule:
+        print(f"\n  Rule group:  {rule.get('__group__', 'unknown')}")
+        print(f"  Expression:  {rule.get('query', metric_expr)}")
+        print(f"  For:         {rule.get('duration', '?')}s")
+        if threshold is not None:
+            print(f"  Threshold:   {operator} {threshold}")
+
+    print(f"\n  Firing instances: {len(instances)}")
+    for inst in instances:
+        label_str = "  ".join(f"{k}={v}" for k, v in inst["labels"].items())
+        print(f"    [{label_str}]")
+        for w_start, w_end in inst["windows"]:
+            print(
+                f"      {ts_str(w_start)} → {ts_str(w_end)}  ({duration_note([(w_start, w_end)])})"
+            )
+
+    if peaks:
+        print("\n  Peak metric values during firing window:")
+        for p in peaks[:5]:  # top 5 dimensions
+            m_str = "  ".join(
+                f"{k}={v}" for k, v in p["metric"].items() if k not in ("alertname",)
+            )
+            thresh_str = ""
+            if threshold is not None:
+                over = p["peak_value"] - threshold
+                thresh_str = f"  ({over:+.2f} over threshold)"
+            print(f"    {p['peak_value']:.2f}  at {p['peak_ts']}{thresh_str}")
+            if m_str:
+                print(f"    labels: {m_str}")
+    elif metric_expr:
+        print(
+            "\n  [No metric samples found in firing window — alert may have resolved before re-evaluation]"
+        )
+
+    print()
+    if assessment:
+        print(f"  Assessment:  {assessment['assessment']}")
+        print()
+        for line in assessment["explanation"].split(". "):
+            line = line.strip()
+            if line:
+                print(f"  {line}.")
+        print()
+        print("  Fix:")
+        for line in assessment["fix"].splitlines():
+            print(f"    {line}")
+    else:
+        print("  Assessment:  No known false-alert pattern matched.")
+        print("  Next step:   Review logs with the relevant service skill.")
+
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Diagnose a past firing alert by re-evaluating its metric expression",
+    )
+    parser.add_argument(
+        "--alert",
+        required=True,
+        help="Alertname to investigate (e.g. TraefikHighLatency)",
+    )
+    parser.add_argument(
+        "--hours", type=float, default=6, help="Look-back window in hours (default: 6)"
+    )
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    now = int(time.time())
+    start = int(now - args.hours * 3600)
+
+    try:
+        rule = fetch_rule(args.alert)
+        instances = find_firing_windows(args.alert, start, now)
+
+        if not instances:
+            print(
+                f"No firing windows found for '{args.alert}' in the past {args.hours}h."
+            )
+            sys.exit(0)
+
+        raw_expr = rule["query"] if rule else ""
+        metric_expr, operator, threshold = parse_threshold(raw_expr)
+
+        # Widen the eval window slightly to capture the metric values
+        if instances:
+            all_starts = [w[0] for i in instances for w in i["windows"]]
+            all_ends = [w[1] for i in instances for w in i["windows"]]
+            eval_start = int(min(all_starts)) - 300
+            eval_end = int(max(all_ends)) + 300
+        else:
+            eval_start, eval_end = start, now
+
+        peaks = (
+            evaluate_metric(metric_expr, eval_start, eval_end) if metric_expr else []
+        )
+        assessment = assess(instances, metric_expr, threshold)
+
+        if args.as_json:
+            print(
+                json.dumps(
+                    {
+                        "alert": args.alert,
+                        "rule_expr": raw_expr,
+                        "instances": [
+                            {**i, "windows": [[s, e] for s, e in i["windows"]]}
+                            for i in instances
+                        ],
+                        "peaks": peaks,
+                        "assessment": assessment["assessment"] if assessment else None,
+                        "fix": assessment["fix"] if assessment else None,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            # Attach group name to rule for display
+            if rule:
+                rule["__group__"] = rule.get("name", "?")
+            print_report(
+                args.alert,
+                rule,
+                metric_expr,
+                operator,
+                threshold,
+                instances,
+                peaks,
+                assessment,
+            )
+
+    except RuntimeError as e:
+        print(f"[ERROR] {e}", file=sys.stderr)
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/sre-triage/tests/test_skill_content.py
+++ b/skills/sre-triage/tests/test_skill_content.py
@@ -1,0 +1,215 @@
+"""
+TDD tests for sre-triage SKILL.md correctness.
+
+Each test maps to a tracked beads issue. Run with:
+  pytest .xtrm/skills/default/sre-triage/tests/ -v
+"""
+
+import re
+from pathlib import Path
+
+SKILL_PATH = Path(__file__).parent.parent / "SKILL.md"
+
+
+def _content() -> str:
+    return SKILL_PATH.read_text()
+
+
+def _frontmatter(content: str) -> str:
+    """Extract YAML frontmatter between the first two --- markers."""
+    if not content.startswith("---"):
+        return ""
+    end = content.index("---", 3)
+    return content[3:end]
+
+
+def _section(content: str, heading: str) -> str:
+    """Extract content from a heading until the next same-level heading."""
+    idx = content.find(heading)
+    if idx == -1:
+        return ""
+    after = content[idx:]
+    # Find next ### heading (same or higher level)
+    next_heading = re.search(r"\n###? ", after[len(heading) :])
+    if next_heading:
+        return after[: len(heading) + next_heading.start()]
+    return after
+
+
+# ---------------------------------------------------------------------------
+# infra-veb: Step 6 must reference the correct health_check.py path
+# ---------------------------------------------------------------------------
+
+
+def test_step6_correct_health_check_path():
+    """Step 6 verify command must point to a project-owned scripts/health_check.py, not the skill scripts dir."""
+    content = _content()
+    step6 = _section(content, "### Step 6")
+    assert (
+        "infra/scripts/health_check.py" in step6
+    ), "Step 6 should reference the project's <infra>/scripts/health_check.py fallback"
+    assert (
+        "sre-triage/scripts/health_check.py" not in step6
+        and "checking-stack-health/scripts/health_check.py" not in step6
+    ), "Step 6 references a non-existent health_check.py inside the skill scripts dir"
+
+
+# ---------------------------------------------------------------------------
+# infra-crv: SKILL_DIR must use $CLAUDE_PROJECT_DIR, not a hardcoded path
+# ---------------------------------------------------------------------------
+
+
+def test_skill_dir_uses_env_var():
+    """SKILL_DIR in Step 2b must reference $CLAUDE_PROJECT_DIR, not a hardcoded host path."""
+    content = _content()
+    step2b = _section(content, "### Step 2b")
+    assert (
+        "$CLAUDE_PROJECT_DIR" in step2b
+    ), "SKILL_DIR should be set via $CLAUDE_PROJECT_DIR for portability"
+    assert (
+        "SKILL_DIR=~/projects" not in step2b
+    ), "SKILL_DIR must not be hardcoded to a ~/projects/... host path"
+
+
+# ---------------------------------------------------------------------------
+# Regression: TraefikHighLatency must map to the traefik service skill,
+# not to whatever API service sits behind the proxy
+# ---------------------------------------------------------------------------
+
+
+def test_traefik_latency_maps_to_traefik_skill():
+    """Alert→Service table: TraefikHighLatency must map to the traefik skill, not the backend API."""
+    content = _content()
+    # Find the table row for TraefikHighLatency and capture the Likely service/container column.
+    match = re.search(r"\|\s*`TraefikHighLatency`\s*\|[^|]+\|([^|]+)\|", content)
+    assert match, "TraefikHighLatency row not found in Alert→Service mapping table"
+    mapping = match.group(1).strip()
+    assert (
+        "traefik" in mapping.lower()
+    ), f"TraefikHighLatency should map to traefik skill, got: {mapping!r}"
+    # The bug being prevented: routing latency at the proxy to a backend API skill
+    # rather than to the proxy's own skill. The literal upstream-API name varies by
+    # project; the rule is "must contain 'traefik'", which the positive assertion above covers.
+
+
+# ---------------------------------------------------------------------------
+# infra-ag8: allowed-tools must include Bash(docker *)
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_tools_includes_docker():
+    """Frontmatter allowed-tools must include Bash(docker *) for fallback commands."""
+    content = _content()
+    fm = _frontmatter(content)
+    assert (
+        "Bash(docker" in fm
+    ), "allowed-tools must include Bash(docker *) — Step 2b fallback uses docker commands"
+
+
+# ---------------------------------------------------------------------------
+# infra-31l: Step 2b must instruct deriving --hours from the user's statement
+# ---------------------------------------------------------------------------
+
+
+def test_hours_derived_from_user_statement():
+    """Step 2b must tell the agent to derive the --hours value from what the user said."""
+    content = _content()
+    step2b = _section(content, "### Step 2b")
+    keywords = [
+        "derive",
+        "from the user",
+        "user said",
+        "user mention",
+        "user's statement",
+    ]
+    assert any(kw in step2b.lower() for kw in keywords), (
+        "Step 2b must instruct the agent to derive --hours from the user's statement, "
+        "not always default to --hours 6"
+    )
+
+
+# ---------------------------------------------------------------------------
+# infra-cdl: description must mention retroactive / past-alert investigation
+# ---------------------------------------------------------------------------
+
+
+def test_description_mentions_retroactive_investigation():
+    """Frontmatter description must mention past alerts or retroactive investigation."""
+    content = _content()
+    fm = _frontmatter(content)
+    desc_match = re.search(r"description:\s*>-\s*\n((?:  .*\n?)+)", fm)
+    assert desc_match, "description field not found in frontmatter"
+    desc = desc_match.group(1).lower()
+    keywords = [
+        "past alert",
+        "retroactive",
+        "hours ago",
+        "telegram",
+        "resolved alert",
+        "historical",
+    ]
+    assert any(
+        kw in desc for kw in keywords
+    ), f"Description should mention retroactive/past-alert investigation capability. Got: {desc!r}"
+
+
+# ---------------------------------------------------------------------------
+# infra-2it: Step 2b must not use nested "Step 1" / "Step 2" labels
+# ---------------------------------------------------------------------------
+
+
+def test_no_nested_step_labels_in_step2b():
+    """Step 2b must not use '**Step 1' / '**Step 2' — collides with outer numbered steps."""
+    content = _content()
+    step2b = _section(content, "### Step 2b")
+    assert (
+        "**Step 1" not in step2b
+    ), "Step 2b must not use '**Step 1' internally — use 'Phase A' or bullet points instead"
+    assert (
+        "**Step 2" not in step2b
+    ), "Step 2b must not use '**Step 2' internally — use 'Phase B' or bullet points instead"
+
+
+# ---------------------------------------------------------------------------
+# infra-dua: scripts: must not appear in YAML frontmatter
+# ---------------------------------------------------------------------------
+
+
+def test_no_scripts_key_in_frontmatter():
+    """The scripts: key is non-standard and must not appear in YAML frontmatter."""
+    content = _content()
+    fm = _frontmatter(content)
+    assert (
+        "scripts:" not in fm
+    ), "scripts: is not a recognized Claude skill frontmatter key — move it to the skill body"
+
+
+# ---------------------------------------------------------------------------
+# infra-01l: freshness probe must be cadence-aware, not a blanket >600s query
+# ---------------------------------------------------------------------------
+
+
+def test_freshness_probe_is_cadence_aware():
+    """Step 1/6 freshness query must not flag daily/hourly feeds with a blanket 600s SLO."""
+    content = _content()
+    step1 = _section(content, "### Step 1 — Live Health Probe via mcpq")
+    step6 = _section(content, "### Step 6")
+
+    # Regression: the original blanket query lacked a feed_id filter and flagged
+    # daily/hourly feeds. Forbid the pattern of `time() - <freshness_metric> > 600`
+    # without a {feed_id=~...} narrow. The freshness metric name itself is
+    # project-shaped (the placeholder example uses `example_project_freshness_*`).
+    forbidden_re = re.compile(r"time\(\)\s*-\s*\w*freshness\w*\s*>\s*600\s*$", re.MULTILINE)
+    assert not forbidden_re.search(step1), "Step 1 must not use a blanket freshness >600s query"
+    assert not forbidden_re.search(step6), "Step 6 must not use a blanket freshness >600s query"
+
+    combined = (step1 + step6).lower()
+    assert (
+        "cadence-aware" in combined
+    ), "Freshness guidance should explicitly be cadence-aware"
+    assert (
+        "feed_id=~" in step1
+    ), "Step 1 should narrow the 600s SLO to known fast/live feeds"
+    assert (
+        "daily" in combined and "hourly" in combined
+    ), "Freshness guidance must say daily/hourly feeds are not degraded solely by >600s age"


### PR DESCRIPTION
## Summary

- First materialization of the `devops-sre` / monitor role from `docs/devops/devops-system.md` §5.1.
- Surfaces stack health via `mcpq` (sidecar registry already in `.mcpq.json`, so no new config file), classifies into PASS/DEGRADED/CRITICAL/UNKNOWN, and routes to expert service skills by runtime directory inference — no frozen mapping tables, no schema, no new CLI.
- Sanitized of proprietary names: all Mercury / project-codename references replaced with `example-project` placeholders, marked illustrative in a header banner. Methodology, mcpq invocation pattern, universal PromQL probes (`up == 0`, `ALERTS{alertstate="firing"}`, `node_*`, `container_*`), and status taxonomy are universal.
- Prometheus HTTP client (`alert_history.py`, `alert_investigator.py`) builds a urllib opener that **only** registers `HTTPHandler` and `HTTPSHandler` — `file://`, `ftp://`, etc. are structurally impossible regardless of what `PROMETHEUS_URL` is set to. Addresses a semgrep finding caught at push time.
- Lands as the canonical source. Consumer repos (starting with mercury-infra, where the unsanitized version currently lives at `.xtrm/skills/default/sre-triage/`) will inherit this on next `xt update --apply`.

## Test plan

- [ ] `cd skills/sre-triage && python3 -m pytest tests/ -v` — all 9 tests pass
- [ ] `grep -inE "mercury|darth|mmd|cmex|treasury-API|MarketData|globex|qwen|squawk" SKILL.md scripts/ tests/` — no matches
- [ ] semgrep + osv pre-push hooks pass
- [ ] Consumer-side: after `xt update --apply` in a project with `.mcpq.json` configured, `/sre-triage` appears in the available-skills catalog
- [ ] Companion mercury-infra PR: mercuryintelligence/infra#97

🤖 Generated with [Claude Code](https://claude.com/claude-code)