### PR TITLE
feat(service-skills): reconcile.py runner-callable Python (xtrm-pm5d8.1 Phase B step 1)

### DIFF
--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -607,6 +607,10 @@
           "hash": "a437a67e7ae741b2ceaee35740a535a65e8f8aadf14d479d378616c7ccc46232",
           "version": "0.9.0"
         },
+        "multiplexing/SKILL.md": {
+          "hash": "3f49f5c5d4c9d627eb1d654bf5460378025622e320103504f840058dd5488d7f",
+          "version": "0.9.0"
+        },
         "planning/SKILL.md": {
           "hash": "b02da9548702f9256c0b4938490dad86a8898bbe72e2152d22999a02b3f608a8",
           "version": "0.9.0"
@@ -728,7 +732,7 @@
           "version": "0.9.0"
         },
         "service-skills/install/git-hooks/post_merge_drift_sweep.py": {
-          "hash": "836bdb22c47887ca808a4f53232a9153cefcab01ca4203dd40b7c6bda88a8691",
+          "hash": "a3ddf2f1dc84950c58cd0bf893b499e1c6e87be83fed8578730125b001b7e602",
           "version": "0.9.0"
         },
         "service-skills/install/git-hooks/skill_staleness.py": {
@@ -793,6 +797,10 @@
         },
         "service-skills/scripts/layout_migrator.py": {
           "hash": "8f98fb15f7feffd8de7e58491aee17b195bd82e8413bc2525ca416835e8cd38f",
+          "version": "0.9.0"
+        },
+        "service-skills/scripts/reconcile.py": {
+          "hash": "327ca6f12d696a92715c7efc22d19da9bd115fcf3077ba740b18a086a3d89f1e",
           "version": "0.9.0"
         },
         "service-skills/scripts/scaffolder.py": {
@@ -909,6 +917,18 @@
         },
         "specialists-creator/SKILL.md": {
           "hash": "f84c22e11e08f83ab73c7f3d52df3b071037600740352713d1494f57799b679e",
+          "version": "0.9.0"
+        },
+        "sre-triage/scripts/alert_history.py": {
+          "hash": "b212bb8dad1ec0ae2db97824d4f72ece15db079bddfde466e230ef1e852bd0d3",
+          "version": "0.9.0"
+        },
+        "sre-triage/scripts/alert_investigator.py": {
+          "hash": "a950e1e0745766abe0f8acb9bd457b7ba08672628e21a82e091601f86e25fe85",
+          "version": "0.9.0"
+        },
+        "sre-triage/SKILL.md": {
+          "hash": "f9328ec682414e64304c75d38eddafe9014c23fb4334a16398ed0eaa64827bd2",
           "version": "0.9.0"
         },
         "sync-docs/references/doc-structure.md": {

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -607,10 +607,6 @@
           "hash": "a437a67e7ae741b2ceaee35740a535a65e8f8aadf14d479d378616c7ccc46232",
           "version": "0.9.0"
         },
-        "multiplexing/SKILL.md": {
-          "hash": "3f49f5c5d4c9d627eb1d654bf5460378025622e320103504f840058dd5488d7f",
-          "version": "0.9.0"
-        },
         "planning/SKILL.md": {
           "hash": "b02da9548702f9256c0b4938490dad86a8898bbe72e2152d22999a02b3f608a8",
           "version": "0.9.0"
@@ -917,18 +913,6 @@
         },
         "specialists-creator/SKILL.md": {
           "hash": "f84c22e11e08f83ab73c7f3d52df3b071037600740352713d1494f57799b679e",
-          "version": "0.9.0"
-        },
-        "sre-triage/scripts/alert_history.py": {
-          "hash": "b212bb8dad1ec0ae2db97824d4f72ece15db079bddfde466e230ef1e852bd0d3",
-          "version": "0.9.0"
-        },
-        "sre-triage/scripts/alert_investigator.py": {
-          "hash": "a950e1e0745766abe0f8acb9bd457b7ba08672628e21a82e091601f86e25fe85",
-          "version": "0.9.0"
-        },
-        "sre-triage/SKILL.md": {
-          "hash": "f9328ec682414e64304c75d38eddafe9014c23fb4334a16398ed0eaa64827bd2",
           "version": "0.9.0"
         },
         "sync-docs/references/doc-structure.md": {

--- a/.xtrm/skills/default/service-skills/scripts/reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/reconcile.py
@@ -163,7 +163,7 @@ def update_yaml_registry(project_root: Path, new_ref: str) -> None:
 def reconcile(options: ReconcileOptions) -> dict[str, Any]:
     project_root = Path(get_project_root())
     registry = load_registry(str(project_root))
-    drifted = scan_drift(str(project_root), enrich_with_gitnexus=True, use_gitnexus=True)
+    drifted = scan_drift(str(project_root), enrich_with_gitnexus=False, use_gitnexus=False)
     selected = drifted[: options.max_files] if options.max_files is not None else drifted
     result: dict[str, Any] = {
         "status": "success",

--- a/.xtrm/skills/default/service-skills/scripts/reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/reconcile.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Standalone service-skills drift reconciler for zero-install runners."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from bootstrap import get_project_root, get_registry_path, load_registry, save_registry  # type: ignore[import-not-found]  # noqa: E402
+from drift_detector import scan_drift  # type: ignore[import-not-found]  # noqa: E402
+
+NANO_GPT_URL = os.environ.get("NANO_GPT_API_URL", "https://nano-gpt.com/api/v1/chat/completions")
+NANO_GPT_MODEL = os.environ.get("NANO_GPT_MODEL", "gpt-4o-mini")
+TOKEN_CHARS = 4
+
+
+@dataclass(frozen=True)
+class ReconcileOptions:
+    dry_run: bool
+    max_files: int | None
+    api_key: str
+    cost_limit_tokens: int | None
+
+
+@dataclass(frozen=True)
+class LlmResult:
+    content: str
+    tokens: int
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Reconcile service SKILL.md drift.")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON only")
+    parser.add_argument("--dry-run", action="store_true", help="build prompts and call API without writes")
+    parser.add_argument("--max-files", type=int, default=None, help="maximum drifted files to reconcile")
+    return parser.parse_args(argv)
+
+
+def parse_cost_limit(value: str | None) -> int | None:
+    if value is None or value == "":
+        return None
+    limit = int(value)
+    if limit < 0:
+        raise ValueError("XTRM_AUTO_RECONCILE_COST_LIMIT_TOKENS must be non-negative")
+    return limit
+
+
+def estimate_tokens(text: str) -> int:
+    return max(1, (len(text) + TOKEN_CHARS - 1) // TOKEN_CHARS)
+
+
+def build_prompt(drift: dict[str, Any], current_skill: str, source_evidence: str) -> str:
+    citations = {
+        "symbols": drift.get("symbols", []),
+        "processes": drift.get("processes", []),
+        "cross_territory": drift.get("cross_territory", []),
+        "tier": drift.get("tier"),
+        "tier_source": drift.get("tier_source"),
+        "gitnexus_status": drift.get("gitnexus_status"),
+    }
+    return "\n".join(
+        [
+            "You reconcile service skill documentation with implementation drift.",
+            "Return only the complete updated SKILL.md content. No markdown fences. No commentary.",
+            f"Service: {drift.get('service_id', 'unknown')} ({drift.get('service_name', 'unknown')})",
+            f"Drifted source file: {drift.get('file_path', 'unknown')}",
+            f"Drift evidence: {json.dumps(citations, sort_keys=True)}",
+            "",
+            "Current SKILL.md:",
+            current_skill,
+            "",
+            "Source file evidence:",
+            source_evidence,
+        ]
+    )
+
+
+def parse_llm_response(payload: dict[str, Any]) -> LlmResult:
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("nano-gpt response missing choices")
+    message = choices[0].get("message") if isinstance(choices[0], dict) else None
+    content = message.get("content") if isinstance(message, dict) else None
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError("nano-gpt response missing content")
+    usage = payload.get("usage") if isinstance(payload.get("usage"), dict) else {}
+    total_tokens = usage.get("total_tokens", 0)
+    return LlmResult(content=content.strip() + "\n", tokens=total_tokens if isinstance(total_tokens, int) else 0)
+
+
+def call_nano_gpt(prompt: str, api_key: str) -> LlmResult:
+    try:
+        import httpx  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise RuntimeError("httpx is required for reconcile.py") from exc
+    response = httpx.post(
+        NANO_GPT_URL,
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        json={"model": NANO_GPT_MODEL, "messages": [{"role": "user", "content": prompt}]},
+        timeout=120,
+    )
+    response.raise_for_status()
+    return parse_llm_response(response.json())
+
+
+def atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+        handle.write(content)
+        temp_path = Path(handle.name)
+    os.replace(temp_path, path)
+
+
+def current_head(project_root: Path) -> str:
+    result = subprocess.run(["git", "-C", str(project_root), "rev-parse", "HEAD"], capture_output=True, text=True, check=False)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def find_skill_path(drift: dict[str, Any], registry: dict[str, Any]) -> str | None:
+    skill_path = drift.get("skill_path")
+    if isinstance(skill_path, str) and skill_path:
+        return skill_path
+    service_id = drift.get("service_id")
+    service = registry.get("services", {}).get(service_id) if isinstance(service_id, str) else None
+    if isinstance(service, dict) and isinstance(service.get("skill_path"), str):
+        return service["skill_path"]
+    return None
+
+
+def bump_last_sync_ref(project_root: Path, new_ref: str, dry_run: bool) -> str | None:
+    registry = load_registry(str(project_root))
+    services = registry.get("services", {})
+    old_refs = [service.get("last_sync_ref") for service in services.values() if isinstance(service, dict)]
+    old_ref = next((ref for ref in old_refs if isinstance(ref, str) and ref), None)
+    for service in services.values():
+        if isinstance(service, dict):
+            service["last_sync_ref"] = new_ref
+    if not dry_run:
+        save_registry(registry, str(project_root))
+        update_yaml_registry(project_root, new_ref)
+    return old_ref
+
+
+def update_yaml_registry(project_root: Path, new_ref: str) -> None:
+    for name in ("service-registry.yml", "service-registry.yaml"):
+        path = project_root / name
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        updated = re.sub(r"(last_sync_ref:\s*)[^\n]*", rf"\g<1>{new_ref}", text)
+        atomic_write(path, updated)
+
+
+def reconcile(options: ReconcileOptions) -> dict[str, Any]:
+    project_root = Path(get_project_root())
+    registry = load_registry(str(project_root))
+    drifted = scan_drift(str(project_root), enrich_with_gitnexus=True, use_gitnexus=True)
+    selected = drifted[: options.max_files] if options.max_files is not None else drifted
+    result: dict[str, Any] = {
+        "status": "success",
+        "drift_count": len(drifted),
+        "reconciled_count": 0,
+        "failed": [],
+        "cost_tokens": 0,
+        "last_sync_ref_old": None,
+        "last_sync_ref_new": current_head(project_root),
+    }
+    for drift in selected:
+        try:
+            skill_path_value = find_skill_path(drift, registry)
+            if not skill_path_value:
+                raise ValueError(f"missing skill_path for {drift.get('service_id', 'unknown')}")
+            skill_path = project_root / skill_path_value
+            source_path = project_root / str(drift["file_path"])
+            prompt = build_prompt(drift, skill_path.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8", errors="ignore"))
+            projected_tokens = result["cost_tokens"] + estimate_tokens(prompt)
+            if options.cost_limit_tokens is not None and projected_tokens > options.cost_limit_tokens:
+                result["status"] = "partial"
+                result["failed"].append({"file_path": drift.get("file_path"), "error": "cost limit exceeded before request"})
+                break
+            llm_result = call_nano_gpt(prompt, options.api_key)
+            result["cost_tokens"] += llm_result.tokens or estimate_tokens(prompt)
+            if options.cost_limit_tokens is not None and result["cost_tokens"] > options.cost_limit_tokens:
+                result["status"] = "partial"
+                result["failed"].append({"file_path": drift.get("file_path"), "error": "cost limit exceeded after request"})
+                break
+            if not options.dry_run:
+                atomic_write(skill_path, llm_result.content)
+            result["reconciled_count"] += 1
+        except Exception as exc:
+            result["status"] = "partial"
+            result["failed"].append({"file_path": drift.get("file_path"), "error": str(exc)})
+    if result["reconciled_count"] and not (options.dry_run or result["status"] == "partial"):
+        result["last_sync_ref_old"] = bump_last_sync_ref(project_root, result["last_sync_ref_new"], options.dry_run)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    api_key = os.environ.get("NANO_GPT_API_KEY")
+    if not api_key:
+        print("NANO_GPT_API_KEY is required for reconcile.py", file=sys.stderr)
+        return 2
+    try:
+        options = ReconcileOptions(args.dry_run, args.max_files, api_key, parse_cost_limit(os.environ.get("XTRM_AUTO_RECONCILE_COST_LIMIT_TOKENS")))
+        output = reconcile(options)
+    except Exception as exc:
+        output = {"status": "failed", "drift_count": 0, "reconciled_count": 0, "failed": [{"file_path": None, "error": str(exc)}], "cost_tokens": 0, "last_sync_ref_old": None, "last_sync_ref_new": ""}
+    print(json.dumps(output, sort_keys=True) if args.json else json.dumps(output, indent=2, sort_keys=True))
+    return 0 if output["status"] == "success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.xtrm/skills/default/service-skills/scripts/reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/reconcile.py
@@ -13,13 +13,16 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 sys.path.insert(0, str(Path(__file__).parent))
 from bootstrap import get_project_root, get_registry_path, load_registry, save_registry  # type: ignore[import-not-found]  # noqa: E402
 from drift_detector import scan_drift  # type: ignore[import-not-found]  # noqa: E402
 
-NANO_GPT_URL = os.environ.get("NANO_GPT_API_URL", "https://nano-gpt.com/api/v1/chat/completions")
+DEFAULT_NANO_GPT_URL = "https://nano-gpt.com/api/v1/chat/completions"
 NANO_GPT_MODEL = os.environ.get("NANO_GPT_MODEL", "gpt-4o-mini")
+ALLOWED_NANO_GPT_HOSTS = {"nano-gpt.com"}
+SECRET_QUERY_PARAMS = {"api_key", "key", "token"}
 TOKEN_CHARS = 4
 
 
@@ -59,6 +62,7 @@ def estimate_tokens(text: str) -> int:
 
 
 def build_prompt(drift: dict[str, Any], current_skill: str, source_evidence: str) -> str:
+    """Trust model: source files come from the repo (trusted but commit-reviewed); LLM output is treated as PR-reviewed (human approves auto-PR)."""
     citations = {
         "symbols": drift.get("symbols", []),
         "processes": drift.get("processes", []),
@@ -97,13 +101,37 @@ def parse_llm_response(payload: dict[str, Any]) -> LlmResult:
     return LlmResult(content=content.strip() + "\n", tokens=total_tokens if isinstance(total_tokens, int) else 0)
 
 
+def get_nano_gpt_url() -> str:
+    return os.environ.get("NANO_GPT_API_URL", DEFAULT_NANO_GPT_URL)
+
+
+def validate_nano_gpt_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise ValueError("NANO_GPT_API_URL must use https")
+    if parsed.hostname not in ALLOWED_NANO_GPT_HOSTS:
+        raise ValueError("NANO_GPT_API_URL host must be nano-gpt.com")
+    query_keys = {key.lower() for key in parse_qs(parsed.query)}
+    if query_keys & SECRET_QUERY_PARAMS:
+        raise ValueError("NANO_GPT_API_URL must not contain secret query parameters")
+    return url
+
+
+def redact_exception(exc: Exception, api_key: str | None = None) -> str:
+    message = f"{type(exc).__name__}: {str(exc)[:200]}"
+    message = re.sub(r"Bearer\s+\S+", "Bearer [REDACTED]", message)
+    if api_key:
+        message = message.replace(api_key, "[REDACTED]")
+    return message
+
+
 def call_nano_gpt(prompt: str, api_key: str) -> LlmResult:
     try:
         import httpx  # type: ignore[import-not-found]
     except ImportError as exc:
         raise RuntimeError("httpx is required for reconcile.py") from exc
     response = httpx.post(
-        NANO_GPT_URL,
+        validate_nano_gpt_url(get_nano_gpt_url()),
         headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
         json={"model": NANO_GPT_MODEL, "messages": [{"role": "user", "content": prompt}]},
         timeout=120,
@@ -125,15 +153,19 @@ def current_head(project_root: Path) -> str:
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
-def find_skill_path(drift: dict[str, Any], registry: dict[str, Any]) -> str | None:
+def find_skill_path(drift: dict[str, Any], registry: dict[str, Any], project_root: Path) -> str | None:
     skill_path = drift.get("skill_path")
-    if isinstance(skill_path, str) and skill_path:
-        return skill_path
-    service_id = drift.get("service_id")
-    service = registry.get("services", {}).get(service_id) if isinstance(service_id, str) else None
-    if isinstance(service, dict) and isinstance(service.get("skill_path"), str):
-        return service["skill_path"]
-    return None
+    if not isinstance(skill_path, str) or not skill_path:
+        service_id = drift.get("service_id")
+        service = registry.get("services", {}).get(service_id) if isinstance(service_id, str) else None
+        skill_path = service.get("skill_path") if isinstance(service, dict) else None
+    if not isinstance(skill_path, str) or not skill_path:
+        return None
+    resolved_root = project_root.resolve()
+    resolved_skill_path = (project_root / skill_path).resolve()
+    if not resolved_skill_path.is_relative_to(resolved_root):
+        raise ValueError(f"skill_path escapes project root: {skill_path}")
+    return skill_path
 
 
 def bump_last_sync_ref(project_root: Path, new_ref: str, dry_run: bool) -> str | None:
@@ -176,7 +208,7 @@ def reconcile(options: ReconcileOptions) -> dict[str, Any]:
     }
     for drift in selected:
         try:
-            skill_path_value = find_skill_path(drift, registry)
+            skill_path_value = find_skill_path(drift, registry, project_root)
             if not skill_path_value:
                 raise ValueError(f"missing skill_path for {drift.get('service_id', 'unknown')}")
             skill_path = project_root / skill_path_value
@@ -198,7 +230,7 @@ def reconcile(options: ReconcileOptions) -> dict[str, Any]:
             result["reconciled_count"] += 1
         except Exception as exc:
             result["status"] = "partial"
-            result["failed"].append({"file_path": drift.get("file_path"), "error": str(exc)})
+            result["failed"].append({"file_path": drift.get("file_path"), "error": redact_exception(exc, options.api_key)})
     if result["reconciled_count"] and not (options.dry_run or result["status"] == "partial"):
         result["last_sync_ref_old"] = bump_last_sync_ref(project_root, result["last_sync_ref_new"], options.dry_run)
     return result
@@ -211,10 +243,11 @@ def main(argv: list[str] | None = None) -> int:
         print("NANO_GPT_API_KEY is required for reconcile.py", file=sys.stderr)
         return 2
     try:
+        validate_nano_gpt_url(get_nano_gpt_url())
         options = ReconcileOptions(args.dry_run, args.max_files, api_key, parse_cost_limit(os.environ.get("XTRM_AUTO_RECONCILE_COST_LIMIT_TOKENS")))
         output = reconcile(options)
     except Exception as exc:
-        output = {"status": "failed", "drift_count": 0, "reconciled_count": 0, "failed": [{"file_path": None, "error": str(exc)}], "cost_tokens": 0, "last_sync_ref_old": None, "last_sync_ref_new": ""}
+        output = {"status": "failed", "drift_count": 0, "reconciled_count": 0, "failed": [{"file_path": None, "error": redact_exception(exc, api_key)}], "cost_tokens": 0, "last_sync_ref_old": None, "last_sync_ref_new": ""}
     print(json.dumps(output, sort_keys=True) if args.json else json.dumps(output, indent=2, sort_keys=True))
     return 0 if output["status"] == "success" else 1
 

--- a/.xtrm/skills/default/service-skills/scripts/tests/test_reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/tests/test_reconcile.py
@@ -1,0 +1,138 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import reconcile
+
+
+def test_build_prompt_includes_drift_evidence():
+    prompt = reconcile.build_prompt(
+        {
+            "service_id": "alpha",
+            "service_name": "Alpha",
+            "file_path": "src/alpha.py",
+            "symbols": ["alpha.run"],
+            "processes": ["alpha-flow"],
+            "tier": "high",
+        },
+        "# Alpha\nold",
+        "def run(): pass",
+    )
+
+    assert "Return only the complete updated SKILL.md content" in prompt
+    assert "alpha.run" in prompt
+    assert "alpha-flow" in prompt
+    assert "# Alpha\nold" in prompt
+    assert "def run(): pass" in prompt
+
+
+def test_parse_llm_response_extracts_content_and_tokens():
+    result = reconcile.parse_llm_response(
+        {"choices": [{"message": {"content": "# Updated\n"}}], "usage": {"total_tokens": 42}}
+    )
+
+    assert result.content == "# Updated\n"
+    assert result.tokens == 42
+
+
+def test_cost_cap_halts_before_request(tmp_path, monkeypatch):
+    skill_path = tmp_path / "skills/alpha/SKILL.md"
+    source_path = tmp_path / "src/alpha.py"
+    skill_path.parent.mkdir(parents=True)
+    source_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Alpha\n" + "x" * 100, encoding="utf-8")
+    source_path.write_text("print('alpha')\n", encoding="utf-8")
+    monkeypatch.setattr(reconcile, "get_project_root", lambda: str(tmp_path))
+    monkeypatch.setattr(reconcile, "load_registry", lambda root: {"services": {"alpha": {"skill_path": "skills/alpha/SKILL.md"}}})
+    monkeypatch.setattr(reconcile, "scan_drift", lambda *args, **kwargs: [{"service_id": "alpha", "file_path": "src/alpha.py"}])
+    monkeypatch.setattr(reconcile, "call_nano_gpt", lambda prompt, api_key: pytest.fail("API should not be called"))
+
+    result = reconcile.reconcile(reconcile.ReconcileOptions(False, None, "key", 1))
+
+    assert result["status"] == "partial"
+    assert result["reconciled_count"] == 0
+    assert result["failed"][0]["error"] == "cost limit exceeded before request"
+
+
+def test_missing_key_exits_2(monkeypatch, capsys):
+    monkeypatch.delenv("NANO_GPT_API_KEY", raising=False)
+
+    exit_code = reconcile.main(["--json"])
+
+    assert exit_code == 2
+    assert "NANO_GPT_API_KEY" in capsys.readouterr().err
+
+
+def test_dry_run_does_not_write_or_bump(tmp_path, monkeypatch):
+    skill_path = tmp_path / "skills/alpha/SKILL.md"
+    source_path = tmp_path / "src/alpha.py"
+    skill_path.parent.mkdir(parents=True)
+    source_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Alpha\nold\n", encoding="utf-8")
+    source_path.write_text("print('alpha')\n", encoding="utf-8")
+    monkeypatch.setattr(reconcile, "get_project_root", lambda: str(tmp_path))
+    monkeypatch.setattr(reconcile, "load_registry", lambda root: {"services": {"alpha": {"skill_path": "skills/alpha/SKILL.md"}}})
+    monkeypatch.setattr(reconcile, "scan_drift", lambda *args, **kwargs: [{"service_id": "alpha", "file_path": "src/alpha.py"}])
+    monkeypatch.setattr(reconcile, "current_head", lambda root: "new-sha")
+    monkeypatch.setattr(reconcile, "call_nano_gpt", lambda prompt, api_key: reconcile.LlmResult("# Alpha\nnew\n", 10))
+    monkeypatch.setattr(reconcile, "bump_last_sync_ref", lambda *args, **kwargs: pytest.fail("registry should not be bumped"))
+
+    result = reconcile.reconcile(reconcile.ReconcileOptions(True, None, "key", None))
+
+    assert result["status"] == "success"
+    assert result["reconciled_count"] == 1
+    assert skill_path.read_text(encoding="utf-8") == "# Alpha\nold\n"
+
+
+def test_atomic_write_uses_os_replace(tmp_path, monkeypatch):
+    target = tmp_path / "SKILL.md"
+    calls = []
+    real_replace = reconcile.os.replace
+
+    def spy_replace(src, dst):
+        calls.append((Path(src), Path(dst)))
+        real_replace(src, dst)
+
+    monkeypatch.setattr(reconcile.os, "replace", spy_replace)
+
+    reconcile.atomic_write(target, "updated\n")
+
+    assert target.read_text(encoding="utf-8") == "updated\n"
+    assert calls[0][1] == target
+    assert calls[0][0].parent == target.parent
+
+
+def test_json_shape_snapshot(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("NANO_GPT_API_KEY", "key")
+    monkeypatch.setattr(
+        reconcile,
+        "reconcile",
+        lambda options: {
+            "status": "success",
+            "drift_count": 0,
+            "reconciled_count": 0,
+            "failed": [],
+            "cost_tokens": 0,
+            "last_sync_ref_old": None,
+            "last_sync_ref_new": "abc123",
+        },
+    )
+
+    exit_code = reconcile.main(["--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert list(payload) == [
+        "cost_tokens",
+        "drift_count",
+        "failed",
+        "last_sync_ref_new",
+        "last_sync_ref_old",
+        "reconciled_count",
+        "status",
+    ]

--- a/.xtrm/skills/default/service-skills/scripts/tests/test_reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/tests/test_reconcile.py
@@ -136,3 +136,48 @@ def test_json_shape_snapshot(tmp_path, monkeypatch, capsys):
         "reconciled_count",
         "status",
     ]
+
+
+def test_escaped_skill_path_fails_without_write(tmp_path, monkeypatch):
+    source_path = tmp_path / "src/alpha.py"
+    escaped_path = tmp_path.parent / "escape.md"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text("print('alpha')\n", encoding="utf-8")
+    escaped_path.write_text("outside\n", encoding="utf-8")
+    monkeypatch.setattr(reconcile, "get_project_root", lambda: str(tmp_path))
+    monkeypatch.setattr(reconcile, "load_registry", lambda root: {"services": {"alpha": {"skill_path": "../escape.md"}}})
+    monkeypatch.setattr(reconcile, "scan_drift", lambda *args, **kwargs: [{"service_id": "alpha", "file_path": "src/alpha.py"}])
+    monkeypatch.setattr(reconcile, "call_nano_gpt", lambda prompt, api_key: pytest.fail("API should not be called"))
+
+    result = reconcile.reconcile(reconcile.ReconcileOptions(False, None, "key", None))
+
+    assert result["status"] == "partial"
+    assert result["reconciled_count"] == 0
+    assert "skill_path escapes project root" in result["failed"][0]["error"]
+    assert escaped_path.read_text(encoding="utf-8") == "outside\n"
+
+
+def test_invalid_nano_gpt_url_fails_at_startup(monkeypatch, capsys):
+    monkeypatch.setenv("NANO_GPT_API_KEY", "key")
+    monkeypatch.setenv("NANO_GPT_API_URL", "http://evil.com/x")
+    monkeypatch.setattr(reconcile, "reconcile", lambda options: pytest.fail("reconcile should not run"))
+
+    exit_code = reconcile.main(["--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert payload["status"] == "failed"
+    assert "NANO_GPT_API_URL must use https" in payload["failed"][0]["error"]
+
+
+def test_nano_gpt_url_rejects_secret_query_params():
+    with pytest.raises(ValueError, match="secret query"):
+        reconcile.validate_nano_gpt_url("https://nano-gpt.com/api?api_key=secret")
+
+
+def test_redact_exception_masks_bearer_and_api_key():
+    error = reconcile.redact_exception(RuntimeError("failed Bearer secret-token api-secret"), "api-secret")
+
+    assert "secret-token" not in error
+    assert "api-secret" not in error
+    assert "Bearer [REDACTED]" in error


### PR DESCRIPTION
## Summary

- Adds `.xtrm/skills/default/service-skills/scripts/reconcile.py` — zero-install Python reconciler for service-skills drift on GitHub Actions runners.
- 11 unit tests under `scripts/tests/test_reconcile.py` (prompt build, response parse, cost cap halt, missing key exit, dry-run, atomic write, JSON snapshot, path traversal rejection, URL allowlist, exception redaction).
- This is **Phase B step 1** of 7. The workflow that calls this script (Phase B step 2) is the next sibling bead (xtrm-pm5d8.2).

## Architecture

Researcher verdict (bead xtrm-stwyc) rejected sp-on-runner (pack resolution + 4-layer install stack) and selected **R4 direct Python + A1 per-repo NANO_GPT_API_KEY + O2 auto-PR**. This PR ships the R4 piece.

```
drift_detector.scan_drift(use_gitnexus=False)  →  build_prompt  →  httpx.post nano-gpt (Bearer header)  →  atomic SKILL.md write  →  bump last_sync_ref
```

JSON output: `{status, drift_count, reconciled_count, failed[], cost_tokens, last_sync_ref_old, last_sync_ref_new}`.
Exit codes: `0=success, 1=partial/failed reconcile, 2=missing NANO_GPT_API_KEY`.

## Security hardening (audit job 2dcf6a)

- `skill_path` containment via `Path.resolve().is_relative_to(project_root)` — rejects `../` and absolute paths into `result['failed']`.
- nano-gpt URL allowlist (https-only, hostname=`nano-gpt.com`, no `api_key`/`key`/`token` query params).
- `redact_exception(exc)` strips `Bearer\\s+\\S+` patterns before exception text enters JSON output.
- Cost cap (`XTRM_AUTO_RECONCILE_COST_LIMIT_TOKENS`) pre-flight + post-flight.
- Prompt-injection from source files is **accepted-by-design** — every reconciled SKILL.md goes through O2 auto-PR review (next bead).

## Test plan

- [x] `pytest -q .xtrm/skills/default/service-skills/scripts/tests/test_reconcile.py` → 11 passed (reviewer fad2eb confirmed)
- [x] Reviewer PASS with clean Release Checklist (job fad2eb, bead xtrm-pm5d8.11)
- [x] Security audit findings applied (job 2dcf6a, bead xtrm-pm5d8.9)
- [x] Obligations scan CLEAN (job aa94db, bead xtrm-pm5d8.10)
- [ ] End-to-end smoke on mercury-infra — sibling bead xtrm-pm5d8.4

## Refs

- Bead: xtrm-pm5d8.1 (parent xtrm-pm5d8 / epic xtrm-lwpcn)
- Memory: `reconcile-runner-script-shape-2026-06-22`, `phase-b-architecture-verdict-2026-06-22`
- Researcher verdict: xtrm-stwyc

🤖 Generated with [Claude Code](https://claude.com/claude-code)