### PR TITLE
feat(service-skills): Phase B workflow extension — auto-reconcile + concurrency (xtrm-pm5d8.2)

### DIFF
--- a/.github/workflows/service-skills-drift-sweep.yml
+++ b/.github/workflows/service-skills-drift-sweep.yml
@@ -9,9 +9,8 @@ name: Service-Skills Drift Sweep
 #         pull-requests: write
 #
 # Triggers on the CALLER side (typical: pull_request.closed + merged true).
-# Phase A: detect-only; on drift, post a sticky comment on the merged PR with
-# the summary and the reconcile instruction. Phase B (sp script auto-reconcile
-# on the runner) is tracked under xtrm-lwpcn.
+# Default behavior remains detect-only; on drift, post a sticky comment on the merged PR with
+# the summary and the reconcile instruction. Optional reconcile mode opens an auto-PR.
 
 on:
   workflow_call:
@@ -27,6 +26,18 @@ on:
         description: 'Marker used to find/update an existing comment on the PR'
         type: string
         default: '<!-- service-skills-drift-sweep -->'
+      reconcile-enabled:
+        description: 'Run service-skills auto-reconcile and open a PR when drift exists'
+        type: boolean
+        default: false
+    secrets:
+      nano-gpt-api-key:
+        description: 'nano-gpt API key for service-skills auto-reconcile'
+        required: false
+
+concurrency:
+  group: service-skills-drift-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   drift-sweep:
@@ -34,6 +45,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    outputs:
+      drift-count: ${{ steps.drift.outputs.drift_count }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,6 +110,17 @@ jobs:
           PY
           cat /tmp/drift-summary.md
 
+      - name: Upload drift artifacts
+        if: steps.drift.outputs.drift_count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: service-skills-drift
+          path: |
+            /tmp/drift.json
+            /tmp/drift-summary.md
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Find existing drift-sweep comment
         id: find_comment
         if: steps.drift.outputs.drift_count != '0' && github.event_name == 'pull_request'
@@ -120,3 +144,108 @@ jobs:
         run: |
           echo "::warning::service-skills drift detected (${{ steps.drift.outputs.drift_count }} file(s)) — caller event was '${{ github.event_name }}', no PR to comment on. See run summary."
           cat /tmp/drift-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Annotate reconcile disabled
+        if: steps.drift.outputs.drift_count != '0' && inputs['reconcile-enabled'] == false
+        run: echo "::notice::service-skills auto-reconcile disabled; Phase A drift comment behavior preserved"
+
+      - name: Annotate reconcile missing secret
+        if: steps.drift.outputs.drift_count != '0' && inputs['reconcile-enabled']
+        env:
+          NANO_GPT_API_KEY: ${{ secrets['nano-gpt-api-key'] }}
+        run: |
+          if [ -z "$NANO_GPT_API_KEY" ]; then
+            echo "::warning::service-skills auto-reconcile skipped because nano-gpt-api-key secret is absent; Phase A drift comment behavior preserved"
+          fi
+
+  auto-reconcile:
+    needs: drift-sweep
+    if: needs['drift-sweep'].outputs['drift-count'] != '0' && inputs['reconcile-enabled']
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Download drift artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: service-skills-drift
+          path: /tmp/service-skills-drift
+
+      - name: Reconcile drift
+        id: reconcile
+        env:
+          NANO_GPT_API_KEY: ${{ secrets['nano-gpt-api-key'] }}
+        run: |
+          set +e
+          if [ -z "$NANO_GPT_API_KEY" ]; then
+            echo "::warning::service-skills auto-reconcile skipped because nano-gpt-api-key secret is absent; Phase A drift comment behavior preserved"
+            echo 'status=missing_secret' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 -m pip install --disable-pip-version-check --no-input httpx
+          install_status=$?
+          if [ "$install_status" -ne 0 ]; then
+            echo "::warning::service-skills auto-reconcile skipped because httpx install failed with exit $install_status; Phase A drift comment behavior preserved"
+            echo 'status=failed' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 .xtrm/skills/default/service-skills/scripts/reconcile.py --json > /tmp/reconcile-result.json
+          reconcile_status=$?
+          if [ "$reconcile_status" -ne 0 ]; then
+            echo "::warning::service-skills auto-reconcile skipped because reconcile.py exited $reconcile_status; Phase A drift comment behavior preserved"
+            echo 'status=failed' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python3 - <<'PYOUT' >> "$GITHUB_OUTPUT"
+          import json
+          result = json.load(open('/tmp/reconcile-result.json'))
+          print(f"status={result.get('status', 'unknown')}")
+          print(f"reconciled_count={result.get('reconciled_count', 0)}")
+          PYOUT
+          python3 - <<'PYANN'
+          import json
+          result = json.load(open('/tmp/reconcile-result.json'))
+          status = result.get('status', 'unknown')
+          reconciled_count = int(result.get('reconciled_count', 0) or 0)
+          if status == 'success' and reconciled_count > 0:
+              raise SystemExit(0)
+          reason = 'cost cap hit' if status == 'cost_cap_hit' else f'status={status}, reconciled_count={reconciled_count}'
+          print(f"::warning::service-skills auto-reconcile produced no PR because {reason}; Phase A drift comment behavior preserved")
+          PYANN
+
+      - name: Build auto-PR body
+        if: steps.reconcile.outputs.status == 'success' && steps.reconcile.outputs.reconciled_count != '0'
+        run: |
+          {
+            echo '## Auto-reconcile summary'
+            echo
+            echo '```json'
+            python3 -m json.tool /tmp/reconcile-result.json
+            echo '```'
+            echo
+            echo '## Drift findings'
+            echo
+            cat /tmp/service-skills-drift/drift-summary.md
+          } > /tmp/reconcile-pr-body.md
+
+      - name: Open auto-reconcile PR
+        if: steps.reconcile.outputs.status == 'success' && steps.reconcile.outputs.reconciled_count != '0'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: xtrm-auto-reconcile/${{ github.sha }}
+          commit-message: 'chore(service-skills): auto-reconcile drift [skip ci]'
+          title: 'auto-reconcile: service-skills drift post-merge'
+          body-path: /tmp/reconcile-pr-body.md
+          labels: auto-reconcile, service-skills
+          delete-branch: true

--- a/.github/workflows/service-skills-drift-sweep.yml
+++ b/.github/workflows/service-skills-drift-sweep.yml
@@ -160,8 +160,9 @@ jobs:
 
   auto-reconcile:
     needs: drift-sweep
-    if: needs['drift-sweep'].outputs['drift-count'] != '0' && inputs['reconcile-enabled']
+    if: needs['drift-sweep'].outputs['drift-count'] != '0' && inputs['reconcile-enabled'] && !startsWith(github.event.pull_request.head.ref, 'xtrm-auto-reconcile/') && github.event.pull_request.user.login != 'github-actions[bot]'
     runs-on: ubuntu-latest
+    # Accepted blast radius: checkout pulls trusted post-merge main; pip install is now pinned (FIX A); reconcile.py is in-repo. Future hardening: split into read-only reconcile + write-only PR open. Tracked under xtrm-pm5d8 follow-up.
     permissions:
       contents: write
       pull-requests: write
@@ -193,7 +194,7 @@ jobs:
             echo 'status=missing_secret' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 -m pip install --disable-pip-version-check --no-input httpx
+          python3 -m pip install --disable-pip-version-check --no-input httpx==0.28.1
           install_status=$?
           if [ "$install_status" -ne 0 ]; then
             echo "::warning::service-skills auto-reconcile skipped because httpx install failed with exit $install_status; Phase A drift comment behavior preserved"
@@ -241,7 +242,7 @@ jobs:
 
       - name: Open auto-reconcile PR
         if: steps.reconcile.outputs.status == 'success' && steps.reconcile.outputs.reconciled_count != '0'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7 — pinned to SHA per ossf scorecard
         with:
           branch: xtrm-auto-reconcile/${{ github.sha }}
           commit-message: 'chore(service-skills): auto-reconcile drift [skip ci]'


### PR DESCRIPTION
## Summary

Extends the Phase A reusable workflow `.github/workflows/service-skills-drift-sweep.yml` with optional auto-reconcile (Phase B step 2 of 7).

- `reconcile-enabled` input (default false → fully backward-compatible).
- `nano-gpt-api-key` secret (workflow_call secrets, required: false).
- `concurrency: service-skills-drift-${{ github.ref }}` + `cancel-in-progress: false` (queue, don't cancel).
- New `auto-reconcile` job: gated on drift + opt-in + anti-loop; calls `reconcile.py` and opens auto-PR via peter-evans/create-pull-request.
- Phase A detect+comment behavior preserved verbatim when reconcile-enabled=false.

## Architecture

```
drift-sweep job (Phase A: detect + sticky comment, unchanged when reconcile disabled)
  └─ upload-artifact: /tmp/drift.json + /tmp/drift-summary.md
        ↓
auto-reconcile job (Phase B: gated on opt-in + drift > 0 + anti-loop guard)
  └─ pip install httpx==0.28.1 → reconcile.py --json → peter-evans/create-pull-request@<v7-SHA>
        ↓
xtrm-auto-reconcile/<sha> branch → auto-PR for human review (O2 design)
```

Failure path (secret absent / pip fail / reconcile exit≠0 / reconciled_count==0): falls back to Phase A behavior with explicit annotation, exit 0.

## Security hardening (audit job 8d3365)

- **WF-002 fix**: `httpx==0.28.1` pinned (was floating).
- **WF-003 fix**: peter-evans/create-pull-request SHA-pinned to `22a9089034f40e5a961c8808d113e2c98fb63676` (v7).
- **WF-004 fix**: anti-loop guard — skip when triggering PR head starts with `xtrm-auto-reconcile/` or actor is `github-actions[bot]`.
- **WF-001 accepted-by-design**: split read-only/write-only jobs deferred; blast radius bounded (trusted post-merge main, pinned deps, in-repo reconcile.py). Future hardening tracked under xtrm-pm5d8.

## Test plan

- [x] YAML `safe_load` parses clean
- [x] Reviewer PASS with clean Release Checklist (job f1628a, bead xtrm-pm5d8.15)
- [x] Security audit findings applied (job 8d3365, bead xtrm-pm5d8.13)
- [x] Obligations scan CLEAN (job 7856a6, bead xtrm-pm5d8.14)
- [ ] Live `workflow_dispatch` smoke on mercury-infra — sibling beads xtrm-pm5d8.{4,5,6}

## Refs

- Bead: xtrm-pm5d8.2 (parent xtrm-pm5d8 / epic xtrm-lwpcn)
- Memory: `workflow-phase-b-reconcile-shape-2026-06-22`, `reconcile-runner-script-shape-2026-06-22`, `phase-b-architecture-verdict-2026-06-22`
- Depends on PR #300 (merged): reconcile.py + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)