### PR TITLE
docs(service-skills): promote 'xt update --apply' to Step 0 of Phase B enablement

### DIFF
--- a/docs/service-skills-auto-reconcile.md
+++ b/docs/service-skills-auto-reconcile.md
@@ -36,6 +36,16 @@ The reconcile script lives in the consumer repo at
 
 ## Per-repo enablement
 
+### 0. Vendor the reconcile script (do this first)
+
+The reusable workflow runs `python3 .xtrm/skills/default/service-skills/scripts/reconcile.py` against the consumer repo's working tree. Make sure that file is present and current before opting in:
+
+```sh
+xt update --apply
+```
+
+If the consumer repo's `.xtrm/skills/default/service-skills/scripts/` only contains `drift_detector.py` (older snapshot), Step 1+ will succeed but the auto-reconcile job will exit 2 with `No such file or directory`. Re-run `xt update --apply` whenever `xtrm-tools` ships changes to that directory.
+
 ### 1. Configure the API key secret
 
 ```sh


### PR DESCRIPTION
## Summary

Surfaced during Smoke 1 on mercury-infra (action run 27970585002): mercury-infra had an older xtrm-tools snapshot, so the auto-reconcile job exited 2 (`No such file or directory` for `reconcile.py`).

The docs only mentioned `xt update --apply` in the troubleshooting row — too late. This PR promotes it to **Step 0** of the enablement procedure so the trap is visible up front.

## Test plan

- [x] docs change only; no code touched
- [ ] verified by re-running Smoke 1 after `xt update --apply` on mercury-infra (pane 1 PR #115 vendoring the script — covers the same root cause)

## Refs

- Bead: xtrm-pm5d8.4 (Smoke 1)
- Discovered by: action run 27970585002 on mercuryintelligence/mercury-infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)