### PR TITLE
fix(service-skills): expose reconcile.py failure JSON + stderr (xtrm-pm5d8.4)

### DIFF
--- a/.github/workflows/service-skills-drift-sweep.yml
+++ b/.github/workflows/service-skills-drift-sweep.yml
@@ -201,10 +201,16 @@ jobs:
             echo 'status=failed' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 .xtrm/skills/default/service-skills/scripts/reconcile.py --json > /tmp/reconcile-result.json
+          python3 .xtrm/skills/default/service-skills/scripts/reconcile.py --json > /tmp/reconcile-result.json 2> /tmp/reconcile-stderr.log
           reconcile_status=$?
           if [ "$reconcile_status" -ne 0 ]; then
             echo "::warning::service-skills auto-reconcile skipped because reconcile.py exited $reconcile_status; Phase A drift comment behavior preserved"
+            echo "::group::reconcile.py stdout JSON"
+            cat /tmp/reconcile-result.json || echo '(stdout JSON file missing)'
+            echo "::endgroup::"
+            echo "::group::reconcile.py stderr"
+            cat /tmp/reconcile-stderr.log || echo '(stderr log missing)'
+            echo "::endgroup::"
             echo 'status=failed' >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -224,6 +230,17 @@ jobs:
           reason = 'cost cap hit' if status == 'cost_cap_hit' else f'status={status}, reconciled_count={reconciled_count}'
           print(f"::warning::service-skills auto-reconcile produced no PR because {reason}; Phase A drift comment behavior preserved")
           PYANN
+
+      - name: Upload reconcile diagnostic artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: service-skills-reconcile-result
+          path: |
+            /tmp/reconcile-result.json
+            /tmp/reconcile-stderr.log
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Build auto-PR body
         if: steps.reconcile.outputs.status == 'success' && steps.reconcile.outputs.reconciled_count != '0'


### PR DESCRIPTION
## Summary

Smoke 1 retry on mercury-infra (run 27971070832) had `reconcile.py` exit 1 (status != success) and the workflow short-circuited **without surfacing the result JSON**. Diagnosis was blocked.

This PR adds:

- Stderr capture: `2> /tmp/reconcile-stderr.log` on the python call.
- Failure-branch log groups: `::group::reconcile.py stdout JSON` + stderr — both `cat`'d into the GH Actions log so they survive scroll.
- `always()` upload-artifact step `service-skills-reconcile-result` covering both files with 7-day retention.

No behavior change on the success path. Logs + artifacts only.

## Test plan

- [x] `yaml.safe_load` passes locally
- [ ] Re-run smoke 1 on mercury-infra after this lands; reconcile.py JSON + stderr surface in failure-path logs and as artifact for pane 1 to triage

## Refs

- Bead: xtrm-pm5d8.4
- Discovered by: pane 1 via action run 27971070832

🤖 Generated with [Claude Code](https://claude.com/claude-code)