### PR TITLE
KAN-110-A: Fix serena-pool cwd-race in registerSerenaPool

### DIFF
--- a/packages/pi-extensions/extensions/serena-pool/index.ts
+++ b/packages/pi-extensions/extensions/serena-pool/index.ts
@@ -371,6 +371,8 @@ export const __internals = {
   getProcessStartTime,
   findProcessesByPgid,
   getRepoRoot,
+  isInsideGitRepo,
+  resolveSessionCwd,
   readState,
   writeState,
   removeState,
@@ -379,9 +381,51 @@ export const __internals = {
 };
 export type { PoolState };
 
+/** True when `cwd` is inside a git work tree (cheap synchronous probe). */
+function isInsideGitRepo(cwd: string): boolean {
+  try {
+    return (
+      execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+        cwd,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim() === "true"
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the cwd to bind the Serena daemon to.
+ *
+ * Why: pi's ctx.cwd is captured at session_start emission and can be a stale
+ * snapshot — most notably the parent repo when session_start fires before
+ * pi's own cwd has settled into the linked worktree the session actually runs
+ * in. The launcher (cli worktree-session) spawns pi with `cwd: worktreePath`,
+ * so `process.cwd()` is the live ground truth. The old `ctx?.cwd ??
+ * process.cwd()` form silently trusted a stale ctx.cwd because `??` only
+ * falls through on nullish — never when ctx.cwd is present-but-wrong. That
+ * produced a wrong hashToPort → daemon bound to the parent repo's --project →
+ * the next correct-cwd session found no listener on its expected port and
+ * spawned a SECOND daemon, leaving the first as an orphan (KAN-110-A).
+ *
+ * Resolution: when ctx.cwd and the live cwd disagree, trust the live cwd only
+ * if it is itself inside a git work tree — so we never bind the daemon to an
+ * unrelated process.cwd() (e.g. a test runner in /tmp). getRepoRoot then maps
+ * the worktree cwd to its true toplevel via `git rev-parse --show-toplevel`,
+ * which already returns the linked-worktree root, not the common dir.
+ */
+function resolveSessionCwd(ctxCwd: string | undefined): string {
+  const procCwd = process.cwd();
+  if (!ctxCwd) return procCwd;
+  if (ctxCwd === procCwd) return ctxCwd;
+  return isInsideGitRepo(procCwd) ? procCwd : ctxCwd;
+}
+
 export default function registerSerenaPool(pi: ExtensionAPI) {
   pi.on("session_start", async (_event: unknown, ctx: any) => {
-    const cwd: string = ctx?.cwd ?? process.cwd();
+    const cwd: string = resolveSessionCwd(ctx?.cwd);
     let projectRoot: string;
     try {
       projectRoot = getRepoRoot(cwd);

--- a/packages/pi-extensions/extensions/serena-pool/test/e2e.ts
+++ b/packages/pi-extensions/extensions/serena-pool/test/e2e.ts
@@ -8,21 +8,25 @@
  *
  * Requires: `uvx` on PATH (the real Serena spawn path is exercised).
  *
- * Five scenarios:
+ * Six scenarios:
  *   1. cold start         — clean slate → spawn, port listens, state written
  *   2. warm reuse         — second call → same pid, same state
  *   3. dead recovery      — kill Serena → next call spawns fresh
  *   4. synthetic orphans  — fake state pointing at a detached `sleep` group
  *                           with dead leader → cleanup kills group members
  *   5. concurrent spawn   — 5 parallel calls → exactly one Serena alive
+ *   6. cwd-race           — stale ctx.cwd (parent repo) vs live process.cwd()
+ *                           (linked worktree) → daemon binds to the worktree,
+ *                           no orphan against the parent. Uses real
+ *                           `git worktree add`.
  */
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readdirSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
-import {
+import registerSerenaPool, {
   ensureSerenaForRoot,
   STATE_DIR,
   __internals as I,
@@ -81,6 +85,29 @@ async function withTestRoot(fn: (root: string, port: number) => Promise<void>): 
     killSerenaForPort(port);
     rmSync(root, { recursive: true, force: true });
   }
+}
+
+function git(cwd: string, args: string[]): void {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed in ${cwd}: ${(r.stderr || "").trim()}`);
+  }
+}
+
+type SessionStartCtx = { cwd?: string };
+type SessionStartHandler = (event: unknown, ctx: SessionStartCtx) => Promise<void>;
+
+/** Register the extension against a fake pi and capture its session_start handler. */
+function captureSessionStartHandler(): SessionStartHandler {
+  let captured: SessionStartHandler | null = null;
+  const fakePi = {
+    on(event: string, handler: SessionStartHandler) {
+      if (event === "session_start") captured = handler;
+    },
+  };
+  registerSerenaPool(fakePi as never);
+  if (!captured) throw new Error("registerSerenaPool did not register a session_start handler");
+  return captured;
 }
 
 async function test1_coldStart(): Promise<void> {
@@ -197,6 +224,77 @@ async function test5_concurrentSpawn(): Promise<void> {
   });
 }
 
+async function test6_cwdRace(): Promise<void> {
+  header("6. cwd-race (stale ctx.cwd resolves to live worktree)");
+  // Reproduce KAN-110-A: registerSerenaPool fires session_start with a ctx.cwd
+  // captured stale as the parent repo, while pi's LIVE process.cwd() is the
+  // linked worktree the session is actually running in. Uses a REAL
+  // `git worktree add` (not a bare mkdtemp) so git's worktree semantics are
+  // exercised end-to-end.
+  const tmpBase = mkdtempSync(join(tmpdir(), "serena-pool-race-"));
+  const parent = join(tmpBase, "parent");
+  const worktreeAbs = join(tmpBase, "wt");
+  mkdirSync(parent, { recursive: true });
+
+  const spawnedPorts: number[] = [];
+  const prevCwd = process.cwd();
+  const prevEnvPort = process.env.SERENA_MCP_PORT;
+  try {
+    cleanState();
+    git(parent, ["init", "-q"]);
+    git(parent, ["config", "user.email", "serena-pool-e2e@xtrm.local"]);
+    git(parent, ["config", "user.name", "serena-pool e2e"]);
+    git(parent, ["commit", "--allow-empty", "-q", "-m", "init"]);
+    // REAL linked worktree — git creates worktreeAbs.
+    git(parent, ["worktree", "add", "-q", worktreeAbs]);
+
+    const parentReal = realpathSync(parent);
+    const worktreeReal = realpathSync(worktreeAbs);
+    const expectedPort = I.hashToPort(worktreeReal);
+    const parentPort = I.hashToPort(parentReal);
+    spawnedPorts.push(expectedPort, parentPort);
+    assert(
+      expectedPort !== parentPort,
+      `worktree port (${expectedPort}) differs from parent port (${parentPort})`,
+    );
+
+    // Simulate the race: pi's LIVE cwd is the worktree (launcher guarantee),
+    // but ctx.cwd was captured stale as the parent repo.
+    process.chdir(worktreeReal);
+    const handler = captureSessionStartHandler();
+    await handler({}, { cwd: parentReal });
+
+    const state = I.readState(expectedPort);
+    assert(state != null, "state written at the worktree's port (not the parent's)");
+    assert(
+      state != null && state.projectRoot === worktreeReal,
+      `daemon --project === worktree root (got ${state?.projectRoot})`,
+    );
+    assert(
+      state != null && state.projectRoot !== parentReal,
+      "daemon --project is NOT the stale parent repo",
+    );
+    assert(state != null && I.isPidAlive(state.pid), "spawned Serena pid alive");
+
+    // No orphan daemon bound to the stale parent's port.
+    const orphan = I.readState(parentPort);
+    assert(orphan == null, "no daemon state written against the stale parent port");
+
+    // Env wiring reflects the worktree port.
+    assert(
+      process.env.SERENA_MCP_PORT === String(expectedPort),
+      `SERENA_MCP_PORT wired to worktree port ${expectedPort}`,
+    );
+  } finally {
+    for (const p of spawnedPorts) killSerenaForPort(p);
+    try { process.chdir(prevCwd); } catch { /* ignore */ }
+    try { git(parent, ["worktree", "remove", "--force", worktreeAbs]); } catch { /* parent may be gone */ }
+    rmSync(tmpBase, { recursive: true, force: true });
+    if (prevEnvPort === undefined) delete process.env.SERENA_MCP_PORT;
+    else process.env.SERENA_MCP_PORT = prevEnvPort;
+  }
+}
+
 async function main(): Promise<void> {
   console.log("serena-pool e2e driver\n");
   if (!preflight()) process.exit(2);
@@ -207,6 +305,7 @@ async function main(): Promise<void> {
     test3_deadDaemonRecovery,
     test4_syntheticOrphanCleanup,
     test5_concurrentSpawn,
+    test6_cwdRace,
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
Implements **KAN-110-A** ([Jira](https://xtrmxt.atlassian.net/browse/KAN-110)) — delivers the IDE-style single-LSP behavior Dawid asked for in [comment 10390](https://xtrmxt.atlassian.net/browse/KAN-110?focusedCommentId=10390).

## What this fixes
`registerSerenaPool` used `ctx?.cwd ?? process.cwd()`. The `??` short-circuits on a stale-but-present `ctx.cwd` (parent repo) when `session_start` fires before pi's cwd settles into the linked worktree. Wrong cwd → wrong `hashToPort` → daemon bound to parent `--project` → next correct-cwd session spawns a second daemon and orphans the first.

## How
**Plan B2 (refined): cwd reconciliation.** New `resolveSessionCwd` reconciles `ctx.cwd` with the live `process.cwd()`. On disagreement it trusts `process.cwd()` only when that cwd is itself inside a git work-tree (`isInsideGitRepo`), so an unrelated `process.cwd()` (e.g. a test runner in `/tmp`) never wins. The CLI worktree-session launcher already guarantees `process.cwd() === worktreePath` at `session_start`, so this is the canonical reconciliation.

`getRepoRoot` unchanged — already returns the linked-worktree toplevel via `git rev-parse --show-toplevel`.

## Test plan
- [x] New `test6_cwdRace` uses a REAL `git worktree add`: chdir into the worktree, fire `session_start` with stale `ctx.cwd=parent`, assert daemon `--project === worktreeRoot` and no orphan state on the parent port.
- [x] All 6 e2e tests green (27/27 assertions).
- [x] Reviewer specialist PASS (96/100): re-ran full suite herself, scope verified, forbidden symbols untouched.
- [x] `tsc --noEmit` clean (no new errors; pre-existing external-module import unchanged).

## Scope
- `packages/pi-extensions/extensions/serena-pool/index.ts` — `+46/-4`
- `packages/pi-extensions/extensions/serena-pool/test/e2e.ts` — `+105/-0`
- `getRepoRoot`, `ensureSerenaForRoot`, `spawnSerena`, `hashToPort` **not touched** (R3 verified all correct).
- `.pi/mcp.json` and `config/pi.mcp.json` **not touched** (R1 proved Path B harmful).

## Out of scope (deferred to follow-on tickets, per R3)
- `hashToPort` collision detection (proposed KAN-110-D)
- `isPortListening` HTTP probe upgrade (proposed KAN-110-E)
- Pyright multi-root (Phase 4 — unblocked by this fix, separate scope)
- Upstream Serena PR (Phase 5 — R2 proved not needed)

## Backing research
Four reports landed in this session (R1 xtrm-side map, R2 Serena upstream, R3 synthesis, R4 token efficiency). Available locally at `.xtrm/reports/2026-06-22-r{1,2,3,4}-*.md` for anyone reviewing this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)