### PR TITLE
fix(service-skills): pass NANO_GPT_MODEL + NANO_GPT_API_URL to reconcile.py (xtrm-pm5d8.4)

### DIFF
--- a/.github/workflows/service-skills-drift-sweep.yml
+++ b/.github/workflows/service-skills-drift-sweep.yml
@@ -30,6 +30,14 @@ on:
         description: 'Run service-skills auto-reconcile and open a PR when drift exists'
         type: boolean
         default: false
+      nano-gpt-model:
+        description: 'nano-gpt model id for reconcile.py (NANO_GPT_MODEL). Must match an exact id from the nano-gpt /v1/models catalog. Subscription-covered example: moonshotai/kimi-k2.6:thinking'
+        type: string
+        default: 'moonshotai/kimi-k2.6:thinking'
+      nano-gpt-api-url:
+        description: 'nano-gpt chat-completions endpoint (NANO_GPT_API_URL). Override only to switch base path (e.g. /api/subscription/v1). Hostname is locked to nano-gpt.com.'
+        type: string
+        default: 'https://nano-gpt.com/api/v1/chat/completions'
     secrets:
       nano-gpt-api-key:
         description: 'nano-gpt API key for service-skills auto-reconcile'
@@ -187,6 +195,8 @@ jobs:
         id: reconcile
         env:
           NANO_GPT_API_KEY: ${{ secrets['nano-gpt-api-key'] }}
+          NANO_GPT_MODEL: ${{ inputs['nano-gpt-model'] }}
+          NANO_GPT_API_URL: ${{ inputs['nano-gpt-api-url'] }}
         run: |
           set +e
           if [ -z "$NANO_GPT_API_KEY" ]; then


### PR DESCRIPTION
## Summary

Smoke 1 on mercury-infra kept failing (`reconcile.py` exit 1) because the default model `gpt-4o-mini` isn't covered by the operator's nano-gpt subscription.

Direct curl evidence: `model=moonshotai/kimi-k2.6:thinking` → HTTP 200, `cost=0`, subscription-covered. The exact id matters (variants like `kimi-k2.6`, `kimi-k2.5` 401).

This PR adds two reusable-workflow inputs:

- `nano-gpt-model` (default `moonshotai/kimi-k2.6:thinking`)
- `nano-gpt-api-url` (default `https://nano-gpt.com/api/v1/chat/completions`)

Both are forwarded to `reconcile.py` via the `env:` block on the "Reconcile drift" step. `reconcile.py` already reads `NANO_GPT_MODEL` + `NANO_GPT_API_URL` from env with the same defaults, so backward-compatible. Security guardrail (URL allowlist) in reconcile.py still pins hostname to `nano-gpt.com` regardless of caller override.

## Test plan

- [x] YAML `safe_load` passes
- [x] Direct curl with model `moonshotai/kimi-k2.6:thinking` returns HTTP 200 (cost=0) via subscription
- [ ] Re-run smoke 1 on mercury-infra after merge; expect successful reconcile + auto-PR

## Refs

- Bead: xtrm-pm5d8.4
- Discovered by: smoke 1 retries 1-3 on mercury-infra; resolution via direct nano-gpt probe per operator hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)