### PR TITLE
fix(service-skills): kimi-friendly httpx timeout + open auto-PR on partial (xtrm-pm5d8.4)

### DIFF
--- a/.github/workflows/service-skills-drift-sweep.yml
+++ b/.github/workflows/service-skills-drift-sweep.yml
@@ -235,7 +235,10 @@ jobs:
           result = json.load(open('/tmp/reconcile-result.json'))
           status = result.get('status', 'unknown')
           reconciled_count = int(result.get('reconciled_count', 0) or 0)
-          if status == 'success' and reconciled_count > 0:
+          if status in ('success', 'partial') and reconciled_count > 0:
+              if status == 'partial':
+                  failed = result.get('failed') or []
+                  print(f"::notice::service-skills auto-reconcile partial: reconciled {reconciled_count} file(s); {len(failed)} failed (auto-PR will open with the reconciled subset; failed files stay as drift for the next merge)")
               raise SystemExit(0)
           reason = 'cost cap hit' if status == 'cost_cap_hit' else f'status={status}, reconciled_count={reconciled_count}'
           print(f"::warning::service-skills auto-reconcile produced no PR because {reason}; Phase A drift comment behavior preserved")
@@ -253,7 +256,7 @@ jobs:
           retention-days: 7
 
       - name: Build auto-PR body
-        if: steps.reconcile.outputs.status == 'success' && steps.reconcile.outputs.reconciled_count != '0'
+        if: (steps.reconcile.outputs.status == 'success' || steps.reconcile.outputs.status == 'partial') && steps.reconcile.outputs.reconciled_count != '0'
         run: |
           {
             echo '## Auto-reconcile summary'
@@ -268,7 +271,7 @@ jobs:
           } > /tmp/reconcile-pr-body.md
 
       - name: Open auto-reconcile PR
-        if: steps.reconcile.outputs.status == 'success' && steps.reconcile.outputs.reconciled_count != '0'
+        if: (steps.reconcile.outputs.status == 'success' || steps.reconcile.outputs.status == 'partial') && steps.reconcile.outputs.reconciled_count != '0'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7 — pinned to SHA per ossf scorecard
         with:
           branch: xtrm-auto-reconcile/${{ github.sha }}

--- a/.xtrm/skills/default/service-skills/scripts/reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/reconcile.py
@@ -130,11 +130,12 @@ def call_nano_gpt(prompt: str, api_key: str) -> LlmResult:
         import httpx  # type: ignore[import-not-found]
     except ImportError as exc:
         raise RuntimeError("httpx is required for reconcile.py") from exc
+    timeout = int(os.environ.get("NANO_GPT_TIMEOUT_SECONDS", "300"))
     response = httpx.post(
         validate_nano_gpt_url(get_nano_gpt_url()),
         headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
         json={"model": NANO_GPT_MODEL, "messages": [{"role": "user", "content": prompt}]},
-        timeout=120,
+        timeout=timeout,
     )
     response.raise_for_status()
     return parse_llm_response(response.json())


### PR DESCRIPTION
## Summary

Smoke 1 retry 4 reconciled **9/11** files via kimi-k2.6:thinking. 2 calls hit httpx `ReadTimeout` (120s default too short for reasoning models on long SKILL.md inputs). Result: `status=partial` → previous workflow gate refused to open auto-PR → 9 successful reconciles wasted.

### reconcile.py
- httpx timeout default raised 120 → **300s**
- Configurable via `NANO_GPT_TIMEOUT_SECONDS` env

### reusable workflow
- Auto-PR now opens on `status in ('success', 'partial')` when `reconciled_count > 0` — ships the reconciled subset
- `last_sync_ref` still only bumps on full success (reconcile.py path unchanged) so failed files stay as visible drift → natural retry on next merge
- Partial annotation upgraded to `::notice` listing reconciled + failed counts

11 unit tests still pass (mocks aren't affected by the timeout bump).

## Test plan

- [x] `yaml.safe_load` clean
- [x] `pytest -q test_reconcile.py` → 11 passed
- [ ] Smoke 1 retry 5 on mercury-infra: expect 9-11 reconciled, auto-PR opens with subset, last_sync_ref unchanged if any fail

## Refs

- Bead: xtrm-pm5d8.4
- Discovered by: smoke 1 retry 4 on mercuryintelligence/mercury-infra (run 27982547342)

🤖 Generated with [Claude Code](https://claude.com/claude-code)