### PR TITLE
fix(service-skills): exit 0 on partial+reconciled (xtrm-pm5d8.4)

### DIFF
--- a/.xtrm/skills/default/service-skills/scripts/reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/reconcile.py
@@ -250,7 +250,15 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:
         output = {"status": "failed", "drift_count": 0, "reconciled_count": 0, "failed": [{"file_path": None, "error": redact_exception(exc, api_key)}], "cost_tokens": 0, "last_sync_ref_old": None, "last_sync_ref_new": ""}
     print(json.dumps(output, sort_keys=True) if args.json else json.dumps(output, indent=2, sort_keys=True))
-    return 0 if output["status"] == "success" else 1
+    # Exit 0 when the program achieved useful work (full or partial reconcile).
+    # status field in the JSON carries the quality signal. Workflow gates on
+    # status + reconciled_count to decide auto-PR; downstream shell scripts
+    # that only check $? still get a clean signal for "anything reconciled".
+    if output["status"] == "success":
+        return 0
+    if output["status"] == "partial" and int(output.get("reconciled_count", 0) or 0) > 0:
+        return 0
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

PR #308 added a workflow gate that opens the auto-PR on `status==partial && reconciled_count>0`. That gate never fired because reconcile.py exited 1 on partial — the workflow's "Reconcile drift" step short-circuited on non-zero exit BEFORE writing `status=` to `GITHUB_OUTPUT`. Gate then saw `status=failed` (set by the failure branch) and skipped both Build/Open auto-PR steps.

Smoke 1 retry 5 evidence (run 27984030167): `status=partial, reconciled_count=8, failed=3` — those 8 successful reconciles got wasted.

## Fix

reconcile.py exits 0 when `status==partial AND reconciled_count>0` (the program achieved useful work). JSON `status` field still carries the quality signal for the workflow gate.

## Test plan

- [x] 11 unit tests still pass (no test asserted exit-1-on-partial as a contract)
- [ ] Smoke 1 retry 6 on mercury-infra: expect auto-PR materializes with the 8+ reconciled subset

## Refs

- Bead: xtrm-pm5d8.4
- Discovered by: pane 1 via smoke 1 retry 5 (run 27984030167)

🤖 Generated with [Claude Code](https://claude.com/claude-code)