### PR TITLE
fix(service-skills): bump last_sync timestamp on reconcile (xtrm-qxu4y)

### DIFF
--- a/.xtrm/skills/default/service-skills/scripts/reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/reconcile.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -170,6 +171,11 @@ def find_skill_path(drift: dict[str, Any], registry: dict[str, Any], project_roo
 
 
 def bump_last_sync_ref(project_root: Path, new_ref: str, dry_run: bool) -> str | None:
+    # Mirrors drift_detector.update_sync_time: bump BOTH last_sync_ref (SHA) AND
+    # last_sync (ISO timestamp). scan_drift compares file mtime against last_sync
+    # — bumping only the ref left the timestamp at the old value, so post-merge
+    # source file mtimes triggered drift on every subsequent merge (xtrm-qxu4y).
+    now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     registry = load_registry(str(project_root))
     services = registry.get("services", {})
     old_refs = [service.get("last_sync_ref") for service in services.values() if isinstance(service, dict)]
@@ -177,20 +183,23 @@ def bump_last_sync_ref(project_root: Path, new_ref: str, dry_run: bool) -> str |
     for service in services.values():
         if isinstance(service, dict):
             service["last_sync_ref"] = new_ref
+            service["last_sync"] = now_iso
     if not dry_run:
         save_registry(registry, str(project_root))
-        update_yaml_registry(project_root, new_ref)
+        update_yaml_registry(project_root, new_ref, now_iso)
     return old_ref
 
 
-def update_yaml_registry(project_root: Path, new_ref: str) -> None:
+def update_yaml_registry(project_root: Path, new_ref: str, new_sync_iso: str | None = None) -> None:
     for name in ("service-registry.yml", "service-registry.yaml"):
         path = project_root / name
         if not path.exists():
             continue
         text = path.read_text(encoding="utf-8")
-        updated = re.sub(r"(last_sync_ref:\s*)[^\n]*", rf"\g<1>{new_ref}", text)
-        atomic_write(path, updated)
+        text = re.sub(r"(last_sync_ref:\s*)[^\n]*", rf"\g<1>{new_ref}", text)
+        if new_sync_iso is not None:
+            text = re.sub(r"(last_sync:\s*)[^\n]*", rf"\g<1>{new_sync_iso}", text)
+        atomic_write(path, text)
 
 
 def reconcile(options: ReconcileOptions) -> dict[str, Any]:

--- a/.xtrm/skills/default/service-skills/scripts/tests/test_reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/tests/test_reconcile.py
@@ -138,6 +138,39 @@ def test_json_shape_snapshot(tmp_path, monkeypatch, capsys):
     ]
 
 
+def test_bump_last_sync_ref_also_bumps_timestamp_xtrm_qxu4y(tmp_path, monkeypatch):
+    """Regression: bump_last_sync_ref MUST bump both last_sync_ref AND last_sync.
+
+    Without the timestamp bump, scan_drift's mtime comparison kept tripping on
+    just-merged files (xtrm-qxu4y).
+    """
+    captured = {}
+
+    def fake_load(_root):
+        return {
+            "services": {
+                "alpha": {"last_sync": "2026-06-22T00:00:00Z", "last_sync_ref": "old-sha"},
+                "beta": {"last_sync": "2026-06-22T00:00:00Z", "last_sync_ref": "old-sha"},
+            }
+        }
+
+    def fake_save(registry, _root):
+        captured["registry"] = registry
+
+    monkeypatch.setattr(reconcile, "load_registry", fake_load)
+    monkeypatch.setattr(reconcile, "save_registry", fake_save)
+    monkeypatch.setattr(reconcile, "update_yaml_registry", lambda *a, **kw: None)
+
+    old_ref = reconcile.bump_last_sync_ref(tmp_path, "new-sha", dry_run=False)
+
+    assert old_ref == "old-sha"
+    for service in captured["registry"]["services"].values():
+        assert service["last_sync_ref"] == "new-sha"
+        # New timestamp must be different from the stored old one (i.e. bumped).
+        assert service["last_sync"] != "2026-06-22T00:00:00Z"
+        assert service["last_sync"].endswith("Z")
+
+
 def test_escaped_skill_path_fails_without_write(tmp_path, monkeypatch):
     source_path = tmp_path / "src/alpha.py"
     escaped_path = tmp_path.parent / "escape.md"


### PR DESCRIPTION
## Summary

`scan_drift` compares file mtime against `service.last_sync` (ISO timestamp), **not** `last_sync_ref` (SHA). `reconcile.py.bump_last_sync_ref` was bumping only the ref — so after admin-squash-merging an auto-PR, source file mtimes (now post-merge time) still tripped the mtime gate against the stale `last_sync`, producing a re-reconcile auto-PR after every merge of an auto-PR (non-convergence).

Observed: mercury-infra PR #130 admin-squash-merged 2026-06-23 01:06:07Z → PR #136 opened 34s later against the same 8 of 9 files. Closed #136 as superseded.

## Fix

`reconcile.bump_last_sync_ref` now bumps **both** `last_sync_ref` (SHA) and `last_sync` (now ISO) for every service — mirrors the canonical `drift_detector.update_sync_time`. `update_yaml_registry` also patched to update the `last_sync:` line when present (optional kwarg, backward-compatible).

## Test plan

- [x] 12/12 unit tests pass (added `test_bump_last_sync_ref_also_bumps_timestamp_xtrm_qxu4y` regression test)
- [ ] Mercury-infra re-vendors + next unrelated merge shows `drift_count=0` instead of a re-reconcile auto-PR

## Refs

- Bead: xtrm-qxu4y (discovered-from closed xtrm-pm5d8 Phase B epic)
- Memory: `drift-detector-mtime-vs-last-sync-2026-06-23`

🤖 Generated with [Claude Code](https://claude.com/claude-code)