### PR TITLE
fix(service-skills): --max-files truncation → partial + deferred entries (xtrm-vlxug)

### DIFF
--- a/.xtrm/skills/default/service-skills/scripts/reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/reconcile.py
@@ -207,8 +207,14 @@ def reconcile(options: ReconcileOptions) -> dict[str, Any]:
     registry = load_registry(str(project_root))
     drifted = scan_drift(str(project_root), enrich_with_gitnexus=False, use_gitnexus=False)
     selected = drifted[: options.max_files] if options.max_files is not None else drifted
+    truncated = len(selected) < len(drifted)
     result: dict[str, Any] = {
-        "status": "success",
+        # If --max-files truncated the drift list, the un-processed entries are
+        # deferred — call the run partial so bump_last_sync_ref is skipped and
+        # those services stay visible to the next scan_drift. Without this, all
+        # services' last_sync gets stamped to now and the deferred drift is
+        # silently masked (xtrm-vlxug, codex on mercury-infra PR #137).
+        "status": "partial" if truncated else "success",
         "drift_count": len(drifted),
         "reconciled_count": 0,
         "failed": [],
@@ -216,6 +222,12 @@ def reconcile(options: ReconcileOptions) -> dict[str, Any]:
         "last_sync_ref_old": None,
         "last_sync_ref_new": current_head(project_root),
     }
+    if truncated:
+        for skipped in drifted[len(selected):]:
+            result["failed"].append({
+                "file_path": skipped.get("file_path"),
+                "error": f"deferred: --max-files={options.max_files} truncated this entry",
+            })
     for drift in selected:
         try:
             skill_path_value = find_skill_path(drift, registry, project_root)

--- a/.xtrm/skills/default/service-skills/scripts/tests/test_reconcile.py
+++ b/.xtrm/skills/default/service-skills/scripts/tests/test_reconcile.py
@@ -138,6 +138,40 @@ def test_json_shape_snapshot(tmp_path, monkeypatch, capsys):
     ]
 
 
+def test_max_files_truncation_marks_partial_and_lists_deferred_xtrm_vlxug(tmp_path, monkeypatch):
+    """Regression: --max-files < drift_count must mark status=partial AND list
+    the un-processed entries in failed[], so bump_last_sync_ref is skipped and
+    the deferred drift stays visible to the next scan_drift (xtrm-vlxug)."""
+    skill_path = tmp_path / "skills/alpha/SKILL.md"
+    source_path = tmp_path / "src/alpha.py"
+    skill_path.parent.mkdir(parents=True)
+    source_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Alpha\nold\n", encoding="utf-8")
+    source_path.write_text("print('alpha')\n", encoding="utf-8")
+
+    drifts = [
+        {"service_id": "alpha", "file_path": "src/alpha.py", "skill_path": "skills/alpha/SKILL.md"},
+        {"service_id": "beta", "file_path": "src/beta.py", "skill_path": "skills/beta/SKILL.md"},
+        {"service_id": "gamma", "file_path": "src/gamma.py", "skill_path": "skills/gamma/SKILL.md"},
+    ]
+    monkeypatch.setattr(reconcile, "get_project_root", lambda: str(tmp_path))
+    monkeypatch.setattr(reconcile, "load_registry", lambda root: {"services": {d["service_id"]: {"skill_path": d["skill_path"]} for d in drifts}})
+    monkeypatch.setattr(reconcile, "scan_drift", lambda *args, **kwargs: drifts)
+    monkeypatch.setattr(reconcile, "current_head", lambda root: "new-sha")
+    monkeypatch.setattr(reconcile, "call_nano_gpt", lambda prompt, api_key: reconcile.LlmResult("# Updated\n", 10))
+    monkeypatch.setattr(reconcile, "bump_last_sync_ref", lambda *a, **kw: pytest.fail("bump_last_sync_ref MUST NOT be called when --max-files truncates the drift set"))
+
+    result = reconcile.reconcile(reconcile.ReconcileOptions(False, 1, "key", None))
+
+    assert result["status"] == "partial"
+    assert result["reconciled_count"] == 1
+    # The 2 truncated services must appear in failed[] with a deferred marker.
+    deferred = [f for f in result["failed"] if "deferred" in f.get("error", "")]
+    assert len(deferred) == 2
+    deferred_paths = sorted(f["file_path"] for f in deferred)
+    assert deferred_paths == ["src/beta.py", "src/gamma.py"]
+
+
 def test_bump_last_sync_ref_also_bumps_timestamp_xtrm_qxu4y(tmp_path, monkeypatch):
     """Regression: bump_last_sync_ref MUST bump both last_sync_ref AND last_sync.
 


### PR DESCRIPTION
## Summary

Codex review on mercury-infra PR #137 caught: when `--max-files=N` is smaller than `drift_count`, reconcile.py processed the first N items but `bump_last_sync_ref` stamped `last_sync = now` for **all** services in the registry. `scan_drift` gates on `mtime > last_sync`, so the un-processed drifted entries became invisible — silent masking.

## Fix

On truncation, mark `status='partial'` and append the un-processed entries to `failed[]` with `error='deferred: --max-files=N truncated this entry'`. The existing `reconcile()` guard (`reconciled_count and not partial`) then skips `bump_last_sync_ref`, so the deferred services stay visible to the next `scan_drift`.

No live damage at time of patch — no production caller uses `--max-files` yet — but the trap was real.

## Test plan

- [x] 13/13 unit tests pass (added regression `test_max_files_truncation_marks_partial_and_lists_deferred_xtrm_vlxug`)

## Refs

- Bead: xtrm-vlxug (discovered-from xtrm-qxu4y)
- Memory: `reconcile-max-files-truncation-partial-2026-06-23`
- Codex review: mercury-infra PR #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)