### PR TITLE
fix(service-skills): scope.py resolves canonical pack registry (xtrm-5bnfk)

### DIFF
--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -607,6 +607,10 @@
           "hash": "a437a67e7ae741b2ceaee35740a535a65e8f8aadf14d479d378616c7ccc46232",
           "version": "0.9.0"
         },
+        "multiplexing/SKILL.md": {
+          "hash": "3f49f5c5d4c9d627eb1d654bf5460378025622e320103504f840058dd5488d7f",
+          "version": "0.9.0"
+        },
         "planning/SKILL.md": {
           "hash": "b02da9548702f9256c0b4938490dad86a8898bbe72e2152d22999a02b3f608a8",
           "version": "0.9.0"
@@ -776,7 +780,7 @@
           "version": "0.9.0"
         },
         "service-skills/scripts/bootstrap.py": {
-          "hash": "93d0485546394587c8d53b67fe5e1d0376503cadec676e123d186785c9758304",
+          "hash": "f59ba1dfa2ede3f6e6880679bbb355f23dc49c59e656801d1bfe386a4137a53c",
           "version": "0.9.0"
         },
         "service-skills/scripts/cataloger.py": {
@@ -804,7 +808,7 @@
           "version": "0.9.0"
         },
         "service-skills/scripts/scope.py": {
-          "hash": "8009d07d85d8730ebdc71cf46d0e409bb583fd98bf28d482c1e226e4b4bc023f",
+          "hash": "b59634db12d797e4830a5796cdc0f571d3afe306751a5b086b1926cdd1fc6842",
           "version": "0.9.0"
         },
         "service-skills/scripts/skill_activator.py": {
@@ -913,6 +917,18 @@
         },
         "specialists-creator/SKILL.md": {
           "hash": "f84c22e11e08f83ab73c7f3d52df3b071037600740352713d1494f57799b679e",
+          "version": "0.9.0"
+        },
+        "sre-triage/scripts/alert_history.py": {
+          "hash": "b212bb8dad1ec0ae2db97824d4f72ece15db079bddfde466e230ef1e852bd0d3",
+          "version": "0.9.0"
+        },
+        "sre-triage/scripts/alert_investigator.py": {
+          "hash": "a950e1e0745766abe0f8acb9bd457b7ba08672628e21a82e091601f86e25fe85",
+          "version": "0.9.0"
+        },
+        "sre-triage/SKILL.md": {
+          "hash": "f9328ec682414e64304c75d38eddafe9014c23fb4334a16398ed0eaa64827bd2",
           "version": "0.9.0"
         },
         "sync-docs/references/doc-structure.md": {

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -607,10 +607,6 @@
           "hash": "a437a67e7ae741b2ceaee35740a535a65e8f8aadf14d479d378616c7ccc46232",
           "version": "0.9.0"
         },
-        "multiplexing/SKILL.md": {
-          "hash": "3f49f5c5d4c9d627eb1d654bf5460378025622e320103504f840058dd5488d7f",
-          "version": "0.9.0"
-        },
         "planning/SKILL.md": {
           "hash": "b02da9548702f9256c0b4938490dad86a8898bbe72e2152d22999a02b3f608a8",
           "version": "0.9.0"
@@ -917,18 +913,6 @@
         },
         "specialists-creator/SKILL.md": {
           "hash": "f84c22e11e08f83ab73c7f3d52df3b071037600740352713d1494f57799b679e",
-          "version": "0.9.0"
-        },
-        "sre-triage/scripts/alert_history.py": {
-          "hash": "b212bb8dad1ec0ae2db97824d4f72ece15db079bddfde466e230ef1e852bd0d3",
-          "version": "0.9.0"
-        },
-        "sre-triage/scripts/alert_investigator.py": {
-          "hash": "a950e1e0745766abe0f8acb9bd457b7ba08672628e21a82e091601f86e25fe85",
-          "version": "0.9.0"
-        },
-        "sre-triage/SKILL.md": {
-          "hash": "f9328ec682414e64304c75d38eddafe9014c23fb4334a16398ed0eaa64827bd2",
           "version": "0.9.0"
         },
         "sync-docs/references/doc-structure.md": {

--- a/.xtrm/skills/default/service-skills/scripts/bootstrap.py
+++ b/.xtrm/skills/default/service-skills/scripts/bootstrap.py
@@ -154,9 +154,15 @@ def get_umbrella_dir(project_root: str | None = None) -> Path | None:
 def _select_pack_registry(pack_registries: list[Path], project_root: str) -> Path:
     active_pack = get_pack_path(project_root)
     if active_pack is not None:
-        active_candidate = active_pack / "service-registry.json"
-        if active_candidate in pack_registries:
-            return active_candidate
+        active_resolved = active_pack.resolve()
+        # Match either the umbrella layout (<pack>/service-skills/service-registry.json)
+        # or the pre-umbrella flat layout (<pack>/service-registry.json).
+        for candidate in pack_registries:
+            try:
+                if active_resolved in candidate.resolve().parents:
+                    return candidate
+            except OSError:
+                continue
 
     chosen = sorted(pack_registries)[0]
     if len(pack_registries) > 1:

--- a/.xtrm/skills/default/service-skills/scripts/scope.py
+++ b/.xtrm/skills/default/service-skills/scripts/scope.py
@@ -12,25 +12,27 @@ import os
 import sys
 from pathlib import Path
 
+# bootstrap.py is a sibling in this consolidated scripts/ dir (no cross-skill hop).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bootstrap import get_project_root, get_registry_path  # type: ignore[import-not-found]  # noqa: E402
+
 
 def find_registry() -> Path | None:
-    # 1. CLAUDE_PROJECT_DIR env var (set by Claude Code hooks)
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
-    if project_dir:
-        p = Path(project_dir) / ".claude" / "skills" / "service-registry.json"
-        if p.exists():
-            return p
+    """Resolve the registry via bootstrap's canonical resolver.
 
-    # 2. Walk up from CWD until .git boundary
-    cwd = Path.cwd()
-    for parent in [cwd, *cwd.parents]:
-        p = parent / ".claude" / "skills" / "service-registry.json"
-        if p.exists():
-            return p
-        if (parent / ".git").exists():
-            break
+    Precedence (see bootstrap.get_registry_path):
+      1. $SERVICE_REGISTRY_PATH override
+      2. <root>/.xtrm/skills/user/packs/<pack>/service-skills/service-registry.json  (canonical)
+      3. <root>/.xtrm/skills/user/packs/<pack>/service-registry.json                 (pre-umbrella)
+      4. <root>/service-registry.json                                                (root symlink)
+      5. <root>/.claude/skills/service-registry.json                                  (legacy)
 
-    return None
+    Project root: $CLAUDE_PROJECT_DIR if set, else bootstrap's git-walkup.
+    Pack: $XTRM_PACK if set, else single-pack auto-detect.
+    """
+    project_root = os.environ.get("CLAUDE_PROJECT_DIR") or get_project_root()
+    registry = get_registry_path(project_root)
+    return registry if registry.exists() else None
 
 
 def main() -> None:

--- a/skills/service-skills/scripts/bootstrap.py
+++ b/skills/service-skills/scripts/bootstrap.py
@@ -154,9 +154,15 @@ def get_umbrella_dir(project_root: str | None = None) -> Path | None:
 def _select_pack_registry(pack_registries: list[Path], project_root: str) -> Path:
     active_pack = get_pack_path(project_root)
     if active_pack is not None:
-        active_candidate = active_pack / "service-registry.json"
-        if active_candidate in pack_registries:
-            return active_candidate
+        active_resolved = active_pack.resolve()
+        # Match either the umbrella layout (<pack>/service-skills/service-registry.json)
+        # or the pre-umbrella flat layout (<pack>/service-registry.json).
+        for candidate in pack_registries:
+            try:
+                if active_resolved in candidate.resolve().parents:
+                    return candidate
+            except OSError:
+                continue
 
     chosen = sorted(pack_registries)[0]
     if len(pack_registries) > 1:

--- a/skills/service-skills/scripts/scope.py
+++ b/skills/service-skills/scripts/scope.py
@@ -12,25 +12,27 @@ import os
 import sys
 from pathlib import Path
 
+# bootstrap.py is a sibling in this consolidated scripts/ dir (no cross-skill hop).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bootstrap import get_project_root, get_registry_path  # type: ignore[import-not-found]  # noqa: E402
+
 
 def find_registry() -> Path | None:
-    # 1. CLAUDE_PROJECT_DIR env var (set by Claude Code hooks)
-    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
-    if project_dir:
-        p = Path(project_dir) / ".claude" / "skills" / "service-registry.json"
-        if p.exists():
-            return p
+    """Resolve the registry via bootstrap's canonical resolver.
 
-    # 2. Walk up from CWD until .git boundary
-    cwd = Path.cwd()
-    for parent in [cwd, *cwd.parents]:
-        p = parent / ".claude" / "skills" / "service-registry.json"
-        if p.exists():
-            return p
-        if (parent / ".git").exists():
-            break
+    Precedence (see bootstrap.get_registry_path):
+      1. $SERVICE_REGISTRY_PATH override
+      2. <root>/.xtrm/skills/user/packs/<pack>/service-skills/service-registry.json  (canonical)
+      3. <root>/.xtrm/skills/user/packs/<pack>/service-registry.json                 (pre-umbrella)
+      4. <root>/service-registry.json                                                (root symlink)
+      5. <root>/.claude/skills/service-registry.json                                  (legacy)
 
-    return None
+    Project root: $CLAUDE_PROJECT_DIR if set, else bootstrap's git-walkup.
+    Pack: $XTRM_PACK if set, else single-pack auto-detect.
+    """
+    project_root = os.environ.get("CLAUDE_PROJECT_DIR") or get_project_root()
+    registry = get_registry_path(project_root)
+    return registry if registry.exists() else None
 
 
 def main() -> None:

--- a/skills/service-skills/tests/test_bootstrap_registry_path.py
+++ b/skills/service-skills/tests/test_bootstrap_registry_path.py
@@ -45,6 +45,58 @@ def test_root_used_only_when_no_xtrm_registry(tmp_path: Path):
     assert get_registry_path(str(tmp_path)) == root_reg
 
 
+def test_xtrm_pack_env_selects_umbrella_pack(tmp_path: Path, monkeypatch):
+    # xtrm-5bnfk: with multiple packs present under the umbrella layout, $XTRM_PACK
+    # must steer get_registry_path to that pack's umbrella registry (not just the
+    # alphabetically-first one). Pre-fix, _select_pack_registry only matched the
+    # flat <pack>/service-registry.json layout, so umbrella registries fell
+    # through to sorted()[0] and silently picked the wrong pack.
+    for pack in ("infra", "darth-feedor"):
+        reg = tmp_path / f".xtrm/skills/user/packs/{pack}/service-skills/service-registry.json"
+        reg.parent.mkdir(parents=True)
+        reg.write_text("{}")
+    monkeypatch.setenv("XTRM_PACK", "infra")
+    chosen = get_registry_path(str(tmp_path))
+    assert chosen == tmp_path / ".xtrm/skills/user/packs/infra/service-skills/service-registry.json"
+
+
+def test_scope_find_registry_resolves_canonical_pack(tmp_path: Path, monkeypatch):
+    # xtrm-5bnfk: scope.py previously had its own resolver that only knew
+    # .claude/skills/service-registry.json — it never found the canonical
+    # .xtrm/skills/user/packs/<pack>/service-skills/service-registry.json,
+    # so on mercury-infra the specialist's pre-script always reported
+    # 'No drift detected' even when drift existed. The fix delegates
+    # scope.find_registry() to bootstrap.get_registry_path().
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    import scope as scope_mod
+    canonical = tmp_path / ".xtrm/skills/user/packs/infra/service-skills/service-registry.json"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text("{}")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.delenv("XTRM_PACK", raising=False)
+    monkeypatch.delenv("SERVICE_REGISTRY_PATH", raising=False)
+    assert scope_mod.find_registry() == canonical
+
+
+def test_scope_find_registry_returns_none_when_absent(tmp_path: Path, monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    import scope as scope_mod
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.delenv("XTRM_PACK", raising=False)
+    monkeypatch.delenv("SERVICE_REGISTRY_PATH", raising=False)
+    assert scope_mod.find_registry() is None
+
+
+def test_scope_find_registry_honours_env_override(tmp_path: Path, monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    import scope as scope_mod
+    custom = tmp_path / "custom-registry.json"
+    custom.write_text("{}")
+    monkeypatch.setenv("SERVICE_REGISTRY_PATH", str(custom))
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    assert scope_mod.find_registry() == custom
+
+
 def test_run_gitnexus_json_omits_json_flag_and_uses_repo(tmp_path: Path, monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary

scope.py couldn't find the canonical registry at `.xtrm/skills/user/packs/<pack>/service-skills/service-registry.json` — it only walked `.claude/skills/service-registry.json`. On mercury-infra (and every post-umbrella-migration repo) that meant the specialist pre-script always reported \"No drift detected\" even when drift existed, blocking Phase C smoke from producing a real auto-reconcile PR (xtrm-d8r36.5, mercury-infra action 28038439215).

This is the same L0 pattern that `drift_detector.py` already solved by delegating to `bootstrap.get_registry_path`. `scope.py` now does the same — single canonical resolver, no parallel precedence logic.

## Changes

- `scope.find_registry()` delegates to `bootstrap.get_registry_path()` (5-layer precedence; see commit body)
- `bootstrap._select_pack_registry()`: latent bug fix. When `XTRM_PACK` is set among multiple packs, the matcher only recognized the pre-umbrella flat `<pack>/service-registry.json`. Umbrella registries fell through to `sorted()[0]` and silently picked the wrong pack alphabetically. Now matches any registry whose path lives under the active pack (flat or umbrella).
- 4 new tests (`test_xtrm_pack_env_selects_umbrella_pack`, `test_scope_find_registry_resolves_canonical_pack`, `test_scope_find_registry_returns_none_when_absent`, `test_scope_find_registry_honours_env_override`). All 9 tests pass.

## Phase C unblocks
- xtrm-d8r36.8 closes when this lands and mercury-infra runs `xt update --apply`
- next mercury-infra merge should produce: specialist pre-script lists drifted services → kimi reconciles ≥1 SKILL.md → auto-PR opens → first true Phase C end-to-end smoke evidence
- xtrm-d8r36.9 (gitnexus glibc) stays open separately; specialist falls back to `synced (string-level only)` per its documented degraded mode

## Test plan
- [x] 9 unit tests pass locally (4 new + 5 pre-existing)
- [x] Registry/pack parity: 348/348
- [x] Skills-symlinks check pass
- [ ] CI green
- [ ] Mercury-infra dummy merge → auto-PR opens with ≥1 reconciled SKILL.md (xtrm-d8r36.5 final smoke evidence, pane-1 owned)

## Reference
- Bead: xtrm-5bnfk (P0)
- Resolution order: per `bootstrap.get_registry_path` (canonical since b86y5)
- Operator policy: \"canonical pack path only — no symlinks, no per-repo workarounds\"