### PR TITLE
fix(service-skills): parser reads parsed_json.{services,actions,summary} (xtrm-n02m4)

### DIFF
--- a/.github/workflows/service-skills-drift-sweep.yml
+++ b/.github/workflows/service-skills-drift-sweep.yml
@@ -423,17 +423,22 @@ jobs:
             echo 'path=specialist' >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # specialist returns JSON {summary, services, actions}; derive a reconciled_count
-          # by counting non-empty edits in services[].edits or actions[]. Tolerant parser.
+          # sp script wraps the specialist's JSON output under .parsed_json:
+          #   {success, output (raw str), parsed_json: {summary, services[], actions[]}, meta}
+          # Read services/actions/summary from parsed_json with a top-level fallback so
+          # legacy payloads (or any future un-nested shape) still parse. xtrm-n02m4 RCA.
           python3 - <<'PYOUT' >> "$GITHUB_OUTPUT"
           import json, sys
           try:
               r = json.load(open('/tmp/reconcile-result.json'))
           except Exception as e:
               print('status=parse_error'); print('reconciled_count=0'); print('path=specialist'); sys.exit(0)
-          actions = r.get('actions') or []
-          services = r.get('services') or []
+          payload = r.get('parsed_json') if isinstance(r.get('parsed_json'), dict) else r
+          actions = payload.get('actions') or []
+          services = payload.get('services') or []
           # reconciled = count of services with edits applied OR explicit synced verdicts
+          # (a 'synced (audited-and-unchanged)' verdict still bumps last_sync_ref in the
+          # registry, so peter-evans has a real diff to PR even when no SKILL.md changed).
           reconciled = 0
           for s in services:
               if isinstance(s, dict):
@@ -442,7 +447,8 @@ jobs:
           # fallback: action items with type containing 'edit' or 'sync'
           if reconciled == 0:
               reconciled = sum(1 for a in actions if isinstance(a, dict) and any(k in str(a.get('type','')).lower() for k in ('edit','sync','reconcile')))
-          status = 'success' if reconciled > 0 else (r.get('summary',{}).get('status') or 'unknown') if isinstance(r.get('summary'), dict) else 'unknown'
+          summary = payload.get('summary') if isinstance(payload.get('summary'), dict) else {}
+          status = 'success' if reconciled > 0 else (summary.get('status') or 'unknown')
           print(f'status={status}')
           print(f'reconciled_count={reconciled}')
           print('path=specialist')


### PR DESCRIPTION
## Summary

Smoke v14 on mercury-infra (action 28100725859) finally produced a real specialist run on ubuntu-24.04 + gitnexus: **8 services audited as 'synced (audited-and-unchanged)'**. But the reusable workflow's reconcile-result parser computed \`reconciled_count=0\` and skipped peter-evans → no auto-PR opened.

## Root cause

\`sp script\` wraps the specialist's JSON output under \`.parsed_json\`:

\`\`\`json
{
  \"success\": true,
  \"output\": \"...raw string...\",
  \"parsed_json\": { \"summary\": {...}, \"services\": [...], \"actions\": [...] },
  \"meta\": { \"model\": \"...\", \"trace_id\": \"...\" }
}
\`\`\`

The parser was reading \`r.get('services')\` / \`r.get('actions')\` from the top level — always empty for the wrapped shape.

## Fix

- Read \`services\` / \`actions\` / \`summary\` from \`parsed_json\` when present.
- Fall back to top-level for any legacy or future un-nested payload (tolerant).
- No behavior change for the existing success path; only the previously-broken wrapped-shape branch is now correct.

## Why \"audited-and-unchanged\" still counts

A \`synced (audited-and-unchanged)\` verdict still calls \`drift_detector.py sync <service-id>\` inside the specialist, which bumps \`last_sync_ref\` / \`last_sync\` in the canonical pack registry. peter-evans sees those JSON updates as real file diffs and opens the auto-PR. Operator gets a reviewable artifact.

## Verified locally

Three fixtures via inline parser:
- v14 shape (8 audited services) → \`reconciled_count=8\`, \`status=success\`
- top-level legacy → \`reconciled_count=1\`, \`status=success\`
- empty → \`reconciled_count=0\`, \`status=unknown\`

## Test plan
- [x] YAML parses
- [x] Parser fixtures (v14, legacy, empty)
- [ ] CI green
- [ ] Mercury-infra dummy merge → auto-PR opens (xtrm-d8r36.5 + .8 final smoke evidence)

## Reference
- Bead: xtrm-n02m4 (P0)
- Smoke v14 evidence: mercuryintelligence/infra action 28100725859
- Last gate before Phase C is fully end-to-end shipped