### PR TITLE
ci(service-skills): bump specialists-version default to 3.18.0 (xtrm-d8r36.7)

### DIFF
--- a/.github/workflows/service-skills-drift-sweep.yml
+++ b/.github/workflows/service-skills-drift-sweep.yml
@@ -31,11 +31,11 @@ on:
         type: boolean
         default: false
       specialists-version:
-        description: 'Exact @jaggerxtrm/specialists npm version used by the auto-reconcile job. Ignored when specialists-git-ref is set. Bump via PR — never use latest/main per Phase C pinning policy (xtrm-d8r36.2).'
+        description: 'Exact @jaggerxtrm/specialists npm version used by the auto-reconcile job. Ignored when specialists-git-ref is set. Bump via PR — never use latest/main per Phase C pinning policy (xtrm-d8r36.2). 3.18.0 is the first registry release shipping service-skills-sync@1.6.0 (requires_worktree:false + script_template); earlier 3.17.x shipped v1.2.0 which is not CI-invocable.'
         type: string
-        default: '3.17.0'
+        default: '3.18.0'
       specialists-git-ref:
-        description: 'Optional pin to a github:xtrm-dev/specialists#<sha-or-ref>. When set, overrides specialists-version (used while waiting on a registry publish — xtrm-d8r36.7). Empty string disables.'
+        description: 'Optional escape hatch: pin to github:xtrm-dev/specialists#<sha-or-ref> instead of the npm registry. Originally added during xtrm-d8r36.7 while waiting for a registry release with service-skills-sync >=1.5; the 3.18.0 default makes this unnecessary for normal use, but the hook is retained for unblock-before-publish scenarios. Empty string disables.'
         type: string
         default: ''
       specialists-pack:


### PR DESCRIPTION
## Summary

\`@jaggerxtrm/specialists@3.18.0\` is the first registry release that ships \`service-skills-sync@1.6.0\` with all three fixes Phase C needed and that the \`[needs-codex]\` follow-up xtrm-d8r36.7 asked for:

- \`execution.requires_worktree: false\` (was missing → loader defaulted to true → \"worktree specialists are not allowed\")
- \`prompt.script_template\` present (was missing → \`sp script\` fell back to \`task_template\` which needs \`\$prompt\`)
- \`service-skills-sync\` version bumped 1.2.0 → 1.6.0

Verified just now via \`npm pack @jaggerxtrm/specialists@3.18.0\`:
- pkg version: 3.18.0
- service-skills-sync version: 1.6.0
- requires_worktree: False
- script_template present: True
- response_format: markdown (parser passes \`--json\` regardless — no change needed)
- execution.model: None (the \`sp init --global\` + \`sp edit --global\` seeding step from PR #313 still required)

## Changes

- \`specialists-version\` default: \`'3.17.0'\` → \`'3.18.0'\`
- \`specialists-git-ref\` description re-framed as an unblock-before-publish escape hatch (was: \"used while waiting on a registry publish — xtrm-d8r36.7\"). Default stays empty; mechanism untouched.

## Mercury-infra side (pane 1)

This unblocks dropping the \`specialists-git-ref: 2092439620a4532d53a7066c7a670a0b78445175\` override that was wired up in smoke v3. Pane 1 owns that edit; recommended diff in their caller:
\`\`\`yaml
with:
  reconcile-enabled: true
- specialists-git-ref: '2092439620a4532d53a7066c7a670a0b78445175'
+ # specialists-version defaults to 3.18.0 (xtrm-tools service-skills-drift-sweep.yml)
  specialists-pack: 'default'
  runs-on-reconcile: '[\"self-hosted\",\"infra\"]'
\`\`\`

The market-data fan-out pane 1 is now working on should use the simple npm path from the start — no git-ref override needed.

## Closes
- xtrm-d8r36.7 [needs-codex] (specialists release published, default tracking it)

## Test plan
- [x] YAML parses
- [x] Local 'npm pack 3.18.0' verifies the specialist shape
- [ ] CI green on this PR
- [ ] Mercury-infra caller edit drops the git-ref override (pane 1)
- [ ] Market-data caller (pane 1's current fan-out) uses 3.18.0 default directly