### PR TITLE
fix(service-skills): drop :thinking from default model ids (xtrm-efa2a)

### DIFF
--- a/.github/workflows/service-skills-drift-sweep.yml
+++ b/.github/workflows/service-skills-drift-sweep.yml
@@ -59,13 +59,13 @@ on:
         type: string
         default: '"ubuntu-latest"'
       nano-gpt-model:
-        description: 'nano-gpt model id (NANO_GPT_MODEL). Specialist consumes this under the hood. Subscription-covered example: moonshotai/kimi-k2.6:thinking'
+        description: 'nano-gpt model id (NANO_GPT_MODEL). Specialist consumes this under the hood. The :thinking variant has long quiet reasoning phases that exceed the specialist 120s no-activity stall_timeout on real-drift workloads (xtrm-efa2a) — default switched to the non-thinking model.'
         type: string
-        default: 'moonshotai/kimi-k2.6:thinking'
+        default: 'moonshotai/kimi-k2.6'
       specialists-model:
-        description: 'Provider-prefixed model id passed to sp script --model (specialist v1.6.0 has model:null and requires explicit override). Format: <provider>/<model-id>.'
+        description: 'Provider-prefixed model id passed to sp script --model (specialist v1.6.0 has model:null and requires explicit override). Format: <provider>/<model-id>. Default avoids the :thinking variant to stay under the specialist 120s no-activity stall_timeout (xtrm-efa2a).'
         type: string
-        default: 'nano-gpt/moonshotai/kimi-k2.6:thinking'
+        default: 'nano-gpt/moonshotai/kimi-k2.6'
       nano-gpt-api-url:
         description: 'nano-gpt chat-completions endpoint (NANO_GPT_API_URL). Override only to switch base path. Hostname locked to nano-gpt.com.'
         type: string


### PR DESCRIPTION
## Summary

Market-data fan-out smoke (mercury-market-data run 28108345620, 2026-06-24 15:05Z) stalled the specialist at 177s with \`Session stalled: no activity for 120000ms\`. Mercury-infra smoke v15 passed because all services were audited-and-unchanged (fast path); market-data has real drift (serving-platform stale 2 months) and tripped the stall.

## Root cause

\`moonshotai/kimi-k2.6:thinking\` has long quiet reasoning phases between tokens that exceed \`service-skills-sync.execution.stall_timeout_ms = 120000\` (hardcoded in the specialist JSON). Local traces from operator's machine confirm:

| model | runtime |
|---|---|
| \`moonshotai/kimi-k2.6\` (non-thinking) | 38746ms ✓ |
| \`moonshotai/kimi-k2.5\` | 8207ms / 107106ms (107s — barely under 120s ceiling) |
| \`moonshotai/kimi-k2.6:thinking\` (market-data run) | 177386ms ✗ (stall at ~120s) |

## Fix

Cheapest of three options from xtrm-efa2a (A/B/C — picked A). Default flip in the reusable workflow:

- \`nano-gpt-model\`: \`moonshotai/kimi-k2.6:thinking\` → \`moonshotai/kimi-k2.6\`
- \`specialists-model\`: \`nano-gpt/moonshotai/kimi-k2.6:thinking\` → \`nano-gpt/moonshotai/kimi-k2.6\`

The pi-config step already auto-derives the registered \`models[]\` entry in \`\$HOME/.pi/agent/{models.json,auth.json}\` from \`SPECIALISTS_MODEL\`, so the model registration follows the default flip automatically — no secondary edit needed on the consumer side, no NANO_GPT_API_KEY rotation needed.

## Why not option C (raise stall_timeout_ms upstream)?

The specialists repo is codex-owned read-only. The default flip is reversible in one PR if the non-thinking variant produces unacceptable reconciliations; the upstream timeout bump is the durable fix to file with codex later (xtrm-d8r36.9 sibling).

## Test plan
- [x] YAML parses; both defaults flipped
- [ ] CI green
- [ ] Mercury-market-data smoke produces auto-PR with reconciled SKILL.md (serving-platform real drift, kimi non-thinking should complete in <60s per local trace)
- [ ] Mercury-infra smoke still produces auto-PR (all-audited fast path — should be unaffected)

## Closes
- xtrm-efa2a (P1)

## Reference
- Bead: xtrm-efa2a
- Specialist stall constant: \`service-skills-sync.execution.stall_timeout_ms = 120000\` (codex-owned, can't change here)
- Smoke evidence: mercury-market-data run 28108345620