### PR TITLE
fix(service-skills): seed stall_timeout_ms=600000 via sp edit --global (xtrm-efa2a)

### DIFF
--- a/.github/workflows/service-skills-drift-sweep.yml
+++ b/.github/workflows/service-skills-drift-sweep.yml
@@ -66,6 +66,10 @@ on:
         description: 'Provider-prefixed model id passed to sp script --model (specialist v1.6.0 has model:null and requires explicit override). Format: <provider>/<model-id>. Default avoids the :thinking variant to stay under the specialist 120s no-activity stall_timeout (xtrm-efa2a).'
         type: string
         default: 'nano-gpt/moonshotai/kimi-k2.6'
+      specialists-stall-timeout-ms:
+        description: 'Override for service-skills-sync.execution.stall_timeout_ms. Upstream specialist default of 120000 fires on real-drift workloads (xtrm-efa2a market-data run 28118772361 stalled at 120s even with the non-:thinking model). 600000 (10min) accommodates the multi-phase Serena+gitnexus tool-call architecture. Pre-step seeds this via sp edit --global; codex-side default bump tracked separately.'
+        type: number
+        default: 600000
       nano-gpt-api-url:
         description: 'nano-gpt chat-completions endpoint (NANO_GPT_API_URL). Override only to switch base path. Hostname locked to nano-gpt.com.'
         type: string
@@ -351,6 +355,7 @@ jobs:
         env:
           SP_BIN: ${{ steps.install_specialists.outputs.sp_bin }}
           SPECIALISTS_MODEL: ${{ inputs['specialists-model'] }}
+          SPECIALISTS_STALL_TIMEOUT_MS: ${{ inputs['specialists-stall-timeout-ms'] }}
         run: |
           set +e
           # service-skills-sync v1.6.0 sets execution.model:null; SpecialistLoader.get
@@ -379,7 +384,21 @@ jobs:
             exit 0
           fi
           echo "::notice::seeded global override: service-skills-sync.execution.model=$SPECIALISTS_MODEL"
+          # xtrm-efa2a: upstream stall_timeout_ms=120000 fires on real-drift work even
+          # without :thinking. Bump it in the global override layer; non-fatal if the
+          # edit fails (we keep the model seed and let the run try).
+          "$SP_BIN" edit --global --set "service-skills-sync.execution.stall_timeout_ms" "$SPECIALISTS_STALL_TIMEOUT_MS" 2> /tmp/sp-edit-stall-stderr.log
+          stall_edit_status=$?
+          if [ "$stall_edit_status" -ne 0 ]; then
+            echo "::warning::sp edit --global --set stall_timeout_ms=$SPECIALISTS_STALL_TIMEOUT_MS failed (exit $stall_edit_status); specialist will use upstream default 120000ms"
+            echo "::group::sp edit stall_timeout_ms stderr"
+            tail -30 /tmp/sp-edit-stall-stderr.log 2>/dev/null
+            echo "::endgroup::"
+          else
+            echo "::notice::seeded global override: service-skills-sync.execution.stall_timeout_ms=$SPECIALISTS_STALL_TIMEOUT_MS"
+          fi
           "$SP_BIN" edit --global --get "service-skills-sync.execution.model" 2>&1 | head -3
+          "$SP_BIN" edit --global --get "service-skills-sync.execution.stall_timeout_ms" 2>&1 | head -3
 
       - name: Reconcile drift (specialist path)
         id: reconcile


### PR DESCRIPTION
## Summary

Follow-up to #324. Dropping \`:thinking\` from the model id wasn't enough — market-data run 28118772361 with non-\`:thinking\` \`kimi-k2.6\` still stalled at 120s (duration 232795ms, same \`Session stalled: no activity for 120000ms\` error). The real cause is \`service-skills-sync.execution.stall_timeout_ms\` hardcoded at 120000 in the specialist JSON — too aggressive for the multi-phase Serena + gitnexus tool-call architecture, which has silent gaps >120s between visible tool activity bursts even on chatty models.

## Fix

Extend the existing \`Configure specialist model override (global user.json)\` pre-step to also seed \`execution.stall_timeout_ms\` via \`sp edit --global\`. Same precedence chain as the model seed (CLI > global > user > specialist default).

- New input \`specialists-stall-timeout-ms\` (number, default \`600000\` = 10min). Consumers can override per-repo.
- Non-fatal: if the stall edit fails, the model seed still applies and the run gets the upstream 120000ms (degraded but not worse than today).

## Why not C (codex upstream bump)?

Specialists is codex-owned read-only. The B fix here unblocks today; C remains the durable upstream ask. Once codex bumps the specialist default, this input can be retired or re-defaulted to inherit.

## Trace evidence
| run | model | duration | result |
|---|---|---|---|
| 28108345620 (#276) | \`kimi-k2.6:thinking\` | 177386ms | stall @ 120s |
| 28118772361 (#277) | \`kimi-k2.6\` | 232795ms | stall @ 120s |

Both crossed the 120s idle threshold; total durations differ but the stall is gap-based not wall-based.

## Test plan
- [x] YAML parses; new input wired
- [ ] CI green
- [ ] Mercury-market-data re-trigger: specialist completes; auto-PR opens with serving-platform reconciliation
- [ ] Mercury-infra still passes the audited-and-unchanged fast path
- [ ] No regression on smoke runs with override=120000 (caller can confirm degraded behavior matches pre-fix)

## Closes
- xtrm-efa2a (P1)

## Reference
- Bead: xtrm-efa2a (B + C recommendation)
- Trace evidence: market-data runs 28108345620 + 28118772361
- Upstream constant: \`service-skills-sync.execution.stall_timeout_ms = 120000\` (codex-owned)