### PR TITLE
fix(xtrm-ui): don't compact read/inspect tool results into model context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `@jaggerxtrm/pi-extensions` v0.9.1
+
+#### Fixed
+
+- **`xtrm-ui` no longer compacts read/inspect tool results into the model's context.** In `pi`, the value a `tool_result` hook returns *replaces* the model-facing content — it is not a display-only transform. For Serena/GitNexus read tools (`read_file`, `find_symbol`, `find_referencing_symbols`, `get_symbols_overview`, `search_for_pattern`, `find_file`, `list_dir`, `read_memory`, the JetBrains equivalents, and `gitnexus_query`/`context`/`impact`/`detect_changes`) the compactor replaced the payload with a one-line `· N lines` / `· N results` summary — the full text survived only in `details.xtrmOriginalText` for the interactive TUI expand view, so any pi agent that loads Serena via `pi-serena-tools` was blind on reads. A new `PAYLOAD_TOOLS` allow-list short-circuits the `tool_result` handler (`return undefined`) so these pass through verbatim regardless of the `compactExternalToolResults` pref; mutation/no-payload tools keep their compact one-line summaries. `pi-serena-compact` is deliberately a `tool_result` no-op ("xtrm-ui owns external tool compaction globally") and is intentionally untouched. (xtrm-ikg38)
+
 ### Changed
 
 - **Service-skills reusable workflow is now provider-agnostic (xtrm-g5hk2).** `service-skills-drift-sweep.yml` accepts new generic inputs `provider-name` (default `nano-gpt`), `provider-api` (default `openai-completions`), `provider-base-url` (default `https://nano-gpt.com/api/v1`), `provider-model` (default `moonshotai/kimi-k2.6`), and a new generic secret `provider-api-key`. The pi provider config step now writes `providers[<provider-name>] = {baseUrl, apiKey, api, authHeader, models:[…]}` dynamically; the `sp script --model` arg is constructed as `<provider-name>/<provider-model>`. External callers can target any openai-compatible provider (openrouter, vllm, etc) via `provider-*`. The legacy inputs (`nano-gpt-model`, `nano-gpt-api-url`, `specialists-model`) and legacy secret (`nano-gpt-api-key`) are retained as deprecated aliases that emit `::warning::` lines when used — the `provider-*` form wins when both are set. The Phase B fallback (`reconcile.py`) remains nano-gpt-only and is skipped with a clear notice when `provider-name` is anything else; the specialist path is the only supported route for non-nano-gpt providers. Discovered while authoring the `setup-service-skills-sync` skill (xtrm-d8r36 follow-up). (xtrm-g5hk2)

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -1363,6 +1363,33 @@ function withXtrmToolDetails(details: unknown, sourceText: string, toolName: str
 
 const XTRM_BUILTIN_TOOLS = new Set(["bash", "read", "edit", "write", "find", "grep", "ls"]);
 
+// Tools whose RESULT PAYLOAD the model needs verbatim in context. In pi, a tool_result
+// hook's return value REPLACES the model-facing content (not just the TUI render), so
+// compacting these blinds headless agents/specialists — they have no row to expand and
+// would receive only "· N lines" / "· N results". Mutation/no-payload tools are still
+// summarized below, preserving most of the token savings.
+const PAYLOAD_TOOLS = new Set<string>([
+  // Serena reads / inspection
+  "read_file",
+  "find_symbol",
+  "find_referencing_symbols",
+  "get_symbols_overview",
+  "search_for_pattern",
+  "find_file",
+  "list_dir",
+  "read_memory",
+  // JetBrains backend equivalents
+  "jet_brains_find_symbol",
+  "jet_brains_find_referencing_symbols",
+  "jet_brains_get_symbols_overview",
+  "jet_brains_type_hierarchy",
+  // GitNexus reads (same blindness risk)
+  "gitnexus_query",
+  "gitnexus_context",
+  "gitnexus_impact",
+  "gitnexus_detect_changes",
+]);
+
 function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): void {
   const activeToolCalls = new Map<string, string>();
 
@@ -1413,6 +1440,9 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
       trackToolCallEnd(event.toolCallId);
       return undefined;
     }
+    // Never compact read/inspect tools: the hook return replaces model-facing content,
+    // so summarizing these would blind headless agents/specialists (no row to expand).
+    if (PAYLOAD_TOOLS.has(event.toolName)) return undefined;
     if (!getPrefs().compactExternalToolResults) return undefined;
 
     const text = getTextContent({ content: event.content as Array<{ type: string; text?: string }> });

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
## Problem

In `pi`, the value a `tool_result` hook returns **replaces** the model-facing content — it is not a display-only transform. `xtrm-ui`'s `tool_result` compactor was rewriting Serena/GitNexus **read/inspect** tool results into a one-line `· N lines` / `· N results` summary, keeping the full payload only in `details.xtrmOriginalText` for the interactive TUI expand view.

Result: any pi agent that loads Serena (via `pi-serena-tools`, e.g. interactive sessions) received only a line count, never the file body — effectively **blind on reads**.

Prior fix attempts misfired: `pi-serena-compact`'s `tool_result` is a deliberate no-op (`return undefined`, comment *"xtrm-ui owns external tool compaction globally"*), and PR #306 was the unrelated serena-pool cwd-race. So the blindness survived every patch aimed elsewhere.

## Fix

Add a `PAYLOAD_TOOLS` allow-list and short-circuit (`return undefined`) the `tool_result` handler for read/inspect tools so they pass through verbatim, regardless of the `compactExternalToolResults` pref:

- Serena: `read_file`, `find_symbol`, `find_referencing_symbols`, `get_symbols_overview`, `search_for_pattern`, `find_file`, `list_dir`, `read_memory`
- JetBrains equivalents
- GitNexus: `gitnexus_query`, `gitnexus_context`, `gitnexus_impact`, `gitnexus_detect_changes`

Mutation/no-payload tools (`replace_symbol_body`, `write_memory`, edits, …) keep their compact one-line summaries, so most of the token savings remain. `pi-serena-compact` is intentionally untouched.

Bumps `@jaggerxtrm/pi-extensions` 0.9.0 → 0.9.1. The package ships `.ts` directly (no build step).

## Validation

Verified in a consumer repo (Hiryuen) across three independent layers:
1. **Source** — the `PAYLOAD_TOOLS` skip is placed before compaction; covers read tools, excludes mutation tools.
2. **Behavior** — a headless pi agent quoted a file's exact last line (impossible from a `· N lines` summary).
3. **Airtight** — the raw recorded `toolResult` was the full 7493-char file body, not `· 156 lines`.

Sanity: a mutation tool (`replace_symbol_body`) still shows the compact one-liner.

bead: xtrm-ikg38

🤖 Generated with [Claude Code](https://claude.com/claude-code)