### PR TITLE
chore: pre-container cleanup — deprecate service-skills-drift-sweep for Mercury (xtrm-n0nmv)

### DIFF
--- a/.github/workflows/service-skills-drift-sweep.yml
+++ b/.github/workflows/service-skills-drift-sweep.yml
@@ -1,5 +1,11 @@
 name: Service-Skills Drift Sweep
 
+# DEPRECATED for Mercury (2026-06-26):
+# Mercury service-skills-sync moves to the containerized devops-bot
+# (see xtrm-dev/xtrm:docs/devops/mercury-devops-collaborator.md).
+# This reusable workflow is KEPT for non-Mercury ecosystem consumers
+# who still want a CI-driven path. No active maintenance for Mercury.
+#
 # Reusable workflow — call from a consumer repo with:
 #   jobs:
 #     drift:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Pre-container cleanup: `service-skills-drift-sweep.yml` deprecated for Mercury, `setup-service-skills-sync` skill removed (xtrm-n0nmv).** The containerized `mercury-devops-collaborator` design (`xtrm-dev/xtrm:docs/devops/mercury-devops-collaborator.md`) supersedes the CI-driven service-skills-sync flow for Mercury repos. The reusable workflow now carries a deprecation preamble at the top: kept for non-Mercury ecosystem consumers, no active maintenance for Mercury. The default-skill `setup-service-skills-sync` (which taught operators how to wire the CI caller) is removed entirely; it was untracked source material on the local clone, never shipped via npm. Supersession notes added to closed beads `xtrm-oafcs` (Node 24 bumps for the runner that's no longer used) and `xtrm-92wx3` (reconcile.py vendoring to Mercury siblings — Phase B fallback path retired). (xtrm-n0nmv)
+
 ### Fixed
 
 - **`xt install --global` no longer clobbers global hooks (xtrm-il7ov, P0).** `runClaudeRuntimeSyncPhase` now early-returns when invoked with `isGlobal: true`: the `~/.claude/settings.json` `hooks` section is left intact and only `ensureGlobalStatusLine()` runs. Every xtrm-managed hook command references `<projectRoot>/.xtrm/hooks/` and is project-scoped by definition; replacing the global `hooks` section with project-hardcoded paths previously wiped hand-configured user hooks (PreCompact `bd prime`, SessionStart `context-mode-cache-heal.mjs`) and caused project hooks to fire twice. Source fix applied in `cli/src/core/claude-runtime-sync.ts` and `cli/dist/index.cjs` rebuilt so the behavior is actually active in the CLI bundle. Two regression tests added in `cli/src/tests/claude-runtime-sync-global-guard.test.ts`. (xtrm-il7ov)


### PR DESCRIPTION
## Summary

Pre-container cleanup for the `mercury-devops-collaborator` design (`xtrm-dev/xtrm:docs/devops/mercury-devops-collaborator.md`), which supersedes the CI-driven service-skills-sync flow for Mercury repos. Three small artifact resolutions in xtrm-tools.

## Diff

- `.github/workflows/service-skills-drift-sweep.yml` — deprecation preamble added at top. Workflow body untouched; kept for non-Mercury ecosystem consumers.
- `.xtrm/skills/default/setup-service-skills-sync/` — removed. Taught operators how to wire the CI caller that's about to be torn down by pane 1. Was untracked WIP on the local clone; never shipped via npm.
- `CHANGELOG.md` — Unreleased entry under Changed.
- bd: supersession notes posted (out-of-band, before this PR) on closed `xtrm-oafcs` and `xtrm-92wx3` capturing the why-this-is-moot context.

## Scope boundaries

- Specialists repo changes (pane 3 owns)
- Mercury caller workflow removal (pane 1 owns)
- `xtrm-vu2ro.1` / `xtrm-efa2a.1` (specialists territory — implementation staged locally awaiting next release)
- Pre-existing P0s `xtrm-6ofgm` / `xtrm-il7ov` (unrelated to container cleanup)

## Test plan

- [x] YAML parses
- [x] No orphan registry entries for the removed skill
- [ ] CI green

Closes xtrm-n0nmv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)