### PR TITLE
session report: 2026-06-26 (pre-container cleanup + container-design pivot)

### DIFF
--- a/.xtrm/reports/2026-06-26-02d99ea5.md
+++ b/.xtrm/reports/2026-06-26-02d99ea5.md
@@ -1,0 +1,113 @@
+---
+session_date: 2026-06-26
+branch: main
+commits: 1
+issues_closed: 1
+issues_filed: 1
+specialist_dispatches: 0
+models_used: ["Opus 4.7"]
+handoff_bead: xtrm-l7tkx
+prior_ssot: .xtrm/reports/2026-06-25-4d5625ff.md
+---
+
+# Session Report — 2026-06-26
+
+## Summary
+
+Pre-container cleanup pass on `xtrm-tools` triggered by infra pane 1's containerized `mercury-devops-collaborator` design (`xtrm-dev/xtrm:docs/devops/mercury-devops-collaborator.md`), which supersedes the entire CI-driven `service-skills-sync` flow for Mercury repos. PR #335 (`chore/pre-container-cleanup`) shipped three artifact resolutions in one commit: a deprecation preamble at the top of `.github/workflows/service-skills-drift-sweep.yml` (workflow kept for non-Mercury ecosystem consumers, no maintenance for Mercury), removal of the untracked `setup-service-skills-sync` default skill (taught operators how to wire the now-defunct CI caller), and `CHANGELOG.md` Unreleased entry. Supersession notes were added to two already-closed beads (`xtrm-oafcs`, `xtrm-92wx3`) capturing why the work is moot under the container model. A separate piece of pane-2 work this session was the architectural review of pane 3's `auto-reconcile-delivery.md` design doc (Options A/B/C/D for specialist PR delivery); pane 2's verdict was "Option D short-term, Option C long-term as separate spike, discard Option B" — but the operator then collapsed the whole frame with the container design, so the design doc and the verdict are both archived rather than acted on. No specialists dispatched, no npm publish, no touch on specialists repo / Mercury repos. Scope was strictly limited to xtrm-tools cleanup per the operator brief; pane 1 owns Mercury caller workflow removal, pane 3 owns specialists implementation staging.
+
+## Issues Closed
+
+### Cleanup tracking
+
+| ID | Title | Type | Close Reason / Context |
+|----|-------|------|------------------------|
+| xtrm-n0nmv | Pre-container cleanup: deprecate service-skills-drift-sweep for Mercury, remove setup-service-skills-sync skill | chore | Filed and closed this session as the tracker bd for PR #335 (commit `aef9fe43` merged into main). Three artifact resolutions: deprecation preamble on reusable workflow, removal of `setup-service-skills-sync` default skill, supersession notes on closed `xtrm-oafcs` and `xtrm-92wx3`. |
+
+### Supersession notes posted (already-closed beads — context-only updates)
+
+| ID | Update | Context |
+|----|--------|---------|
+| xtrm-oafcs | Added supersession note pointing at `xtrm/docs/devops/mercury-devops-collaborator.md §13`. Original Node 24 LTS bumps (PR #329, yesterday) stay valid for ecosystem callers; the gh-on-self-hosted motivation that drove the bumps becomes moot once the container ships with its own pinned glibc-safe image. | Already-closed bead; only the why-this-is-moot context was added. |
+| xtrm-92wx3 | Added supersession note: `reconcile.py` Phase B fallback retired in container model. Container's `service-skills-sync` specialist runs end-to-end inside the container, opens PRs from its own fork, never relies on a CI fallback. xtrm-tools registry entry stays (ecosystem consumers). | Already-closed bead; context-only update. |
+
+## Issues Filed
+
+| ID | P | Type | Title | Why |
+|----|---|------|-------|-----|
+| xtrm-n0nmv | P2 | chore | Pre-container cleanup: deprecate service-skills-drift-sweep for Mercury, remove setup-service-skills-sync skill | Tracker bd needed to satisfy the bd-claim gate before editing the workflow file and CHANGELOG. Description recorded the three artifact resolutions and the scope boundary (xtrm-tools only; specialists + Mercury repos out of scope per brief). |
+| xtrm-zyqsx | P2 | task | Session report 2026-06-26 + handoff bead | Tracker bd for filling out this report and filing the handoff. |
+
+## Specialist Dispatches
+
+*No specialist dispatches this session. Communication with pane 3 (specialists/glm-5.2) was via the multiplexing protocol — bd notes + `/tmp/pane3-codex-hold-no-release-2026-06-25.txt` pointer + single-line `tmux send-keys` ping — to deliver the HOLD directive on pane 3's local commits and request the `auto-reconcile-delivery.md` design doc.*
+
+## Problems Encountered
+
+| Problem | Root Cause | Resolution |
+|---------|------------|------------|
+| Original brief framed Phase B PR delivery as a specialist-side feature (xtrm-vu2ro.1 Phase 6 with `gh` in `external_commands`) | Pane 2's earlier handoff brief to pane 3 assumed `gh` was preinstalled on every Actions runner; verified false — `gh` ships only on GitHub-hosted runners, while the reusable workflow's `runs-on-reconcile` input defaults to `ubuntu-latest` but explicitly documents `["self-hosted","infra"]` as the alternative. The `capabilities.external_commands` gate is fatal pre-run, so specialist would crash before doing any work on self-hosted consumers — strictly worse than status quo. | Pane 3 caught the gotcha during their own scoping pass, marked both their local commits RELEASE BLOCKED, asked the architectural question (runner-embedded vs daemon-on-host). Pane 2 instructed HOLD via `/tmp` pointer; pane 3 wrote `docs/design/auto-reconcile-delivery.md` (local commit, not pushed) with 4 options + reversibility analysis. Operator then superseded the whole frame with the `mercury-devops-collaborator` container design, making the Path A/B/C/D analysis moot. Both pane 3's local commits stay local as scratch evidence; design doc is archived rather than acted on. |
+| Generated session-report skeleton stamped 2026-06-25 despite session running 2026-06-26 local | `xt report generate` derives the filename date from the latest commit timestamp; the most recent merge (PR #335) landed at 23:26 UTC = 01:26 my time = next day local. | Renamed file from `2026-06-25-02d99ea5.md` to `2026-06-26-02d99ea5.md` and corrected `session_date` in frontmatter. Yesterday's SSOT (`2026-06-25-4d5625ff.md`) stays intact; this report is a sibling, scoped only to today's cleanup work, with a `prior_ssot` frontmatter pointer for chronology. |
+
+## Code Changes
+
+The session's substantive code change is a single 10-line diff in PR #335; the rest of the files the CLI report skeleton listed (`cli/src/core/claude-runtime-sync.ts`, `cli/src/commands/install.ts`, `cli/src/commands/update.ts`, `cli/src/utils/repo-root.ts`, `cli/src/tests/claude-runtime-sync-global-guard.test.ts`, `cli/src/tests/resolve-main-project-root.test.ts`, `cli/dist/index.cjs`, `docs/service-skills-auto-reconcile.md`) belong to yesterday's session (PRs #330 / #331 / #327 / #326) and are documented in `2026-06-25-4d5625ff.md`.
+
+### PR #335 — pre-container cleanup (commit `aef9fe43`)
+
+- `.github/workflows/service-skills-drift-sweep.yml`: 6-line deprecation preamble at top of file, body untouched. The reusable workflow keeps full functionality for non-Mercury ecosystem consumers; the preamble flags that Mercury repos are migrating off the CI path and the workflow gets no further Mercury-driven maintenance.
+- `.xtrm/skills/default/setup-service-skills-sync/`: directory removed. The skill was untracked local source (operator WIP that never shipped via npm), so no registry entry to scrub and no consumer-side impact. It described how to wire the now-defunct CI caller workflow.
+- `CHANGELOG.md`: one Unreleased entry under `### Changed` documenting both resolutions and pointing at the design doc.
+
+### Pane 3 (specialists worktree, NOT pushed, NOT in xtrm-tools)
+
+- `docs/design/auto-reconcile-delivery.md` (commit `d2c3eca5`, local only): 178-line design doc analyzing Options A (status quo Path A), B (runner-embedded gh), C (daemon-on-host), D (evolved Path A with `auto_pr_intent` JSON), with trade-off matrix and reversibility analysis. Recommendation was D + C-as-spike; superseded by container design.
+- Two earlier scratch commits on pane 3's branch (`222dd5ad` efa2a.1 stall_timeout=600000, `a434398e` vu2ro.1 Phase 6 prompt draft): treated as local evidence, not PR candidates per pane 2's HOLD directive.
+
+## Documentation Updates
+
+- `CHANGELOG.md`: Unreleased / Changed — one bullet for xtrm-n0nmv with the three resolutions and a pointer to `xtrm-dev/xtrm:docs/devops/mercury-devops-collaborator.md`.
+- `.xtrm/reports/2026-06-26-02d99ea5.md` (this report): new SSOT for today's session, sibling to yesterday's `2026-06-25-4d5625ff.md`.
+- Bead notes added to closed `xtrm-oafcs` and `xtrm-92wx3` (supersession-by-design context).
+
+## Open Issues with Context
+
+### Ready for next session — container-implementation handoff (pane 1 / pane 3 territory)
+
+| ID | P | Title | Status | Context / Suggestions |
+|----|---|-------|--------|----------------------|
+| xtrm-efa2a.1 | P1 | [needs-codex] Bump service-skills-sync.execution.stall_timeout_ms default 120000 → 600000 | in_progress | Promoted to Phase 4 of the container design (per `mercury-devops-collaborator.md` §13). Pane 3 has the value staged in local commit `222dd5ad` (not pushed). Next pane-3 session: include in the next specialists npm release alongside `requires_worktree: true` and Phase 6 prompt. xtrm-tools side is zero-action. |
+| xtrm-vu2ro.1 | P1 | [needs-codex] Extend service-skills-sync system_prompt with Phase 6 (specialist opens PR via gh CLI) | in_progress | Promoted to Phase 4 of the container design. Pane 3 has the Phase 6 prompt staged in local commit `a434398e` (not pushed). Inside the container, `gh` is image-baked, so the `external_commands: gh` gate is no longer fatal — the gotcha that drove the design-doc detour evaporates. Next pane-3 session: include in next specialists release. xtrm-tools side is zero-action. |
+| xtrm-u22fw | P1 | Session handoff 2026-06-25: release-prep/docs + service-skills follow-ups | open | Yesterday's handoff. Already triaged by this session; today's work (PR #335) is downstream of it. Can close after the next session reads this report. |
+
+### Carried over — needs board hygiene
+
+Older handoff/backlog beads listed in yesterday's `2026-06-25-4d5625ff.md` §"Backlog / older board items still visible" carry over unchanged (xtrm-r1ed7, xtrm-c4fqp, xtrm-mp0f2, xtrm-t2530, xtrm-drdg6, xtrm-24gjf, xtrm-pan6c, xtrm-5a9ts, xtrm-p72bo, xtrm-n74m8, UI/triage cluster, xtrm-yb0u, xtrm-9xg2.*, xtrm-4ud5, xtrm-o0eu, xtrm-r1ed7.4, xtrm-yep0f). Not re-listed here to avoid duplication; see prior report.
+
+### Container design — not a bd, but the new center of gravity
+
+The `mercury-devops-collaborator.md` design has 10 open questions (Q1–Q10) deferred to implementation phases. xtrm-tools is mostly downstream of this — the reusable workflow stays for ecosystem consumers, the `service-skills-sync` specialist eventually becomes a container-internal v0 instance. No xtrm-tools-side feature work is currently blocking the container ramp-up; pane 1 owns image authoring, fork strategy, webhook receiver, dispatcher, end-to-end smoke (Phases 1–6 in §11).
+
+## Memories Saved
+
+| Key | Content |
+|-----|---------|
+| `memory-acked:xtrm-n0nmv` (kv) | `nothing novel - cleanup pass per design doc xtrm/docs/devops/mercury-devops-collaborator.md §13; no engineering insight worth memorializing` |
+
+No `bd remember` calls this session. The cleanup was mechanical execution of the brief; the substantive engineering insight (gh-on-self-hosted gotcha, runner-embedded vs daemon-on-host trade-offs) lives in pane 3's `auto-reconcile-delivery.md` design doc and operator's container design doc, both of which are documents-of-record at the xtrm umbrella layer. No xtrm-tools-side memory worth saving.
+
+## Suggested Next Priority
+
+1. **Pane 1 picks up container implementation Phases 1–6** per `mercury-devops-collaborator.md` §11. xtrm-tools side is non-blocking for this; pane 1 will operate on `mercury-infra` repo and the new container image. No xtrm-tools PRs anticipated until Phase 8 (caller workflow removals on Mercury repos finish, at which point the operator may choose to fully retire the reusable workflow — but that's a deliberate decision for later, not today).
+2. **Pane 3 includes the two staged local commits in the next specialists npm release** (xtrm-efa2a.1 stall_timeout=600000 + xtrm-vu2ro.1 Phase 6 prompt). The container makes both safe to ship: stall_timeout is decoupled from any consumer behavior, and Phase 6's `gh` dependency is satisfied inside the image. Pane 3 should coordinate the release with pane 1's container-image build.
+3. **Next pane-2 session: close stale handoff beads (`xtrm-c4fqp`, `xtrm-mp0f2`, `xtrm-t2530`, `xtrm-drdg6`)** carried over from yesterday's report. These are all superseded by today's container-design pivot and the Phase C closeout that landed yesterday; closing them clears triage noise.
+4. **If the operator confirms the container fully owns Mercury auto-reconcile**, file a single follow-up bd to remove the reusable workflow's `auto-reconcile` job (the deprecation preamble is the current marker). Defer until Phases 7/8 of the container ramp complete and at least one cycle of operator review confirms the container model holds.
+
+## Final Cleanup Verification
+
+- `git worktree list`: only main worktree present (no session-created worktrees).
+- `sp ps`: 0 active jobs. Pre-existing `dolt sql-server count 3 > expected 1` warning is operational/infra, not session-launched.
+- Process scan: gitnexus mcp / specialists / serena MCP processes all parent-attached to active terminals (pts/22 = this Claude Code session); not leaked.
+- `tmux ls`: only `design`, `infra`, `sre`, `ts` operator sessions. No `sp-*` / `xt-*` orphans.
+- Shared checkout: clean on `main`, untracked `.xtrm/skills/default/sre-triage/` remains (pre-existing operator-local mirror, intentionally untouched per yesterday's report Final Cleanup Verification).
+- `.xtrm/skills/default/setup-service-skills-sync/` confirmed gone (committed deletion in PR #335).


### PR DESCRIPTION
## Summary

SSOT session report for 2026-06-26. Small scope:

- PR #335 `chore/pre-container-cleanup` (already merged) — deprecation preamble on the reusable workflow, removed `setup-service-skills-sync` default skill, supersession notes on closed `xtrm-oafcs` / `xtrm-92wx3`.
- Architectural pivot: pane 1's `mercury-devops-collaborator` container design supersedes the CI-driven `service-skills-sync` flow for Mercury repos. Pane 3's `auto-reconcile-delivery.md` design doc (Options A/B/C/D) is archived rather than acted on.

Handoff bead: `xtrm-l7tkx` (P1, non-blocking relates to `xtrm-efa2a.1`, `xtrm-vu2ro.1`, `xtrm-u22fw`).
Prior SSOT: `.xtrm/reports/2026-06-25-4d5625ff.md` (release-prep + Phase C closeout).

Closes xtrm-zyqsx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)