### PR TITLE
docs(using-xtrm): xt worktree audit-prs/branch-gc/restart-audit (xtrm-brqvq)

### DIFF
--- a/.xtrm/config/instructions/agents-top.md
+++ b/.xtrm/config/instructions/agents-top.md
@@ -30,6 +30,7 @@ Use these as the minimal operational surface; use `--help` for full syntax.
 - `bd update <id> --claim`, `bd remember "<insight>"`, `bd close <id> --reason="..."`
 - `bv --robot-triage --format toon`, `bv --robot-next` — never bare `bv`
 - `xt report list` / latest report file, `xt update --apply`, `xt end`
+- `xt worktree --help` — PR/branch/restart audit primitives (`audit-prs`, `branch-gc`, `restart-audit`); pair with specialists `doctor --pr-drift` / `doctor --reap-dead-jobs`. Details: `/using-xtrm`.
 - `gh pr list --state merged --limit 5` or equivalent host CLI when PR context matters
 - `sp --help`, `sp list` / `specialists list`, `sp ps`, `sp feed <job-id>`, `sp result <job-id>`
 

--- a/.xtrm/config/instructions/claude-top.md
+++ b/.xtrm/config/instructions/claude-top.md
@@ -30,6 +30,7 @@ Use these as the minimal operational surface; use `--help` for full syntax.
 - `bd update <id> --claim`, `bd remember "<insight>"`, `bd close <id> --reason="..."`
 - `bv --robot-triage --format toon`, `bv --robot-next` — never bare `bv`
 - `xt report list` / latest report file, `xt update --apply`, `xt end`
+- `xt worktree --help` — PR/branch/restart audit primitives (`audit-prs`, `branch-gc`, `restart-audit`); pair with specialists `doctor --pr-drift` / `doctor --reap-dead-jobs`. Details: `/using-xtrm`.
 - `gh pr list --state merged --limit 5` or equivalent host CLI when PR context matters
 - `sp --help`, `sp list` / `specialists list`, `sp ps`, `sp feed <job-id>`, `sp result <job-id>`
 

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -1060,11 +1060,11 @@
           "version": "0.9.0"
         },
         "xt-end/SKILL.md": {
-          "hash": "2dec40f9b1277c2247a0b9bbdcc2a28c4188ae493d6609a62bdde8a2f42552b1",
+          "hash": "d0b6c9269c04e8c07b5c10417f0927cfcb80cd64e8c39d45b35c056591d8f768",
           "version": "0.9.0"
         },
         "xt-merge/SKILL.md": {
-          "hash": "3befa09563fed162193f62ff72811a5e113153659c15d85a9d3a31dd1276b2e2",
+          "hash": "4e99071c17bc5a408025328592e3d06a9e4cd1d816a27ef8237eff24cb26473b",
           "version": "0.9.0"
         }
       }
@@ -1376,11 +1376,11 @@
           "version": "0.9.0"
         },
         "instructions/agents-top.md": {
-          "hash": "cddfdf1346c908fb665d8a0a0288a81aa506b0ef671a6dea5c363033d0758c32",
+          "hash": "a481a666ac7163b136518a19f5ecfc2d2a080ce02ad7537347b366acc9d2ace9",
           "version": "0.9.0"
         },
         "instructions/claude-top.md": {
-          "hash": "baf969e03167f9dba696713fc3707256c5a2caf731cb79526ccd3df4dc6c423d",
+          "hash": "27012693e1be7629b26ef99f476527c519c22c4030af087efea6ed23f13c84f9",
           "version": "0.9.0"
         },
         "pi.mcp.json": {

--- a/.xtrm/skills/default/xt-end/SKILL.md
+++ b/.xtrm/skills/default/xt-end/SKILL.md
@@ -238,6 +238,29 @@ If cleanup is needed after `xt end --yes`:
 git worktree remove <path> --force
 ```
 
+Before destructive branch cleanup, use the safe audit/GC primitives rather than
+manually deleting refs:
+
+```bash
+xt worktree branch-gc --prefix xt/ --json      # dry-run by default
+xt worktree branch-gc --prefix xt/ --apply --yes
+```
+
+`branch-gc` must stay dry-run unless deletion is explicitly intended. Apply mode
+requires `--apply` plus confirmation/`--yes`; it should only delete merged/closed
+managed PR branches and skip open, unknown, no-PR, checked-out, or non-matching refs.
+
+For restart or handoff hygiene, run the read-only audit when local worktree state
+looks suspicious or after interrupted sessions:
+
+```bash
+xt worktree restart-audit --json
+```
+
+`restart-audit` is non-destructive: it reports orphaned managed dirs, branches
+without worktrees, closed-PR cleanup suggestions, and PRs needing operator
+attention. It must not delete directories/branches or replay hooks.
+
 Keep the worktree only if an explicit keep policy exists (for example, known immediate follow-up work on the same branch).
 
 ---
@@ -250,6 +273,7 @@ Always report:
 - linked or inferred issues
 - whether anomalies were auto-remediated
 - whether the worktree was removed
+- any branch-GC or restart-audit findings if those checks were run
 - reminder: monitor CI and merge when green; no auto-merge assumption
 
 If linkage had to be inferred from commits rather than detected by `xt end`, say so explicitly.

--- a/.xtrm/skills/default/xt-merge/SKILL.md
+++ b/.xtrm/skills/default/xt-merge/SKILL.md
@@ -82,6 +82,18 @@ pop it when done in Stage 6.
 
 ## Stage 1 — Build the queue
 
+Prefer the xt audit primitive first; it gives PR-state classifications (`clean`,
+`needs-rebase`, `conflict`, `blocked`, `closed`, `merged`) and JSON suitable for
+automation:
+
+```bash
+xt worktree audit-prs --json
+```
+
+Stop before merging if any queued PR reports `conflict`, `blocked`, or an
+unexpected/unknown state. For `needs-rebase`, run the rebase cascade before trusting
+CI or merging that PR. The audit is read-only; it must not rebase, push, or delete.
+
 List all open PRs from xt worktree branches:
 
 ```bash
@@ -94,8 +106,8 @@ This sorts by creation time. The top row is the **head of the queue** — merge 
 
 If there are draft PRs in the list, skip them. Drafts are not ready to merge.
 
-If `gh pr list` returns an error (network, auth, wrong repo), stop and report the
-error. Do not continue with stale or incomplete data.
+If `gh pr list` or `xt worktree audit-prs` returns an error (network, auth, wrong
+repo), stop and report the error. Do not continue with stale or incomplete data.
 
 Present the sorted queue to the user before proceeding:
 ```
@@ -255,10 +267,12 @@ When the queue is empty:
 git stash pop   # report any conflicts — do not discard silently
 
 gh pr list --state open
+xt worktree audit-prs --json
 git log origin/main --oneline -5
 ```
 
-Confirm no open xt/ PRs remain and show the user the final state of main.
+Confirm no open xt/ PRs remain, no xt PRs still need rebase/conflict attention,
+and show the user the final state of main.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,9 @@ bv --robot-insights | jq '.Cycles'               # Circular deps — must fix
 - `xt claude` — launch Claude Code in a sandboxed worktree
 - `xt pi` — launch Pi in a sandboxed worktree
 - `xt end` — close session: commit / push / PR / cleanup
+- `xt worktree audit-prs --json` — read-only PR drift / needs-rebase audit before merge queues
+- `xt worktree branch-gc --prefix xt/ --json` — dry-run merged/closed branch cleanup; add `--apply --yes` only when deletion is intended
+- `xt worktree restart-audit --json` — read-only restart/handoff hygiene audit for orphaned dirs, branch/worktree drift, and PR attention
 <!-- xtrm:end -->
 
 <!-- gitnexus:start -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Keep only the commands an agent needs without another manual. Use `--help` for f
 - `bv --robot-triage --format toon` / `bv --robot-next` — ranked work selection; never run bare `bv`.
 - `xt update --apply` — refresh xtrm-managed assets in a repo.
 - `xt end` — close worktree session / PR flow when appropriate.
+- `xt worktree audit-prs --json`, `branch-gc --json`, `restart-audit --json` — PR drift, safe branch-GC dry run, and restart/handoff hygiene.
 
 ### Specialists
 

--- a/XTRM-GUIDE.md
+++ b/XTRM-GUIDE.md
@@ -285,6 +285,9 @@ Enable with `xt skills enable <pack-name>`.
 | `pi` | Launch Pi in a sandboxed worktree |
 | `end` | Close worktree session: rebase, push, PR, cleanup |
 | `worktree list` | List all active worktrees |
+| `worktree audit-prs` | Read-only PR drift audit for xt worktree PRs (`needs-rebase`, conflicts, blocked/closed/merged states; JSON available) |
+| `worktree branch-gc` | Safe branch cleanup for merged/closed managed PR branches; dry-run by default, `--apply --yes` required to delete |
+| `worktree restart-audit` | Read-only restart/handoff audit for orphaned dirs, branches without worktrees, and PR attention findings |
 | `worktree clean` | Remove stale/merged worktrees |
 | `worktree remove` | Remove a specific worktree |
 | `docs` | Documentation inspection and drift-check suite (`xtrm docs --help`) |

--- a/skills/using-xtrm/SKILL.md
+++ b/skills/using-xtrm/SKILL.md
@@ -105,6 +105,22 @@ bd recall "quality-check-runs-twice-..."
 
 ---
 
+## PR / branch / restart audit primitives
+
+`xt worktree` exposes durable PR drift, branch GC, and restart audit primitives that downstream agents (Mercury devops collaborator, specialists orchestrators) compose instead of reimplementing inline `gh`/`git` bash.
+
+| Command | Use when | Composes with |
+|---|---|---|
+| `xt worktree audit-prs [--json]` | You want a structured report of every xt worktree's PR merge-state (`clean` / `needs-rebase` / `conflicted` / `blocked` / `stale` / `unknown`) without modifying branches | Specialists `doctor --pr-drift` consumes the same `gh pr view` shape; `sp ps --needs-attention` filters jobs whose PR is non-clean |
+| `xt worktree branch-gc [--prefix xt/] [--apply --yes] [--json]` | Stale `feature/<bead>-executor\|debugger\|reviewer` or `xt/*` branches need cleanup after merge; default is dry-run, `--apply` deletes only merged/closed PR branches | Run after `/xt-end` / `/xt-merge` to drop the merged branch trail; pairs with specialists chain-cleanup after reviewer PASS |
+| `xt worktree restart-audit [--prefix xt/] [--json]` | Container/host restarted; you need a startup/cron-safe audit of orphaned worktree dirs, branch/worktree drift, and PR-attention candidates | Pairs with specialists `doctor --reap-dead-jobs` — worktree-side orphans (this) + job-side orphans (specialists) cover both axes of a restart-recovery sweep |
+
+Safety: all three are read-only by default. `branch-gc` requires explicit `--apply --yes` to delete. Auto-rebase / force-push is never performed — conflict states are reported, never hand-resolved.
+
+`--json` output on all three includes structured fields (repo, branch, pr_url/pr_number, merge_state, action, outcome, duration_ms, redacted error) so cron and Mercury infra can consume them without parsing human output.
+
+---
+
 ## Prompt Shaping (silent, before every non-trivial task)
 
 | Task type | Apply |

--- a/skills/xt-end/SKILL.md
+++ b/skills/xt-end/SKILL.md
@@ -238,6 +238,29 @@ If cleanup is needed after `xt end --yes`:
 git worktree remove <path> --force
 ```
 
+Before destructive branch cleanup, use the safe audit/GC primitives rather than
+manually deleting refs:
+
+```bash
+xt worktree branch-gc --prefix xt/ --json      # dry-run by default
+xt worktree branch-gc --prefix xt/ --apply --yes
+```
+
+`branch-gc` must stay dry-run unless deletion is explicitly intended. Apply mode
+requires `--apply` plus confirmation/`--yes`; it should only delete merged/closed
+managed PR branches and skip open, unknown, no-PR, checked-out, or non-matching refs.
+
+For restart or handoff hygiene, run the read-only audit when local worktree state
+looks suspicious or after interrupted sessions:
+
+```bash
+xt worktree restart-audit --json
+```
+
+`restart-audit` is non-destructive: it reports orphaned managed dirs, branches
+without worktrees, closed-PR cleanup suggestions, and PRs needing operator
+attention. It must not delete directories/branches or replay hooks.
+
 Keep the worktree only if an explicit keep policy exists (for example, known immediate follow-up work on the same branch).
 
 ---
@@ -250,6 +273,7 @@ Always report:
 - linked or inferred issues
 - whether anomalies were auto-remediated
 - whether the worktree was removed
+- any branch-GC or restart-audit findings if those checks were run
 - reminder: monitor CI and merge when green; no auto-merge assumption
 
 If linkage had to be inferred from commits rather than detected by `xt end`, say so explicitly.

--- a/skills/xt-merge/SKILL.md
+++ b/skills/xt-merge/SKILL.md
@@ -82,6 +82,18 @@ pop it when done in Stage 6.
 
 ## Stage 1 — Build the queue
 
+Prefer the xt audit primitive first; it gives PR-state classifications (`clean`,
+`needs-rebase`, `conflict`, `blocked`, `closed`, `merged`) and JSON suitable for
+automation:
+
+```bash
+xt worktree audit-prs --json
+```
+
+Stop before merging if any queued PR reports `conflict`, `blocked`, or an
+unexpected/unknown state. For `needs-rebase`, run the rebase cascade before trusting
+CI or merging that PR. The audit is read-only; it must not rebase, push, or delete.
+
 List all open PRs from xt worktree branches:
 
 ```bash
@@ -94,8 +106,8 @@ This sorts by creation time. The top row is the **head of the queue** — merge 
 
 If there are draft PRs in the list, skip them. Drafts are not ready to merge.
 
-If `gh pr list` returns an error (network, auth, wrong repo), stop and report the
-error. Do not continue with stale or incomplete data.
+If `gh pr list` or `xt worktree audit-prs` returns an error (network, auth, wrong
+repo), stop and report the error. Do not continue with stale or incomplete data.
 
 Present the sorted queue to the user before proceeding:
 ```
@@ -255,10 +267,12 @@ When the queue is empty:
 git stash pop   # report any conflicts — do not discard silently
 
 gh pr list --state open
+xt worktree audit-prs --json
 git log origin/main --oneline -5
 ```
 
-Confirm no open xt/ PRs remain and show the user the final state of main.
+Confirm no open xt/ PRs remain, no xt PRs still need rebase/conflict attention,
+and show the user the final state of main.
 
 ---
 

--- a/templates/claude-md-fragments/bd-workflow.md
+++ b/templates/claude-md-fragments/bd-workflow.md
@@ -148,3 +148,6 @@ Gate output appears as hook context. Fix failures before proceeding — do not c
 
 - `xt claude` — launch Claude Code in a sandboxed worktree
 - `xt end` — close session: commit / push / PR / cleanup
+- `xt worktree audit-prs --json` — read-only PR drift / needs-rebase audit before merge queues
+- `xt worktree branch-gc --prefix xt/ --json` — dry-run merged/closed branch cleanup; add `--apply --yes` only when deletion is intended
+- `xt worktree restart-audit --json` — read-only restart/handoff hygiene audit for orphaned dirs, branch/worktree drift, and PR attention


### PR DESCRIPTION
## Summary

- `skills/using-xtrm/SKILL.md` — new "PR / branch / restart audit primitives" subsection with composition table mapping each xt subcommand to its specialists-side pairing (`doctor --pr-drift`, post-merge chain-cleanup, `doctor --reap-dead-jobs`). Includes safety notes (read-only by default, no auto-rebase / no force-push) and the structured `--json` field set.
- `.xtrm/config/instructions/{claude,agents}-top.md` — one-line `xt worktree --help` pointer added to the essential-commands list; compact templates stay compact (no flag tables).

## Why

xtrm-lk4on landed three durable xt primitives (`xt worktree audit-prs`, `branch-gc`, `restart-audit`) but `/using-xtrm` had zero mention of them, and Mercury devops collaborator + specialists orchestrators couldn't discover the xt-side surface without grepping source.

Companion: `specialists-agt` closed in `xtrm-dev/specialists` for the reverse cross-link in `/using-specialists-v3` (already on master via 07713d6e).

## Test plan

- [x] grep `audit-prs|branch-gc|restart-audit` matches in `skills/using-xtrm/SKILL.md` (4 hits)
- [x] grep `xt worktree --help` matches in both `claude-top.md` and `agents-top.md`
- [x] No new tables or long manuals added to compact templates
- [x] Pre-commit hooks pass (whitespace, EOF, secrets, conflict markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)