### PR TITLE
docs(sre-triage): teach opentelemetry-mcp mcpq server

### DIFF
--- a/.xtrm/skills/default/sre-triage/SKILL.md
+++ b/.xtrm/skills/default/sre-triage/SKILL.md
@@ -2,9 +2,10 @@
 name: sre-triage
 description: >-
   Cross-stack health verification with runtime-inferred routing. Queries
-  Prometheus + Grafana live via the `mcpq` CLI (sidecar registry lives in
-  `.mcpq.json` — `mcpq servers` lists them) to enumerate firing alerts, down
-  containers, and stale freshness feeds; matches each finding to a registered
+  Prometheus + Grafana + OpenTelemetry traces live via the `mcpq` CLI (sidecar
+  registry lives in `.mcpq.json` — `mcpq servers` lists them) to enumerate firing
+  alerts, down containers, stale freshness feeds, and trace-side error hot-spots;
+  matches each finding to a registered
   service skill by listing the service-skills directory and matching container
   prefix / `territory:` globs; emits a triage report and loads expert personas
   for affected services. Also handles retroactive investigation of past alerts —
@@ -137,6 +138,46 @@ mcpq prometheus call example_project_execute_query \
 Warn when host CPU > 80%, host memory > 85%, any container > 80% CPU, or any
 container > 85% memory-vs-limit. Use the offending container name to load the
 right service skill before diagnosing further.
+
+---
+
+### Step 1c — Trace-side signals via `opentelemetry-mcp`
+
+Added 2026-07-01 (infra-z398). Whenever a service in the mcpq registry (`mcpq
+servers` → `opentelemetry-mcp`) is present, use it to pull span-level context
+that Prometheus alone cannot surface: which specific request path is erroring,
+which upstream span propagated a fault, and which LLM tool call is dominating
+latency. Backed by Tempo; only services actively emitting OTel spans show up.
+
+Use these tools opportunistically alongside Step 1 — they are especially useful
+when Step 1 shows a `severity=warning`/`critical` on an instrumented service or
+when the user reports "requests are slow" without a firing alert:
+
+```bash
+# What services are currently reporting spans?
+mcpq opentelemetry-mcp call list_services --json
+
+# Recent traces that carried an error status
+mcpq opentelemetry-mcp call find_errors --json
+
+# Slowest LLM traces (only meaningful if any producer emits traceloop.* attrs)
+mcpq opentelemetry-mcp call get_llm_slow_traces --json
+
+# One specific trace by ID (e.g. from a forensic.v1 log's correlation.trace_id)
+mcpq opentelemetry-mcp call get_trace --arg trace_id=<hex> --json
+```
+
+Full tool inventory: `mcpq opentelemetry-mcp list-tools`.
+
+Trace-side signals **do not** classify the stack on their own (see Step 2 for
+overall state). They enrich the routing decision in Step 3: an erroring service
+in `find_errors` output routes to that service's expert skill exactly like a
+`up == 0` result would.
+
+Fallback if the sidecar is unreachable: query Tempo directly via
+`docker exec infra-prometheus wget -qO- 'http://tempo:3200/api/search?...'` OR
+open the Tempo datasource in Grafana — do not skip trace-side signals silently
+when investigating a latency/error incident on an instrumented service.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds Step 1c to the `sre-triage` skill so operators + agents know they can call Tempo-backed trace queries via `mcpq` alongside the existing Prometheus + Grafana probes.

The Mercury infra shipped an `opentelemetry-mcp` sidecar backed by Tempo on 2026-06-30 (mercury-infra PR #182), and moved its mcpq registry entry into the canonical parent `~/projects/mercury/.mcpq.json` on 2026-07-01 (mercury-infra PR #183). This PR teaches the canonical `sre-triage` skill about the new query surface so every downstream materialization picks it up on `xt update --apply`.

## Changes
- `sre-triage` description header: now mentions "OpenTelemetry traces" and "trace-side error hot-spots"
- New **Step 1c — Trace-side signals via `opentelemetry-mcp`**: covers `list_services`, `find_errors`, `get_llm_slow_traces`, `get_trace` — with fallback guidance (docker exec Tempo query API, or Grafana Tempo datasource)

## Verification
- Live-smoked in mercury-infra: `mcpq opentelemetry-mcp list-tools` returns 11 tools, `list_services` returns `mmd-api`
- Sidecar container `infra-opentelemetry-mcp` up and healthy
- Materialized copy at `mercury-infra/.xtrm/skills/default/sre-triage/SKILL.md` already updated with project-specific customization