### PR TITLE
ci: split PR CI to hosted, push CI to Mercury runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,12 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["self-hosted","linux","mercury-lite","xtrm-tools"]') }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON(vars.CI_RUNNER || '["self-hosted","linux","mercury-lite","xtrm-tools"]') }}
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_RUNNER || '["self-hosted","linux","mercury-lite","xtrm-tools"]') }}
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Implements infra-wmlx Opt1 for the first xtrm-tools migration slice (`ci.yml` only):

- `pull_request` CI stays on GitHub-hosted `ubuntu-latest` for untrusted PR code.
- trusted `push` CI uses the Mercury runner class via `vars.CI_RUNNER` with the existing xtrm-tools fallback label.
- adds explicit least-privilege `permissions: contents: read`.
- leaves release/secrets-bearing workflows (`publish.yml`, NPM_TOKEN, `id-token: write`) untouched/deferred per infra-c5v8.

## Threat model / decision

Coordinator decision from infra-c5v8: untrusted PR code must not execute on the shared Mercury self-hosted pool because shared runner-work volume + later secrets-bearing deploy/release jobs creates an exfiltration risk class.

This PR therefore migrates only trusted push/post-merge CI to Mercury runner while keeping PR CI hosted.

## Scope

Changed file only:

- `.github/workflows/ci.yml`

No test/build/lint steps changed.

## Local validation

- YAML parse sanity: PASS
- `npm run lint`: PASS
- `npm run typecheck`: PASS
- diff scope vs current `origin/main`: only `.github/workflows/ci.yml`

## Specialist gates

- executor fix: `c4a90d` → commit `3145dfa2`
- seconder: `3102f9` PASS
- test-runner: `1979c4` PASS
- security-auditor: `085a3d` PASS / no findings
- obligations-scanner: `87c575` CLEAN
- reviewer/judge: `ae1e35` PASS / merge-ready, pending runtime runner proof

## Runtime proof still required before merge

- PR event should show `CI / test` running on GitHub-hosted `ubuntu-latest`.
- After merge, trusted push should show CI running on Mercury runner via `CI_RUNNER`.

Do not merge before judge/runtime proof.
