### PR TITLE
fix(skills,templates): broaden --parent framing beyond epic-only

### DIFF
--- a/.xtrm/skills/default/using-xtrm/SKILL.md
+++ b/.xtrm/skills/default/using-xtrm/SKILL.md
@@ -56,6 +56,7 @@ Use these command surfaces when the task is operational rather than code-editing
 | Unfamiliar area of code | `gitnexus_query({query: "concept"})` before opening any file |
 | About to edit a symbol | `gitnexus_impact({target: "name", direction: "upstream"})` |
 | Before `git commit` | `gitnexus_detect_changes({scope: "staged"})` to verify scope |
+| About to `bd create` a bead for a specialist dispatch | Add `--parent <bead-it-services>` (nests `.1`, recursive `.1.1`) + title `<role>: <task>` — never a loose top-level bead |
 | Reading code | `get_symbols_overview` → `find_symbol` — never read whole files |
 | Task is tests | use /test-planning
 | Task is docs updates | use /sync-docs

--- a/templates/claude-md-fragments/bd-workflow.md
+++ b/templates/claude-md-fragments/bd-workflow.md
@@ -1,6 +1,6 @@
 ---
 name: bd-workflow
-version: 1.0.0
+version: 1.0.1
 description: bd issue tracking + bv triage + git/worktree workflow + active gates
 ---
 # XTRM Agent Workflow
@@ -50,7 +50,8 @@ bd update                              # Update last-touched issue (no ID needed
 
 # Creating
 bd create --title="..." --description="..." --type=task --priority=2
-# --parent <epic-id>                   epic child: auto-names `.1`, `.2`, … and adds parent edge
+# --parent <bead-id>                    nest as <id>.1, .2, … (recursive: .1.1) — default whenever this bead
+#                                        services another bead's work, not only epics
 # --deps "discovered-from:<parent-id>"  link follow-ups to source
 # priority: 0=critical  1=high  2=medium  3=low  4=backlog
 # types: task | bug | feature | epic | chore | decision


### PR DESCRIPTION
## Summary
- `templates/claude-md-fragments/bd-workflow.md`: `--parent` line said "epic child" only — same framing bug already fixed in `using-specialists-v3` (v3.6) earlier this session. Broadened to any bead, version bumped 1.0.0 → 1.0.1.
- `.xtrm/skills/default/using-xtrm/SKILL.md`: added a Trigger Patterns row for `bd create --parent` nesting, so orchestrators get the reflex at bead-creation time instead of relying on the deeper `using-specialists-v3` rationale being loaded.

## Test plan
- [x] Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)