### PR TITLE
docs(skills,templates): add contract:draft/ready bead-promotion gate

### DIFF
--- a/.xtrm/skills/default/planning/SKILL.md
+++ b/.xtrm/skills/default/planning/SKILL.md
@@ -56,6 +56,25 @@ Before touching any code, nail down:
 
 If the request is under 8 words or the scope is unclear, ask **one** clarifying question before exploring. Don't ask two.
 
+### Draft capture mode — when the ask is "log this for later," not "plan this now"
+
+Full Phase 1–4 rigor is expensive, and demanding it for every captured idea is what produces the failure this skill exists to prevent — a user skips the bead entirely, or you write a one-liner. When the intent is clearly deferred work (backlog capture, "someone should look at this eventually," an idea surfaced mid-task that isn't the current focus), skip straight to a **draft bead** instead of running Phases 2–4:
+
+```bash
+bd create --title "..." --labels contract:draft --type task --priority 3 \
+  --description "PROBLEM: <2+ real sentences — why this matters, not the title restated>
+SCOPE: <rough guess — 'somewhere in src/auth/, needs investigation' is fine here>
+SUCCESS: TBD — needs exploration
+NON_GOALS: TBD — needs exploration
+CONSTRAINTS: TBD — needs exploration
+VALIDATION: TBD — needs exploration
+OUTPUT: TBD — needs exploration"
+```
+
+**No one-liners, ever — draft mode included.** PROBLEM must be real prose, SCOPE must be a real guess, and every other section must explicitly say `TBD — needs exploration` rather than being silently absent. Draft state lowers the bar on completeness, never on honesty about what's still unknown.
+
+**A draft bead cannot be dispatched.** `using-specialists-v3` rule #15 hard-refuses any specialist run against a `contract:draft` bead. Promoting it later means coming back to this skill and actually running Phases 2–4 (explore, structure, rewrite) against the real bead, then `bd set-state <id> contract=ready --reason "..."`. Draft mode defers the work, not the eventual rigor.
+
 ---
 
 ## Phase 2 — Explore Codebase (Read-Only)
@@ -526,6 +545,7 @@ Before presenting the plan to the user:
 - [ ] If refactor scope exists, rename/extract safety checks were included in plan
 - [ ] test-planning was invoked (or scheduled as next step), including smoke/E2E and log/telemetry requirements
 - [ ] First implementation issue is ready to claim
+- [ ] Any bead intentionally left in draft capture mode carries `contract:draft`, a real PROBLEM + rough SCOPE, and explicit `TBD` markers elsewhere — not silent gaps
 
 If any issue description is empty or just restates the title — it's not ready.
-The test of a good issue: could another agent pick it up cold and succeed?
+The test of a good issue: could another agent pick it up cold and succeed? (For a `contract:draft` bead, the test is different: could another agent tell *why this exists* and *that it needs promotion before dispatch*?)

--- a/.xtrm/skills/default/using-specialists-v3/SKILL.md
+++ b/.xtrm/skills/default/using-specialists-v3/SKILL.md
@@ -7,7 +7,7 @@ description: >
   security checks, multi-step chains, integration-phase reconciliation,
   debugger-restitch on conflicting chains, pre-dispatch conflict-cluster
   mapping, test-failure-map epics, and questions about specialist workflow.
-version: 3.6
+version: 3.7
 ---
 
 # Using Specialists v3
@@ -215,6 +215,7 @@ Do small deterministic edits directly when scope is already obvious and delegati
 12. Drive routine stages autonomously once task is clear. Escalate only for human judgment, destructive actions, repeated crashes, or reviewer `FAIL`.
 13. The orchestrator NEVER edits code directly. Conflict resolution, even mechanical, goes through a debugger or executor specialist. Manual conflict resolution always escalates to the operator. (Exception: epics that explicitly restructure the specialists themselves — bootstrapping via the specialists they restructure is circular. Such epics are operator-authorized manual-orchestrator-direct work and must say so up-front.)
 14. Before dispatching any chain whose work depends on prior chain output, verify git state per the Git State Precondition section: `git status` clean, HEAD contains prior chain commits, no orphaned worktrees. Stale-base dispatch produces guaranteed debugger-restitch loops downstream.
+15. Never dispatch a specialist against a bead tagged `contract:draft` (`bd state <id> contract` returns `draft` or nothing). Promote it first — see Draft Beads And The Promotion Gate. A draft is a sanctioned capture format, not a shortcut around bead quality.
 
 ## Escalation Matrix
 
@@ -238,6 +239,7 @@ Do small deterministic edits directly when scope is already obvious and delegati
 | `npm publish` | Never | Always |
 | Dependency bump | Auto for security-patch bumps | Major/minor bumps escalate |
 | Config file schema-changing edit | Never | Always |
+| Dispatch against `contract:draft` bead | Never (rule #15) | Always — promote first: explore + rewrite full 7-section contract + `bd set-state <id> contract=ready --reason "..."` |
 
 ## Live Registry And Help
 
@@ -299,6 +301,38 @@ Fix three bad smells fast:
 - Missing VALIDATION. Say what proves done, not just that work is “finished.”
 
 What differs: orchestrator writes contract before dispatch, so specialist does less guessing and more useful work.
+
+## Draft Beads And The Promotion Gate
+
+Full 7-section contracts are expensive to write for an idea you won't touch for weeks. Demanding that rigor for every captured thought is exactly what produces the other failure mode: skipping the bead entirely, or writing a one-liner. There is a third, sanctioned option — but it is a capture format, not an escape hatch.
+
+**Draft state.** Tag a bead `contract:draft` at creation:
+
+```bash
+bd create --title "..." --labels contract:draft --type task --priority 3 \
+  --description "PROBLEM: <2+ real sentences — why this matters, not a title restated>
+SCOPE: <rough guess — 'somewhere in src/auth/, needs investigation' is fine>
+SUCCESS: TBD — needs exploration
+NON_GOALS: TBD — needs exploration
+CONSTRAINTS: TBD — needs exploration
+VALIDATION: TBD — needs exploration
+OUTPUT: TBD — needs exploration"
+```
+
+**No one-liners, ever — draft or not.** A draft still requires a real PROBLEM (why this exists, in prose) and a rough SCOPE. Every other section must be present and say `TBD — needs exploration` explicitly. A bare title, or a description that just restates the title, is never a valid bead — draft state lowers the bar on *completeness*, not on *honesty about what's missing*.
+
+**The promotion gate (rule #15).** No specialist may be dispatched against a `contract:draft` bead. Before dispatch, the orchestrator must:
+
+1. Re-read the bead (`bd show <id>`).
+2. Actually explore — the same Phase 2 evidence-gathering the `planning` skill requires before writing a real contract (`gitnexus_query`/`gitnexus_context`/`gitnexus_impact`, or Serena symbol reads).
+3. Rewrite the bead in place to the full 7-section contract (`bd update <id> --description "..."`), replacing every `TBD` with real content grounded in what was just found.
+4. Flip the state: `bd set-state <id> contract=ready --reason "Explored via <what>; rewrote to full contract"`.
+
+Check before any dispatch: `bd state <id> contract` — if it returns `draft` or nothing, stop and promote. This is a hard refuse (Escalation Matrix), not a warning — a stale draft wastes a full specialist turn on a contract the executor will have to guess at, which is the exact failure this rule exists to prevent.
+
+**Current enforcement is a bridge.** This is orchestrator-discipline-enforced today, not yet a hard `sp run` pre-dispatch check — see `specialists-roadmap.md` §5.3 for the planned real enforcement (same class as the existing C1 cwd-mismatch hard-refuse). Follow the rule anyway; do not treat the absence of a hook as license to dispatch against a draft.
+
+What differs: orchestrator has a sanctioned way to capture backlog ideas cheaply without either over-scoping them immediately or letting them decay into unusable one-liners.
 
 ## Bead Title Convention (canonical)
 

--- a/.xtrm/skills/default/using-xtrm/SKILL.md
+++ b/.xtrm/skills/default/using-xtrm/SKILL.md
@@ -57,6 +57,8 @@ Use these command surfaces when the task is operational rather than code-editing
 | About to edit a symbol | `gitnexus_impact({target: "name", direction: "upstream"})` |
 | Before `git commit` | `gitnexus_detect_changes({scope: "staged"})` to verify scope |
 | About to `bd create` a bead for a specialist dispatch | Add `--parent <bead-it-services>` (nests `.1`, recursive `.1.1`) + title `<role>: <task>` — never a loose top-level bead |
+| About to dispatch a specialist (`sp run`) | `bd state <id> contract` — if `draft` or unset, promote first (explore + rewrite full contract + `bd set-state <id> contract=ready`); never dispatch against a draft |
+| Just capturing an idea for later, not working it now | `bd create --labels contract:draft` with a real PROBLEM + rough SCOPE, everything else `TBD` — never a one-liner |
 | Reading code | `get_symbols_overview` → `find_symbol` — never read whole files |
 | Task is tests | use /test-planning
 | Task is docs updates | use /sync-docs

--- a/templates/claude-md-fragments/bd-workflow.md
+++ b/templates/claude-md-fragments/bd-workflow.md
@@ -1,6 +1,6 @@
 ---
 name: bd-workflow
-version: 1.0.1
+version: 1.0.2
 description: bd issue tracking + bv triage + git/worktree workflow + active gates
 ---
 # XTRM Agent Workflow
@@ -31,6 +31,7 @@ description: bd issue tracking + bv triage + git/worktree workflow + active gate
 | **Commit** | `git commit` while claim is open | `bd close <id>` first, then commit |
 | **Stop** | Session end with unclosed claim | `bd close <id>` |
 | **Memory** | `bd close <id>` without issue ack | First run `bd remember "<insight>"` (or decide nothing novel), then `bd kv set "memory-acked:<id>" "saved:<key>"` or `"nothing novel:<reason>"`, then retry `bd close <id> --reason="..."` (Stop hook remains fallback reminder) |
+| **Dispatch** *(bridge — discipline only, not yet hook-enforced)* | Specialist run against a `contract:draft` bead | Promote first: explore + rewrite full 7-section contract + `bd set-state <id> contract=ready --reason "..."`. Check with `bd state <id> contract` before dispatch. |
 
 ## bd Command Reference
 
@@ -52,6 +53,8 @@ bd update                              # Update last-touched issue (no ID needed
 bd create --title="..." --description="..." --type=task --priority=2
 # --parent <bead-id>                    nest as <id>.1, .2, … (recursive: .1.1) — default whenever this bead
 #                                        services another bead's work, not only epics
+# --labels contract:draft               capture-for-later: real PROBLEM + rough SCOPE, rest TBD — never dispatchable
+#                                        until promoted (`bd set-state <id> contract=ready`); see using-specialists-v3
 # --deps "discovered-from:<parent-id>"  link follow-ups to source
 # priority: 0=critical  1=high  2=medium  3=low  4=backlog
 # types: task | bug | feature | epic | chore | decision


### PR DESCRIPTION
## Summary
Mirrors specialists' `contract:draft`/`contract:ready` bead-lifecycle convention into the canonical sources:
- `using-specialists-v3` v3.7 — rule #15 hard-refuse + "Draft Beads And The Promotion Gate" section.
- `planning` — "Draft capture mode."
- `using-xtrm` — 2 new Trigger Patterns rows.
- `bd-workflow.md` fragment v1.0.2 — new Dispatch gate row (marked bridge-only) + `--labels contract:draft` example.

## Test plan
- [x] Doc-only change; diffed against specialists' already-merged source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)