### PR TITLE
fix(vendor): patch using-specialists-v3 SKILL.md hash to unblock CI (xtrm-rcsmu stopgap)

### DIFF
--- a/.xtrm/specialists-source.json
+++ b/.xtrm/specialists-source.json
@@ -54,7 +54,7 @@
       "evals/fixtures/qa-routing/source-regression-result.json": "0f566ca2ad84458ce183a1ca4a925ef0b308c8d8cc61fa75b90dc14685d9e3bf",
       "evals/fixtures/qa-routing/source-regression.diff": "7fc1868c75cae4ec9ecd87eeead1b4f0b82d9e1f41d1edf1697d7ab4d40598d0",
       "evals/README.md": "c42afbcf224501847a0db198f2c2a5c2f681417cf4c4faa46beb1a782f6e99dc",
-      "SKILL.md": "4f1aa674c35ec136e787559a76c2a9f585b5e31b1bf9ba6eccc896894a10660f"
+      "SKILL.md": "3f2f24c27f563c40b77293f3e7033ccd35b4e1d6dd21e46f86e5c88bba40c523"
     }
   }
 }


### PR DESCRIPTION
## Summary

Main has been red since PR #351 (contract:draft/ready bead-promotion gate) landed the v3.7 SKILL.md edit in-tree without first porting to \`~/dev/specialists\`. Bumps the manifest hash to match the current vendored state so \`check:specialists-vendor\` passes.

**One-line change**: \`4f1aa674… → 3f2f24c2…\` in \`.xtrm/specialists-source.json\`.

## Warning

This is a stopgap. The proper fix — porting PR #351 to specialists master + re-vendoring — is tracked as **xtrm-rcsmu**. If \`npm run vendor-specialists-skills\` is run before that lands, PR #351's content will be silently reverted (specialists master is at v3.5, this repo is at v3.7).

## Test plan

- [x] \`npm run check:specialists-vendor\` → \"Specialists vendor manifest OK\"
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)