### PR TITLE
chore(vendor): refresh specialists skills from v3.18.1 (closes xtrm-rcsmu)

### DIFF
--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -908,7 +908,7 @@
           "version": "0.9.1"
         },
         "specialists-creator/scripts/audit-spec-uniformity.mjs": {
-          "hash": "cfc6aa6fc89f18c2e1ddf794047b309aa8cb0185617d84545eb5cb20135d5ac4",
+          "hash": "0ada06784cfd5c3adfa9c9908a9cd23380e8278fb57329fc616a83140a47fb33",
           "version": "0.9.1"
         },
         "specialists-creator/scripts/scaffold-specialist.ts": {
@@ -920,7 +920,7 @@
           "version": "0.9.1"
         },
         "specialists-creator/SKILL.md": {
-          "hash": "f84c22e11e08f83ab73c7f3d52df3b071037600740352713d1494f57799b679e",
+          "hash": "223ab14dbd1c2443f147600691819408faed9f13524d485c0b99394fa84e0981",
           "version": "0.9.1"
         },
         "sre-triage/scripts/alert_history.py": {
@@ -1425,9 +1425,9 @@
   "specialists_source": {
     "version": 1,
     "source": {
-      "kind": "ref",
+      "kind": "repo",
       "ref": "master",
-      "resolved_sha": "3deb623228ad5ab58053a52c434632430c58fb9b",
+      "resolved_sha": "782b572e1e5ca854d0318060615cbcc23ad9fe96",
       "repo_path": "../specialists",
       "source_path": "config/skills"
     },
@@ -1444,10 +1444,10 @@
     ],
     "files": {
       "specialists-creator": {
-        "scripts/audit-spec-uniformity.mjs": "cfc6aa6fc89f18c2e1ddf794047b309aa8cb0185617d84545eb5cb20135d5ac4",
+        "scripts/audit-spec-uniformity.mjs": "0ada06784cfd5c3adfa9c9908a9cd23380e8278fb57329fc616a83140a47fb33",
         "scripts/scaffold-specialist.ts": "c1bfa3693d644072e6d387d2519e131624d99c5b85521ae638680d7485267403",
         "scripts/validate-specialist.ts": "3a5f5a3a77c50e98ecf9188634ff2882f8143b19d0f28a53aff5c42e1bd09dfa",
-        "SKILL.md": "f84c22e11e08f83ab73c7f3d52df3b071037600740352713d1494f57799b679e"
+        "SKILL.md": "223ab14dbd1c2443f147600691819408faed9f13524d485c0b99394fa84e0981"
       },
       "update-specialists": {
         "SKILL.md": "fdf8c680cf3e5dce80c9426f52b56c953f4f7f663c23a33a3378b2b6e4bab5a9"

--- a/.xtrm/skills/default/specialists-creator/SKILL.md
+++ b/.xtrm/skills/default/specialists-creator/SKILL.md
@@ -5,8 +5,8 @@ description: >
   agent through writing a valid `.specialist.json`, choosing supported models,
   validating against the schema, and avoiding common specialist authoring
   mistakes.
-version: 1.3
-synced_at: 78a7883e
+version: 1.4
+synced_at: fc9168e2
 ---
 
 # Specialist Author Guide
@@ -266,7 +266,7 @@ Avoid vague descriptions like "general purpose assistant" or "helps with code". 
 | `mode` | enum | `auto` | `tool` \| `skill` \| `auto` |
 | `timeout_ms` | number | `120000` | ms |
 | `stall_timeout_ms` | number | — | kill if no event for N ms |
-| `interactive` | boolean | `false` | enable multi-turn keep-alive by default |
+| `interactive` | boolean | `false` | enable multi-turn keep-alive by default (also overridable globally via `~/.config/specialists/user.json`) |
 | `response_format` | enum | `text` | `text` \| `json` \| `markdown` |
 | `output_type` | enum | `custom` | `codegen` \| `analysis` \| `review` \| `synthesis` \| `orchestration` \| `workflow` \| `research` \| `custom` |
 | `permission_required` | enum | `READ_ONLY` | see tier table below |
@@ -281,7 +281,8 @@ Avoid vague descriptions like "general purpose assistant" or "helps with code". 
 - Run-level overrides still apply:
   - CLI: `--keep-alive` enables, `--no-keep-alive` disables.
   - MCP `start_specialist`: `keep_alive` enables, `no_keep_alive` disables.
-- Effective precedence: explicit disable (`--no-keep-alive` / `no_keep_alive`) → explicit enable (`--keep-alive` / `keep_alive`) → `execution.interactive` → one-shot default.
+- Effective precedence: explicit disable (`--no-keep-alive` / `no_keep_alive`) → explicit enable (`--keep-alive` / `keep_alive`) → merged `execution.interactive` (package / global user.json / repo) → one-shot default.
+- When the operator wants a cross-repo default, prefer `sp edit --global --set <name>.execution.interactive true|false` over forking per-repo specs.
 
 **Permission tiers** — controls the *native* pi tools the specialist gets. The full resolved tool set also includes catalog-defined GitNexus and Serena tools per tier; see [docs/manifest.md](../../../docs/manifest.md) for the complete picture.
 
@@ -651,6 +652,131 @@ This specialist goes STALE the moment `schema.ts` or `runner.ts` is modified aft
 
 ---
 
+## Global User Override Layer (KAN-90/91)
+
+The same per-spec field schema documented above is also exposed at a **global,
+cross-repo layer** since 2026-06-13. Operators do not need to fork a
+`.specialists/user/<name>.specialist.json` per repo just to swap their model or
+opt out of an extension — those changes live once in
+`~/.config/specialists/user.json` and apply everywhere.
+
+### 3-layer field merge
+
+`SpecialistLoader.get()` resolves fields top-down:
+
+1. **Package canonical** — `config/specialists/<name>.specialist.json` shipped
+   in `@jaggerxtrm/specialists`. Most fields are concrete defaults; `model` and
+   `fallback_model` ship as `null` since KAN-90 part 2.
+2. **`~/.config/specialists/user.json`** — operator's global override. Wins
+   over package canonical for the allowlisted user-environment fields.
+3. **`.specialists/user/<name>.specialist.json`** — per-repo override. Wins
+   over global. Can change any field, including ones blocked at the global
+   layer.
+
+The pre-KAN-90 `.specialists/default/<name>.specialist.json` mirror is no
+longer walked (commit `31a6421c`).
+
+### CLI surface
+
+| Command | Effect |
+|---|---|
+| `sp init --global` | Bootstraps `~/.config/specialists/user.json` with null placeholders for every spec; writes `_doc` sentinel + `overrides-guide.md`. Idempotent — preserves existing values, only adds entries for newly-discovered specialists on re-run. |
+| `sp edit --global --set <name>.<dot.path> <value>` | Writes one field in `user.json` (schema-validated). |
+| `sp edit --global --get <name>.<dot.path>` | Reads the current merged value. |
+| `sp doctor --specialists` | Reports `N/M specialists have a model configured`, lists missing models, and surfaces blocked-field overrides applied with warning. |
+| `sp config show <name> --resolved` | Shows the merged spec for one specialist with per-layer attribution. |
+
+The bare positional form (`sp edit --global <name>.field value` without
+`--set`) currently falls through to `$EDITOR` in some environments — prefer
+`--set` in scripts.
+
+### Allowlist mapping (which fields can be set globally)
+
+The constants in `src/specialist/schema.ts` define what the global layer may
+write:
+
+```ts
+OVERRIDE_ALLOWED_EXECUTION_FIELDS = [
+  'model', 'fallback_model', 'fallback_models',
+  'timeout_ms', 'stall_timeout_ms', 'interactive', 'thinking_level',
+  'max_retries', 'prompt_limit_bytes', 'stdout_limit_bytes',
+]
+OVERRIDE_ALLOWED_NESTED_EXECUTION_PATHS = [
+  'extensions.serena', 'extensions.gitnexus',
+]
+OVERRIDE_ALLOWED_STALL_DETECTION_PATHS = ['waiting_auto_close_ms']
+OVERRIDE_ALLOWED_PROMPT_FIELDS = ['system_prompt_mode']
+OVERRIDE_ALLOWED_TOP_FIELDS = ['beads_write_notes', 'notes_mode', 'output_file']
+```
+
+So `sp edit --global --set executor.notes_mode final-only` is allowed; the
+same effect for `permission_required`, `prompt.system`, `mandatory_rules`,
+`capabilities`, `output_schema`, `auto_commit`, `skills.scripts`, or
+`prompt.task_template` is **blocked at the global layer** and must be done
+per-repo in `.specialists/user/<name>.specialist.json`. A blocked field that
+sneaks into `user.json` is applied with a `BlockedFieldWarning` and reported
+by `sp doctor --specialists`.
+
+### Same fields as the per-spec reference
+
+Every field documented above in `## Schema Reference` applies at the global
+layer with the same semantics — only the **scope** changes (one machine vs one
+repo). Examples:
+
+```bash
+# Set notes_mode + output_file globally for a chained pipeline reader
+sp edit --global --set sync-docs.notes_mode final-only
+sp edit --global --set sync-docs.output_file ".specialists/sync-docs-result.md"
+
+# Opt out of Serena MCP injection on a read-only specialist (RAM saver)
+sp edit --global --set overthinker.execution.extensions.serena false
+
+# Set the default keep-alive behavior globally for one specialist
+sp edit --global --set reviewer.execution.interactive false
+
+# Auto-close forgotten waiting sessions after 1h (graceful close first)
+sp edit --global --set reviewer.stall_detection.waiting_auto_close_ms 3600000
+
+# Set system_prompt_mode to replace globally for a bare specialist
+sp edit --global --set my-bare-spec.prompt.system_prompt_mode replace
+
+# Plural fallback chain (KAN-91 Phase 2; walked on transient failures only)
+sp edit --global --set executor.execution.fallback_models \
+  '["openai-codex/gpt-5.5","anthropic/claude-sonnet-4-6"]'
+```
+
+### Preset references (KAN-91 Phase 3)
+
+Both `model` and `fallback_model`/`fallback_models` entries may be a
+`@preset/<name>` reference:
+
+```bash
+sp edit --global --set executor.execution.model @preset/medium
+sp edit --global --set executor.execution.fallback_models '["@preset/cheap"]'
+sp edit --list-presets    # show available preset names in the installed package
+```
+
+Built-in presets typically include `cheap`, `medium`, `power`. Depth cap = 5;
+cycles surface a structured error at dispatch.
+
+### `_doc` sentinel and `overrides-guide.md`
+
+`sp init --global` writes a `_doc` key at the top of `user.json` pointing at
+`./overrides-guide.md`, and (re)generates that guide with the live field
+reference. Any other `_`-prefixed keys are tolerated as comments. Authors of a
+new specialist should run `sp init --global` after release so existing operators
+get a fresh null-placeholder entry on next bootstrap.
+
+### Pitfall — `thinking_level: "off"`
+
+`thinking_level: null` inherits pi's `defaultThinkingLevel` (typically `high`
+on most installs). Forcing `off` on certain thinking-class models (verified:
+Kimi-via-nano-gpt) silently produces an empty assistant text turn after
+multi-tool runs because the model's tool-result-summary phase needs thinking
+budget. Leave it `null` unless you have a documented reason to force a level.
+
+---
+
 ## Built-in Template Variables
 
 These are **always available** in `task_template` — no configuration needed:
@@ -794,6 +920,7 @@ Quality degrades as the context grows — compressed early context causes incons
 
 **Rules when authoring a specialist:**
 - Set `stall_timeout_ms` explicitly for any specialist that may idle between turns (keep-alive/interactive). Without it, a stuck session holds resources indefinitely.
+- If the operator wants forgotten waiting sessions to retire automatically, set `stall_detection.waiting_auto_close_ms` explicitly; keep it unset/0 when human follow-up should remain indefinitely resumable.
 - Use `thinking_level: low` for orchestration/coordinator specialists that emit structured JSON output — thinking tokens cost context budget without improving structured output quality.
 - For research/explorer specialists: bounded scope per session + `handoff_summary` in `output_schema` > one unbounded session.
 - `interactive: true` specialists must define what "done" looks like in their system prompt — otherwise they drift.
@@ -827,6 +954,7 @@ Before finalising a specialist that uses `interactive: true` or is expected to r
 
 ```
 [ ] stall_timeout_ms set (not relying on timeout_ms alone)
+[ ] waiting_auto_close_ms decision made (unset/0 for indefinite waiting, explicit ms for auto-retire)
 [ ] thinking_level set appropriately for the output type
 [ ] output_schema includes handoff_summary or equivalent for rotation
 [ ] system prompt has explicit termination condition ("you are done when...")

--- a/.xtrm/skills/default/specialists-creator/scripts/audit-spec-uniformity.mjs
+++ b/.xtrm/skills/default/specialists-creator/scripts/audit-spec-uniformity.mjs
@@ -27,7 +27,7 @@ const KNOWN = {
   capabilities: new Set(['required_tools','external_commands','diagnostic_scripts']),
   communication: new Set(['next_specialists','publishes']),
   validation: new Set(['files_to_watch','stale_threshold_days']),
-  stall_detection: new Set(['running_idle_warn_ms','running_idle_kill_ms','waiting_stale_ms','tool_duration_warn_ms']),
+  stall_detection: new Set(['running_idle_warn_ms','running_idle_kill_ms','waiting_stale_ms','waiting_auto_close_ms','tool_duration_warn_ms']),
 };
 
 function unknownKeys(obj, knownSet, path) {

--- a/.xtrm/specialists-source.json
+++ b/.xtrm/specialists-source.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
   "source": {
-    "kind": "ref",
+    "kind": "repo",
     "ref": "master",
-    "resolved_sha": "3deb623228ad5ab58053a52c434632430c58fb9b",
+    "resolved_sha": "782b572e1e5ca854d0318060615cbcc23ad9fe96",
     "repo_path": "../specialists",
     "source_path": "config/skills"
   },
@@ -20,10 +20,10 @@
   ],
   "files": {
     "specialists-creator": {
-      "scripts/audit-spec-uniformity.mjs": "cfc6aa6fc89f18c2e1ddf794047b309aa8cb0185617d84545eb5cb20135d5ac4",
+      "scripts/audit-spec-uniformity.mjs": "0ada06784cfd5c3adfa9c9908a9cd23380e8278fb57329fc616a83140a47fb33",
       "scripts/scaffold-specialist.ts": "c1bfa3693d644072e6d387d2519e131624d99c5b85521ae638680d7485267403",
       "scripts/validate-specialist.ts": "3a5f5a3a77c50e98ecf9188634ff2882f8143b19d0f28a53aff5c42e1bd09dfa",
-      "SKILL.md": "f84c22e11e08f83ab73c7f3d52df3b071037600740352713d1494f57799b679e"
+      "SKILL.md": "223ab14dbd1c2443f147600691819408faed9f13524d485c0b99394fa84e0981"
     },
     "update-specialists": {
       "SKILL.md": "fdf8c680cf3e5dce80c9426f52b56c953f4f7f663c23a33a3378b2b6e4bab5a9"


### PR DESCRIPTION
## Summary

Runs \`scripts/vendor-specialists-skills.mjs\` after publishing \`@jaggerxtrm/specialists@3.18.1\`. Effects:

- \`using-specialists-v3/SKILL.md\` — content unchanged (already at v3.7 via PR #351; specialists 3.18.1 catches up per specialists PR #171 with identical content)
- \`specialists-creator/SKILL.md\` + \`scripts/audit-spec-uniformity.mjs\` — legit upstream refresh from specialists master
- \`.xtrm/specialists-source.json\` — manifest regenerated properly (replaces the stopgap hash patch from PR #353, which is now redundant because specialists master matches xtrm-tools' vendored copy byte-for-byte)
- \`.xtrm/registry.json\` — hash entries for the specialists-creator changes + \`specialists_source\` metadata refresh

## Closes xtrm-rcsmu

The vendor-drift bead can close. Full story:
- PR #351 edited vendored SKILL.md in-tree to v3.7 (rule violation per CLAUDE.md)
- PR #353 (this session) patched the manifest hash as a stopgap; \`xtrm-rcsmu\` filed for tracking
- Specialists PR #171 ported v3.7 content into \`config/skills/using-specialists-v3/SKILL.md\` on specialists master; published as \`@jaggerxtrm/specialists@3.18.1\`
- This PR re-vendors from that release; upstream and downstream are now byte-identical

**Safe to run \`node scripts/vendor-specialists-skills.mjs\` again** — the "don't run until xtrm-rcsmu closes" warning in PR #353 no longer applies.

## Verified

- \`node scripts/verify-specialists-vendor.mjs\` → "Specialists vendor manifest OK"
- \`npm run check:registry-pack-parity\` → 349↔349

🤖 Generated with [Claude Code](https://claude.com/claude-code)