### PR TITLE
release: pi-extensions v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [pi-extensions v0.9.2] — 2026-07-05
+
+### `@jaggerxtrm/pi-extensions` v0.9.2 — 2026-07-05
+
+#### Fixed
+
+- **`pi` failed to start after installing `@jaggerxtrm/pi-extensions@0.9.1`.** The v0.9.1 release added `xtprompt` to `src/registry.ts` (`import xtprompt from "./extensions/xtprompt.ts"`) but shipped no `src/extensions/xtprompt.ts` — every other bundled extension has a one-line shim there re-exporting from `../../extensions/<name>/index.ts`, and the new one was missed. Every `pi` startup crashed with `Cannot find module './extensions/xtprompt.ts'` from `pi-extensions/src/registry.ts:17`, forcing users onto `pi -ne` to load the agent at all. This release adds the missing shim; the `xtprompt` package source at `packages/pi-extensions/extensions/xtprompt/{index.ts,package.json}` was already correct and shipped in v0.9.1.
+
 ## [v0.9.1] — 2026-07-04
 
 ### `xtrm-tools` v0.9.1 — 2026-07-04

--- a/package-lock.json
+++ b/package-lock.json
@@ -4155,7 +4155,7 @@
     },
     "packages/pi-extensions": {
       "name": "@jaggerxtrm/pi-extensions",
-      "version": "0.9.0",
+      "version": "0.9.2",
       "license": "MIT"
     },
     "packages/pi-extensions/extensions/core": {

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {

--- a/packages/pi-extensions/src/extensions/xtprompt.ts
+++ b/packages/pi-extensions/src/extensions/xtprompt.ts
@@ -1,0 +1,3 @@
+import registerExtension from "../../extensions/xtprompt/index.ts";
+
+export default registerExtension;


### PR DESCRIPTION
## Summary

Hotfix release for `@jaggerxtrm/pi-extensions`. v0.9.1 (published from PR #354) shipped a broken registry: `src/registry.ts` imports `./extensions/xtprompt.ts` but the shim file was never created — every other bundled extension has a matching one-liner at `src/extensions/<name>.ts` re-exporting from `../../extensions/<name>/index.ts`, and the new `xtprompt` entry missed it.

Effect on users: every `pi` startup crashes with `Cannot find module './extensions/xtprompt.ts'` from `pi-extensions/src/registry.ts:17`, forcing `pi -ne` to load the agent.

## Changes

- Add `packages/pi-extensions/src/extensions/xtprompt.ts` — one-line shim, same shape as the other 16 bundled extensions.
- Bump `packages/pi-extensions/package.json` `0.9.1 → 0.9.2` and matching lockfile entry (which had also been stale at `0.9.0`).
- Promote `[Unreleased]` → `[pi-extensions v0.9.2] — 2026-07-05` in `CHANGELOG.md`.
- Tag `pi-extensions-v0.9.2` pushed alongside the branch.

## Test plan

- [x] Shim resolves: `node` resolves `src/extensions/xtprompt.ts` → `extensions/xtprompt/index.ts` (verified locally).
- [x] `prepublishOnly` runtime asset check passes (`src/index.ts`, `src/registry.ts`, `extensions`, `themes` all present).
- [ ] After merge, publish `@jaggerxtrm/pi-extensions@0.9.2` to npm.
- [ ] After publish, `pi install npm:@jaggerxtrm/pi-extensions` in a fresh env, run bare `pi` — no `Cannot find module` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)