### PR TITLE
release: pi-extensions v0.9.3 — migrate @mariozechner/* → @earendil-works/*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [pi-extensions v0.9.3] — 2026-07-05
+
+### `@jaggerxtrm/pi-extensions` v0.9.3 — 2026-07-05
+
+#### Changed
+
+- **Migrate all `@mariozechner/*` imports to `@earendil-works/*` across the bundle.** Upstream Pi renamed the npm scope (Mario Zechner → Earendil Works); the currently installed `pi` binary is `@earendil-works/pi-coding-agent@0.80.3`. Legacy `@mariozechner/*` continued to work at runtime only via a temporary compat alias in Pi's extension loader — its own CHANGELOG notes that "the compat entrypoint and the loader alias will be removed in a future release." This release rewrites every specifier (both value and type imports, plus per-extension `peerDependencies` in `serena-pool` and `pi-serena-compact`, and the fallback filesystem path in `xtrm-ui`) to `@earendil-works/pi-{coding-agent,tui,ai}`. Surfaced by Codex review on PR #357 while landing v0.9.2. Verified by swapping the migrated bundle into the live pi runtime and running `pi --version` — no `Cannot find module` errors, no warnings.
+
 ## [pi-extensions v0.9.2] — 2026-07-05
 
 ### `@jaggerxtrm/pi-extensions` v0.9.2 — 2026-07-05

--- a/cli/test/extensions/beads-claim-lifecycle.test.ts
+++ b/cli/test/extensions/beads-claim-lifecycle.test.ts
@@ -3,7 +3,7 @@ import { ExtensionHarness } from "./extension-harness";
 import beadsExtension from "../../../packages/pi-extensions/extensions/beads/index";
 import { SubprocessRunner } from "../../../packages/pi-extensions/src/core";
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({
+vi.mock("@earendil-works/pi-coding-agent", () => ({
 	isToolCallEventType: (name: string, event: any) => event?.toolName === name,
 	isBashToolResult: (event: any) => event?.toolName === "bash",
 }));

--- a/cli/test/extensions/beads-parity.test.ts
+++ b/cli/test/extensions/beads-parity.test.ts
@@ -4,7 +4,7 @@ import beadsExtension from "../../../packages/pi-extensions/extensions/beads/ind
 import { SubprocessRunner } from "../../../packages/pi-extensions/src/core";
 import * as fs from "node:fs";
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({
+vi.mock("@earendil-works/pi-coding-agent", () => ({
 	isToolCallEventType: (name: string, event: any) => event?.toolName === name,
 	isBashToolResult: (event: any) => event?.toolName === "bash",
 }));

--- a/cli/test/extensions/beads.test.ts
+++ b/cli/test/extensions/beads.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ExtensionHarness } from "./extension-harness";
 
-// Mock the @mariozechner Pi runtime packages before importing the extension —
+// Mock the @earendil-works Pi runtime packages before importing the extension —
 // Pi provides these at runtime, but CI's npm install does not pull them in.
 // Without these mocks, vitest fails the entire test file at module-load time
 // trying to resolve unused-at-test-time imports from the extension source.
 // See xtrm-qdsx.
-vi.mock("@mariozechner/pi-coding-agent", () => ({
+vi.mock("@earendil-works/pi-coding-agent", () => ({
 	isToolCallEventType: vi.fn(() => false),
 	isBashToolResult: vi.fn(() => false),
 }));
-vi.mock("@mariozechner/pi-tui", () => ({
+vi.mock("@earendil-works/pi-tui", () => ({
 	truncateToWidth: vi.fn((s: string) => s),
 	visibleWidth: vi.fn((s: string) => s.length),
 }));

--- a/cli/test/extensions/custom-footer-parity.test.ts
+++ b/cli/test/extensions/custom-footer-parity.test.ts
@@ -1,14 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock the @mariozechner Pi runtime packages before importing the extension —
+// Mock the @earendil-works Pi runtime packages before importing the extension —
 // Pi provides these at runtime, but CI's npm install does not pull them in.
 // Without these mocks, vitest fails the entire test file at module-load time.
 // See xtrm-qdsx.
-vi.mock("@mariozechner/pi-coding-agent", () => ({
+vi.mock("@earendil-works/pi-coding-agent", () => ({
 	isToolCallEventType: vi.fn(() => false),
 	isBashToolResult: vi.fn(() => false),
 }));
-vi.mock("@mariozechner/pi-tui", () => ({
+vi.mock("@earendil-works/pi-tui", () => ({
 	truncateToWidth: vi.fn((s: string) => s),
 	visibleWidth: vi.fn((s: string) => s.length),
 }));

--- a/cli/test/extensions/session-flow.test.ts
+++ b/cli/test/extensions/session-flow.test.ts
@@ -3,7 +3,7 @@ import { ExtensionHarness } from "./extension-harness";
 import sessionFlowExtension from "../../../packages/pi-extensions/extensions/session-flow/index";
 import { SubprocessRunner } from "../../../packages/pi-extensions/src/core";
 
-vi.mock("@mariozechner/pi-coding-agent", () => ({
+vi.mock("@earendil-works/pi-coding-agent", () => ({
 	isBashToolResult: (event: any) => event?.toolName === "bash",
 }));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4155,7 +4155,7 @@
     },
     "packages/pi-extensions": {
       "name": "@jaggerxtrm/pi-extensions",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT"
     },
     "packages/pi-extensions/extensions/core": {

--- a/packages/pi-extensions/extensions/auto-session-name/index.ts
+++ b/packages/pi-extensions/extensions/auto-session-name/index.ts
@@ -3,7 +3,7 @@
  *
  * Automatically names sessions based on the first user message.
  */
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
   let named = false;

--- a/packages/pi-extensions/extensions/auto-update/index.ts
+++ b/packages/pi-extensions/extensions/auto-update/index.ts
@@ -1,7 +1,7 @@
 /**
  * oh-pi Auto Update — check for new oh-pi version on session start
  */
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";

--- a/packages/pi-extensions/extensions/beads/index.ts
+++ b/packages/pi-extensions/extensions/beads/index.ts
@@ -1,5 +1,5 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { isToolCallEventType, isBashToolResult } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isToolCallEventType, isBashToolResult } from "@earendil-works/pi-coding-agent";
 import { SubprocessRunner, EventAdapter } from "../../src/core";
 
 export default function (pi: ExtensionAPI) {

--- a/packages/pi-extensions/extensions/compact-header/index.ts
+++ b/packages/pi-extensions/extensions/compact-header/index.ts
@@ -1,9 +1,9 @@
 /**
  * oh-pi Compact Header — table-style startup info with dynamic column widths
  */
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { VERSION } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { VERSION } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {

--- a/packages/pi-extensions/extensions/custom-footer/index.ts
+++ b/packages/pi-extensions/extensions/custom-footer/index.ts
@@ -7,8 +7,8 @@
  * Line 3: ◐ 4843.5 Rework project bootstrap... — beads claim or ○ 6 open
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
 import { SubprocessRunner, EventAdapter } from "../../src/core";
 

--- a/packages/pi-extensions/extensions/custom-provider-qwen-cli/index.ts
+++ b/packages/pi-extensions/extensions/custom-provider-qwen-cli/index.ts
@@ -9,8 +9,8 @@
  * # Then /login qwen-cli, or set QWEN_CLI_API_KEY=...
  */
 
-import type { OAuthCredentials, OAuthLoginCallbacks } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 // =============================================================================
 // Constants

--- a/packages/pi-extensions/extensions/git-checkpoint/index.ts
+++ b/packages/pi-extensions/extensions/git-checkpoint/index.ts
@@ -5,7 +5,7 @@
  * When forking, offers to restore code to that point in history.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export default function (pi: ExtensionAPI) {
 	const checkpoints = new Map<string, string>();

--- a/packages/pi-extensions/extensions/lsp-bootstrap/index.ts
+++ b/packages/pi-extensions/extensions/lsp-bootstrap/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { spawnSync, execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/pi-extensions/extensions/pi-serena-compact/index.ts
+++ b/packages/pi-extensions/extensions/pi-serena-compact/index.ts
@@ -1,16 +1,16 @@
-import type { ExtensionAPI, ToolResultEvent } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ToolResultEvent } from "@earendil-works/pi-coding-agent";
 
 // Serena/GitNexus MCP tool names that produce verbose output
 const COMPACT_TOOLS = new Set([
   // Serena symbol operations
   "find_symbol",
-  "find_referencing_symbols", 
+  "find_referencing_symbols",
   "get_symbols_overview",
   "jet_brains_find_symbol",
   "jet_brains_find_referencing_symbols",
   "jet_brains_get_symbols_overview",
   "jet_brains_type_hierarchy",
-  
+
   // Serena file operations
   "read_file",
   "create_text_file",
@@ -18,30 +18,30 @@ const COMPACT_TOOLS = new Set([
   "replace_lines",
   "delete_lines",
   "insert_at_line",
-  
+
   // Serena search/navigation
   "search_for_pattern",
   "list_dir",
   "find_file",
-  
+
   // Serena symbol editing
   "replace_symbol_body",
   "insert_after_symbol",
   "insert_before_symbol",
   "rename_symbol",
-  
+
   // GitNexus
   "gitnexus_query",
   "gitnexus_context",
   "gitnexus_impact",
   "gitnexus_detect_changes",
   "gitnexus_list_repos",
-  
+
   // Serena memory
   "read_memory",
   "write_memory",
   "list_memories",
-  
+
   // Other verbose tools
   "execute_shell_command",
   "structured_return",
@@ -66,10 +66,10 @@ function getTextContent(content: Array<{ type: string; text?: string }>): string
 
 function truncateLines(text: string, maxLines: number, maxLineLen = 180): string {
   const lines = text.split("\n");
-  const truncated = lines.map(line => 
+  const truncated = lines.map(line =>
     line.length > maxLineLen ? line.slice(0, maxLineLen) + "…" : line
   );
-  
+
   if (truncated.length <= maxLines) return truncated.join("\n");
   return truncated.slice(0, maxLines).join("\n") + `\n… +${truncated.length - maxLines} more lines`;
 }
@@ -80,16 +80,16 @@ function compactResult(
   maxLines: number = 6,
 ): Array<{ type: string; text: string }> {
   const textContent = getTextContent(content);
-  
+
   if (!textContent) {
     return [{ type: "text", text: "✓ No output" }];
   }
-  
+
   // For certain tools, show more output
   const effectiveMaxLines = PRESERVE_OUTPUT_TOOLS.has(toolName) ? 12 : maxLines;
-  
+
   const compacted = truncateLines(textContent, effectiveMaxLines, 180);
-  
+
   return [{ type: "text", text: compacted }];
 }
 

--- a/packages/pi-extensions/extensions/pi-serena-compact/package.json
+++ b/packages/pi-extensions/extensions/pi-serena-compact/package.json
@@ -12,8 +12,8 @@
   "type": "module",
   "main": "index.ts",
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.56.0",
-    "@mariozechner/pi-tui": "^0.56.0"
+    "@earendil-works/pi-coding-agent": "^0.80.0",
+    "@earendil-works/pi-tui": "^0.80.0"
   },
   "pi": {
     "extensions": [

--- a/packages/pi-extensions/extensions/quality-gates/index.ts
+++ b/packages/pi-extensions/extensions/quality-gates/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { SubprocessRunner, EventAdapter } from "../../src/core";
 import * as path from "node:path";
 import * as fs from "node:fs";

--- a/packages/pi-extensions/extensions/serena-pool/index.ts
+++ b/packages/pi-extensions/extensions/serena-pool/index.ts
@@ -20,7 +20,7 @@
  * controlling Serena is verifiably dead (pid+startTime check). Process-group
  * kills are bounded to ours, so editor LSPs / tests / hooks are never touched.
  */
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { spawn, execFileSync } from "node:child_process";
 import { connect } from "node:net";
 import { existsSync, mkdirSync, openSync, writeSync, closeSync, readFileSync, unlinkSync, realpathSync } from "node:fs";

--- a/packages/pi-extensions/extensions/serena-pool/package.json
+++ b/packages/pi-extensions/extensions/serena-pool/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "main": "index.ts",
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.56.0"
+    "@earendil-works/pi-coding-agent": "^0.80.0"
   },
   "pi": {
     "extensions": [

--- a/packages/pi-extensions/extensions/service-skills/index.ts
+++ b/packages/pi-extensions/extensions/service-skills/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { SubprocessRunner } from "../../src/core";
 import * as path from "node:path";
 import * as fs from "node:fs";

--- a/packages/pi-extensions/extensions/session-flow/index.ts
+++ b/packages/pi-extensions/extensions/session-flow/index.ts
@@ -1,5 +1,5 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { isBashToolResult } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isBashToolResult } from "@earendil-works/pi-coding-agent";
 import { SubprocessRunner, EventAdapter } from "../../src/core";
 
 function isClaimCommand(command: string): { isClaim: boolean; issueId: string | null } {

--- a/packages/pi-extensions/extensions/sp-terminal-overlay/index.ts
+++ b/packages/pi-extensions/extensions/sp-terminal-overlay/index.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@mariozechner/pi-coding-agent";
-import { matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
+import { matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
 const MAX_BUFFER_LINES = 2000;
 const DEFAULT_VISIBLE_LINES = 24;

--- a/packages/pi-extensions/extensions/xtrm-loader/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-loader/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { homedir } from "node:os";

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -20,7 +20,7 @@ import type {
   LsToolDetails,
   ReadToolDetails,
   ToolResultEvent,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
   CustomEditor,
   createBashTool,
@@ -30,8 +30,8 @@ import {
   createLsTool,
   createReadTool,
   createWriteTool,
-} from "@mariozechner/pi-coding-agent";
-import { Box, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-coding-agent";
+import { Box, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -184,14 +184,11 @@ function resolvePiCodingAgentEntryPath(): string {
 
   candidates.push(
     join(dirname(process.execPath), "..", "lib", "node_modules", "@earendil-works", "pi-coding-agent", "dist", "index.js"),
-    join(dirname(process.execPath), "..", "lib", "node_modules", "@mariozechner", "pi-coding-agent", "dist", "index.js"),
   );
 
-  for (const packageName of ["@earendil-works/pi-coding-agent", "@mariozechner/pi-coding-agent"]) {
-    try {
-      candidates.push(maybeFileUrlToPath(import.meta.resolve(packageName)));
-    } catch {}
-  }
+  try {
+    candidates.push(maybeFileUrlToPath(import.meta.resolve("@earendil-works/pi-coding-agent")));
+  } catch {}
 
   const entryPath = candidates.find((candidate) => existsSync(candidate));
   if (!entryPath) throw new Error("Could not resolve pi-coding-agent entry path");

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {

--- a/packages/pi-extensions/src/core/adapter.ts
+++ b/packages/pi-extensions/src/core/adapter.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
 
-import type { ExtensionAPI, ToolCallEvent } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ToolCallEvent } from "@earendil-works/pi-coding-agent";
 import { PI_MUTATING_FILE_TOOLS } from "./guard-rules";
 
 export class EventAdapter {

--- a/packages/pi-extensions/src/index.ts
+++ b/packages/pi-extensions/src/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import { registerManagedPiExtensions } from "./registry.ts";
 

--- a/packages/pi-extensions/src/registry.ts
+++ b/packages/pi-extensions/src/registry.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import autoSessionNameExtension from "./extensions/auto-session-name.ts";
 import autoUpdateExtension from "./extensions/auto-update.ts";


### PR DESCRIPTION
## Summary

Follow-up to PR #357 (v0.9.2). Codex flagged the mixed-scope imports; investigation confirmed Pi upstream renamed the npm scope (Mario Zechner → Earendil Works) and the installed runtime is now \`@earendil-works/pi-coding-agent@0.80.3\`. Legacy \`@mariozechner/*\` only worked via Pi's temporary compat alias in the extension loader — pi-coding-agent CHANGELOG explicitly marks it for removal: *"the compat entrypoint and the loader alias will be removed in a future release."*

Rewrites every specifier across \`packages/pi-extensions/{src,extensions}\`:

- **Value imports** (runtime) in \`beads\`, \`compact-header\`, \`custom-footer\`, \`session-flow\`, \`sp-terminal-overlay\`, \`xtprompt\`, \`xtrm-ui\`.
- **Type imports** in every other extension + \`src/registry.ts\` + \`src/core/adapter.ts\` + \`src/index.ts\`.
- **peerDependencies** in \`extensions/serena-pool/package.json\` and \`extensions/pi-serena-compact/package.json\` (bumped range from \`^0.56.0\` to \`^0.80.0\`).
- **Fallback filesystem path** in \`xtrm-ui/index.ts\` (removed the \`@mariozechner/pi-coding-agent\` \`lib/node_modules/\` candidate and deduplicated the \`import.meta.resolve\` list).

## Verification

- \`grep -rEn '@mariozechner' packages/pi-extensions/\` → 0 hits.
- Live smoke: swapped the migrated \`src/\` + \`extensions/\` over the installed \`@jaggerxtrm/pi-extensions@0.9.2\` in \`~/.pi/agent/npm/node_modules/\`, ran \`pi --version\` → prints \`0.80.3\`, no \`ERR_MODULE_NOT_FOUND\`, no warnings. Reverted to installed after test.
- \`CHANGELOG.md\` [Unreleased] → \`[pi-extensions v0.9.3] — 2026-07-05\`.
- \`packages/pi-extensions/package.json\` bumped 0.9.2 → 0.9.3; matching lockfile entry updated.

## Test plan

- [x] No residual \`@mariozechner\` reference in \`packages/pi-extensions/\`.
- [x] Live pi startup smoke against migrated bundle: no error.
- [ ] After merge, publish \`@jaggerxtrm/pi-extensions@0.9.3\` to npm.
- [ ] Reinstall in a real session (\`pi install npm:@jaggerxtrm/pi-extensions@0.9.3\`) — no \`Cannot find module\` on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)