### PR TITLE
feat(instructions): add code-restraint section to top-level agent injections

### DIFF
--- a/.xtrm/config/instructions/agents-top.md
+++ b/.xtrm/config/instructions/agents-top.md
@@ -22,6 +22,12 @@
 - Ask before destructive, irreversible, production-impacting, or history-rewriting actions.
 - Do not ask repetitive “Proceed?” confirmations for normal implementation once scope is clear.
 
+## Code restraint (when implementing directly)
+
+- YAGNI first. Lazy solution that actually works: reuse existing → stdlib → native → one line → minimum. Prefer deletion. No unrequested abstractions. Match existing project conventions; never invent a new style mid-file.
+- Never simplify away: input validation at trust boundaries, error handling preventing data loss, security, accessibility, explicitly requested behavior. Never lazy about understanding the problem.
+- Mark deliberate shortcuts `// SIMPLIFIED: <ceiling>. upgrade when <trigger>.` Unmarked shortcuts silently rot.
+
 ## Essential command surface
 
 Use these as the minimal operational surface; use `--help` for full syntax.

--- a/.xtrm/config/instructions/claude-top.md
+++ b/.xtrm/config/instructions/claude-top.md
@@ -22,6 +22,12 @@
 - Ask before destructive, irreversible, production-impacting, or history-rewriting actions.
 - Do not ask repetitive “Proceed?” confirmations for normal implementation once scope is clear.
 
+## Code restraint (when implementing directly)
+
+- YAGNI first. Lazy solution that actually works: reuse existing → stdlib → native → one line → minimum. Prefer deletion. No unrequested abstractions. Match existing project conventions; never invent a new style mid-file.
+- Never simplify away: input validation at trust boundaries, error handling preventing data loss, security, accessibility, explicitly requested behavior. Never lazy about understanding the problem.
+- Mark deliberate shortcuts `// SIMPLIFIED: <ceiling>. upgrade when <trigger>.` Unmarked shortcuts silently rot.
+
 ## Essential command surface
 
 Use these as the minimal operational surface; use `--help` for full syntax.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Add `## Code restraint (when implementing directly)` to `agents-top.md` and `claude-top.md`.** Companion to specialists PR #173 (unitAI-pzmwf) which introduced a unified code-restraint discipline at the mandatory-rule level and in the orchestrator skill. This layer is for when the agent implements directly without delegating to a specialist. Compact 3-bullet section fits the "managed block" style the file's own header enforces (`This is a compact managed block. Use CLI --help and skills for details; do not paste full manuals here.`): the ladder in one line (YAGNI → reuse → stdlib → native → one line → minimum), the "never simplify away" boundary (input validation at trust boundaries, error handling that prevents data loss, security, accessibility, explicitly requested behavior, understanding the problem), and the deliberate-shortcut marker `// SIMPLIFIED: <ceiling>. upgrade when <trigger>.` The full ladder + rules + tag vocabulary specifics live in the specialists mandatory rule and are not repeated here (reuse over rewrite — the same discipline being taught). Identical text in both files so all downstream propagation (~30 consumer repos via existing `xt update` flow) picks up the same rule regardless of runtime. Zero external plugin brand references in shipped text.
+
 ## [pi-extensions v0.9.3] — 2026-07-05
 
 ### `@jaggerxtrm/pi-extensions` v0.9.3 — 2026-07-05


### PR DESCRIPTION
## Summary

Companion PR to [specialists PR #173](https://github.com/xtrm-dev/specialists/pull/173) (`unitAI-pzmwf`), which introduced a unified **code-restraint discipline** across the specialists ecosystem — no external plugin brand references, own vocabulary.

This PR adds the shallowest layer: a compact 3-bullet section to the two source-of-truth files that propagate the top-level agent workflow across ~30 consumer repos.

## What changed

Both `.xtrm/config/instructions/agents-top.md` and `.xtrm/config/instructions/claude-top.md` gain an identical section between `## Operating rules` and `## Essential command surface`:

\`\`\`markdown
## Code restraint (when implementing directly)

- YAGNI first. Lazy solution that actually works: reuse existing → stdlib → native → one line → minimum. Prefer deletion. No unrequested abstractions. Match existing project conventions; never invent a new style mid-file.
- Never simplify away: input validation at trust boundaries, error handling preventing data loss, security, accessibility, explicitly requested behavior. Never lazy about understanding the problem.
- Mark deliberate shortcuts \`// SIMPLIFIED: <ceiling>. upgrade when <trigger>.\` Unmarked shortcuts silently rot.
\`\`\`

3 bullets. Fits the "compact managed block" style the file's own header enforces.

## Depth model

- **Deepest** (specialists PR #173): full ladder + rules + tag vocab + marker convention in `config/mandatory-rules/code-quality-defaults.md`. Executor/reviewer/seconder inherit via existing `template_sets`.
- **Mid-depth** (specialists PR #173): orchestrator skill `using-specialists-v3/SKILL.md` gains `## Restraint And The Ladder` pointing at the shared rule.
- **Shallow** (this PR): 3-bullet top-level for **direct implementation** (no specialist delegation).

## What NOT to duplicate

The full ladder, tag vocabulary, and marker syntax specifics live in the specialists mandatory rule. Not repeated here — that would violate the same discipline being taught (reuse over rewrite). Consumer repos get the essence in one glance; agents that want the canonical version consult the specialists rule.

## Naming decision

Zero mentions of any external code-restraint plugin/brand in shipped text. Section title is plain `## Code restraint (when implementing directly)`. Comment marker is `// SIMPLIFIED:` — TODO-shaped and self-documenting.

## Testing plan

- [x] Both files still parse as valid markdown.
- [ ] On next `xt update` in a consumer repo, verify the new section propagates and appears in the injected AGENTS.md/CLAUDE.md.
- [ ] No behavioral change to specialists or beads workflow — this is agent-guidance only.

Depends on specialists PR #173 landing first (which defines the tag vocabulary and marker convention referenced in the "deepest" layer). This PR can merge independently since its 3 bullets are self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)