### PR TITLE
fix(service-skills): normalize tz-naive sync_time in drift_detector.scan_drift

### DIFF
--- a/skills/service-skills/scripts/drift_detector.py
+++ b/skills/service-skills/scripts/drift_detector.py
@@ -235,6 +235,10 @@ def scan_drift(project_root: str | None = None, enrich_with_gitnexus: bool = Fal
         last_sync_str = service.get("last_sync", "")
         try:
             sync_time = datetime.fromisoformat(last_sync_str.replace("Z", "+00:00")) if last_sync_str else None
+            # Date-only strings (YYYY-MM-DD) yield tz-naive datetimes; normalize to UTC
+            # so the comparison against tz-aware mtime on line ~250 doesn't crash.
+            if sync_time is not None and sync_time.tzinfo is None:
+                sync_time = sync_time.replace(tzinfo=timezone.utc)
         except ValueError:
             sync_time = None
         # A service with no (or unparseable, e.g. the "never" sentinel) last_sync has been


### PR DESCRIPTION
## Summary

`datetime.fromisoformat("YYYY-MM-DD")` returns a **tz-naive** datetime. `scan_drift` compares it (line 250) against `datetime.fromtimestamp(mtime, tz=timezone.utc)` which is **tz-aware** — every registry with a date-only `last_sync` value crashes with:

```
TypeError: can't compare offset-naive and offset-aware datetimes
```

Normalizing `sync_time` to UTC when naive fixes it. Preserves existing behavior for full ISO timestamps (Z-suffixed already tz-aware after the `.replace()`).

## Repro

Registry with `last_sync: "2026-06-23"`:

```console
$ python3 skills/service-skills/scripts/drift_detector.py scan
TypeError: can't compare offset-naive and offset-aware datetimes
```

After patch — exit 0, scan runs clean.

## Discovery

Downstream in `Rico1109/Hiryuen` while landing AP-01d follow-ups from PR #408. The `scope.py` smoke check and CI `drift-detect` job both hit this. Backported locally in Hiryuen commit `10d023fb` and upstreamed here so `xt update --apply` no longer regresses it.

## Test plan

- [x] `python3 skills/service-skills/scripts/drift_detector.py scan` on Hiryuen registry — exit 0
- [ ] existing service-skills test suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)