### PR TITLE
fix(pi-extensions): correct xtprompt import path and restore enrollment shim

### DIFF
--- a/packages/pi-extensions/src/extensions/xtprompt.ts
+++ b/packages/pi-extensions/src/extensions/xtprompt.ts
@@ -1,0 +1,3 @@
+import registerExtension from "../../extensions/xtprompt/index.ts";
+
+export default registerExtension;

--- a/packages/pi-extensions/src/registry.ts
+++ b/packages/pi-extensions/src/registry.ts
@@ -15,7 +15,7 @@ import sessionFlowExtension from "./extensions/session-flow.ts";
 import spTerminalOverlayExtension from "./extensions/sp-terminal-overlay.ts";
 import xtrmLoaderExtension from "./extensions/xtrm-loader.ts";
 import xtrmUiExtension from "./extensions/xtrm-ui.ts";
-import xtpromptExtension from "./extensions/xtprompt/index.ts";
+import xtpromptExtension from "./extensions/xtprompt.ts";
 
 export type ManagedPiExtension = {
   readonly id: string;


### PR DESCRIPTION
## Bug
- The A-F cleanup (PR #366) mistakenly removed the `src/extensions/xtprompt.ts` shim
- Registry import was rewired to `./extensions/xtprompt/index.ts` which resolves to a path that doesn't exist (xtprompt is an enrollment file, not a directory)
- Runtime error: `Cannot find module './extensions/xtprompt/index.ts'`

## Fix
- Restore the enrollment shim with the canonical re-export pattern
- Fix registry import back to `./extensions/xtprompt.ts`
