### PR TITLE
release: pi-extensions v0.9.4

### DIFF
--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Patch release:\n- Corrects xtprompt import path enrollment (PR #367)\n- Restores the xtprompt enrollment shim\n