### PR TITLE
feat(multiplexing): codify deploy-gap chain + verify-deploy-applied.sh (nsur)

### DIFF
--- a/.xtrm/skills/default/multiplexing/SKILL.md
+++ b/.xtrm/skills/default/multiplexing/SKILL.md
@@ -212,6 +212,32 @@ When a delegated session works on a repo where other sessions are also active, s
 
 The known mitigation is to spawn delegated sessions in dedicated worktrees via `xt claude` or `xt pi`. This is not currently enforced. When pre-flight detects two live sessions in the same checkout, warn the operator and recommend `xt claude` / `xt pi` for the next delegation.
 
+## Deploy-gap chain — post-merge observability guard
+
+When the orchestrator moves a PR from merge to a Deploy Monitor observation window, the running container MUST reflect the merged code. Merging on GitHub does not, by itself, rebuild the container. Between `gh pr merge` and container restart, Prometheus/Tempo/Grafana continue to show pre-merge behavior, and any DM window opened during that gap measures the wrong world. This is the class of failure that let `mercury-market-data-82wh` sit in production for over a month, and that reproduced inside `mmd-sprint 2026-07-03` (EVAL-22).
+
+Enforce the chain as an indivisible sequence:
+
+1. `gh pr merge <N> --repo <owner>/<repo> --squash --admin` (or the repo's canonical merge command).
+2. `docker compose -f <compose> build <service>` on the target host.
+3. `docker compose -f <compose> up -d --force-recreate <service>` on the target host. `--force-recreate` is required — without it, Docker keeps the existing container when the image tag hasn't textually changed even if the bytes underneath have.
+4. Verify the running artifact is newer than the merge, then hand off to DM.
+
+For GitOps-deployed services: wait for the reconciler to advance past the PR's `mergedAt` before handoff.
+
+The verification step is codified as a runnable script bundled with this skill:
+
+```bash
+scripts/verify-deploy-applied.sh <container> <pr-number> <owner/repo>
+# exit 0 → StartedAt > mergedAt, safe to open DM window
+# exit 1 → deploy NOT applied, orchestrator must rebuild + restart
+# exit 2 → usage / dependency error (missing gh/docker, PR unmerged, container absent)
+```
+
+The file also defines a `verify_deploy_applied` bash function that can be sourced by other scripts, sprint runbooks, and `/tmp/<sprint>-deploy-monitor.txt` prompt templates as step 0 of the DM window protocol. DM refuses to open the window when the script returns non-zero and reports `deploy-not-applied` upward to the orchestrator.
+
+Full doctrine: `xtrm/docs/devops/deploy-gap-pattern.md`. Bead: `mercury-market-data-nsur`.
+
 ## End-of-session hygiene
 
 Before closing the orchestrator session:

--- a/.xtrm/skills/default/multiplexing/scripts/verify-deploy-applied.sh
+++ b/.xtrm/skills/default/multiplexing/scripts/verify-deploy-applied.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# verify-deploy-applied — deploy-gap guard for post-merge observability windows.
+#
+# Between a PR merge and the Deploy Monitor (DM) opening its observation
+# window, the running container MUST reflect the merged code. If the
+# container's StartedAt predates the PR's mergedAt, the DM would measure
+# the pre-merge baseline and either miss the regression fix or report a
+# false regression against old bytes. Same class of failure as mmd
+# incident 82wh (regressed code sat in prod for over a month) and
+# mmd-sprint 2026-07-03 (DM aborted window against pre-merge container).
+#
+# Full doctrine: xtrm/docs/devops/deploy-gap-pattern.md
+# Codified per mercury-market-data-nsur (EVAL-22).
+#
+# Usage:
+#   verify-deploy-applied <container> <pr-number> <owner/repo>
+#
+# Exit codes:
+#   0  container StartedAt is AFTER PR mergedAt (deploy applied — safe to open DM window)
+#   1  container StartedAt is BEFORE PR mergedAt (deploy NOT applied — orchestrator must rebuild+restart)
+#   2  usage / dependency error (bad args, gh/docker/jq missing, container not found, PR not merged)
+#
+# Callable as a script or sourced as a function (defines verify_deploy_applied).
+
+set -euo pipefail
+
+verify_deploy_applied() {
+    if [[ $# -ne 3 ]]; then
+        echo "usage: verify_deploy_applied <container> <pr-number> <owner/repo>" >&2
+        return 2
+    fi
+
+    local container="$1"
+    local pr="$2"
+    local repo="$3"
+
+    for cmd in gh docker; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            echo "verify-deploy-applied: missing dependency: $cmd" >&2
+            return 2
+        fi
+    done
+
+    local merged_at
+    merged_at=$(gh pr view "$pr" --repo "$repo" --json mergedAt --jq .mergedAt 2>/dev/null || true)
+    if [[ -z "$merged_at" || "$merged_at" == "null" ]]; then
+        echo "verify-deploy-applied: PR $pr on $repo is not merged (mergedAt is null)" >&2
+        return 2
+    fi
+
+    local started_at
+    started_at=$(docker inspect --format '{{.State.StartedAt}}' "$container" 2>/dev/null || true)
+    if [[ -z "$started_at" ]]; then
+        echo "verify-deploy-applied: container '$container' not found or not running" >&2
+        return 2
+    fi
+
+    # RFC3339 timestamps sort correctly as strings when both use Z suffix.
+    # docker StartedAt uses fractional seconds; gh mergedAt uses whole seconds.
+    # Both are UTC. String comparison is safe.
+    if [[ "$started_at" < "$merged_at" ]]; then
+        cat >&2 <<EOF
+verify-deploy-applied: DEPLOY-NOT-APPLIED
+  container:    $container
+  StartedAt:    $started_at
+  PR:           $repo#$pr
+  mergedAt:     $merged_at
+  action:       run 'docker compose build <service> && docker compose up -d --force-recreate <service>' on the target host, then re-run this check.
+EOF
+        return 1
+    fi
+
+    echo "verify-deploy-applied: OK — $container StartedAt=$started_at > PR $repo#$pr mergedAt=$merged_at"
+    return 0
+}
+
+# Run as a script when not sourced.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    verify_deploy_applied "$@"
+fi


### PR DESCRIPTION
## Summary
- New \`Deploy-gap chain\` section in the /multiplexing skill documenting the merge → build → force-recreate → verify chain the sprint orchestrator must enforce between PR merge and DM window handoff.
- New bundled script \`scripts/verify-deploy-applied.sh\` — callable or sourceable, compares \`docker inspect StartedAt\` against \`gh pr view mergedAt\` and exits 0/1/2 with an actionable diagnostic.

## Why
Closes the gap that EVAL-22 flagged in \`mmd-sprint 2026-07-03\`: the DM aborted its 60-minute observation window at sample 1 because the mmd-snapshot-feed container was still running the pre-merge image. Same class of failure as \`mercury-market-data-82wh\` (regressed code sat in prod for over a month). The doctrine was documented at \`xtrm/docs/devops/deploy-gap-pattern.md\` but had never been codified as a runnable check.

## Test plan
- [x] \`bash -n verify-deploy-applied.sh\` — clean syntax
- [x] No-arg invocation → exit 2 with usage message
- [ ] Live test on next post-merge deploy: run \`scripts/verify-deploy-applied.sh mmd-snapshot-feed <N> mercuryintelligence/market-data\` between merge and DM window; verify exit 0 when container has been rebuilt, exit 1 when not
- [ ] Source the script and call \`verify_deploy_applied\` as a bash function from a sprint runbook

Closes mercury-market-data-nsur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)