### PR TITLE
docs(update-xt): document xt migrate + local-legacy repair recipe

### DIFF
--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -1002,7 +1002,7 @@
           "version": "0.9.1"
         },
         "update-xt/SKILL.md": {
-          "hash": "17499cb70432d3a2f13fd3cdf1a0596bb49736dfc851084d4d4938d59a8f5bc9",
+          "hash": "585509cbea7a5865d690767a49be4f3d0517a88425bb6a52ea65dd357c1bf758",
           "version": "0.9.1"
         },
         "updating-dependencies/schemas/dependency_update_case.schema.json": {

--- a/.xtrm/skills/default/update-xt/SKILL.md
+++ b/.xtrm/skills/default/update-xt/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: update-xt
 description: >
-  Update an xtrm-initialized project to match the current canonical install state.
-  Use this skill whenever the user asks to update, upgrade, repair, or re-sync xtrm
-  in a project — or when they say something like "xt is out of date", "skills aren't
-  loading", "hooks aren't firing", "the install looks wrong", or "I just pulled new
-  xtrm changes". Also triggers when the agent detects stale paths like
-  .claude/skills → active/claude (old structure) or .pi/settings.json pointing to
-  active/pi (old structure). Proactively suggest running this skill after any
-  xtrm-tools upgrade.
+  Update an xtrm-initialized project to match the current canonical install state,
+  and run one-time migrations to the global scope. Use this skill whenever the user
+  asks to update, upgrade, repair, or re-sync xtrm in a project — or when they say
+  "xt is out of date", "skills aren't loading", "hooks aren't firing", "the install
+  looks wrong", or "I just pulled new xtrm changes". Also covers `xt migrate` (move
+  per-repo skills/hooks into the global tree), `xt migrate --restore`, the
+  source-repo guard, and repairing broken `local-legacy` packs. Triggers when the
+  agent detects stale paths like .claude/skills → active/claude or .pi/settings.json
+  pointing to active/pi. Proactively suggest after any xtrm-tools upgrade.
 ---
 
 # update-xt
@@ -129,6 +130,9 @@ Two commands cover almost all drift. Know which fixes what:
 | `xt update --apply --repo .` | Registry-managed assets, bd auto-stage patch, bd/GitNexus maintenance, Pi package assurance |
 | `xt update --apply --all-repos` | Standard local fleet sweep (`~/dev` + `~/projects`), with per-repo commits for changed repos |
 | `xt init -y` | Skills symlink, active/ view rebuild, Pi settings, all phases |
+| `xt migrate skills --apply --repo .` | Move per-repo skills payload into `~/.xtrm/skills`, preserving diverged files as a `local-legacy` override |
+| `xt migrate hooks --apply --repo .` | Same for hooks (`~/.xtrm/hooks`) |
+| `xt migrate --restore <backup.tgz> --apply --repo .` | Undo a migrate from the tarball at `~/.xtrm/migration-backups/` |
 
 ### Fix: Skills symlink stale or active/ view wrong
 
@@ -316,8 +320,116 @@ Common failure modes and fixes:
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `Source and destination must not be the same` | `npm link`'d xtrm-tools + repo has symlinked `.xtrm/skills/default → xtrm-tools` (link chain collapses to same canonical path) | Functionally fine — repo is already in sync via the live symlinks, not a real failure. If you want to **fully decouple** the project from the dev tree, follow the migration recipe below. |
-| `PACK_METADATA_MISMATCH: metadata-only: X, filesystem-only: Y` | A user-skill-pack (`.xtrm/skills/user/packs/<name>/PACK.json`) lists a skill that has been renamed on disk | Edit `PACK.json` so the listed skill names match the directory names; re-run. |
+| `PACK_METADATA_MISMATCH: metadata-only: X, filesystem-only: Y` | Either a user pack renamed a skill without updating `PACK.json`, or a pre-fix `xt migrate` created an invalid `local-legacy` pack (wrong `name` and/or `skills[]` listing dirs that lack `SKILL.md`) | For a hand-authored user pack: edit `PACK.json` so the listed skill names match the directory names, re-run. For `local-legacy`: see the repair recipe under "Migration to global scope" below. |
 | `Cannot read properties of null (reading 'dolt')` | Repo's `.beads/config.yaml` is comments-only (fresh `bd init` default); pre-`xtrm-16ec` xtrm crashes parsing it | Upgrade xtrm-tools to ≥ 0.7.18; the parse result is coerced to `{}` defensively now. |
+
+## Migration to global scope (`xt migrate`)
+
+Move per-repo `.xtrm/skills` and `.xtrm/hooks` payloads into the global tree
+(`~/.xtrm/skills`, `~/.xtrm/hooks`) so consumer repos only carry pointers.
+This is a **one-time destructive** operation per repo; every run creates a
+tarball backup at `~/.xtrm/migration-backups/`.
+
+### Feature-flag gates
+
+- `XTRM_GLOBAL_SKILLS=1` — opts into the global-skills model at runtime.
+- `XTRM_GLOBAL_HOOKS=1` — opts into the global-hooks model at runtime.
+- `xt migrate` runs without the flags but warns that migration "may be
+  premature" — global runtime resolution still needs the flag to activate.
+
+### Commands
+
+```bash
+xt migrate skills --dry-run --repo <path>              # preview only
+xt migrate skills --apply --yes --repo <path>          # execute (destructive)
+xt migrate hooks --apply --yes --repo <path>           # same for hooks
+xt migrate all --apply --yes --repo <path>             # both targets
+xt migrate --restore <backup.tgz> --apply --repo <path>  # undo one component
+xt migrate --restore <backup.tgz> --apply --force --repo <path>  # overwrite existing target
+```
+
+Restoring a `hooks-*.tgz` also rewrites `.claude/settings.json` and
+`.pi/agent/settings.json` from the sidecar `<tgz>.settings.json` that
+`xt migrate hooks --apply` wrote alongside the tarball — no separate
+settings restore is needed.
+
+### What `xt migrate skills --apply` does
+
+1. SHA-256 verifies each file under `.xtrm/skills/{default,optional}` against
+   the corresponding file under `~/.xtrm/skills`.
+2. Files that differ or are absent globally are copied into
+   `.xtrm/skills/user/packs/local-legacy/` with their **full nested path
+   preserved** (`default/foo/SKILL.md` → `local-legacy/foo/SKILL.md`).
+   Top-level source-pack `PACK.json` files are skipped so they never
+   overwrite the authoritative one.
+3. Writes an authoritative `local-legacy/PACK.json` with
+   `name: "local-legacy"`, `schemaVersion: "1"`, and `skills[]` filtered to
+   only those top-level dirs that actually contain a `SKILL.md`.
+4. Tarballs the whole `.xtrm/skills/` tree to
+   `~/.xtrm/migration-backups/skills-<repo>-<ts>.tgz`.
+5. Removes `.xtrm/skills/default` and `.xtrm/skills/optional`. Leaves
+   `active/`, `user/`, `state.json` alone.
+6. Records the migration in `~/.xtrm/known-repos.json` and appends
+   `skills.migrate.ok` (or `skills.migrate.diverged`) events to
+   `~/.xtrm/logs/skills-migration.jsonl`.
+
+`xt migrate hooks --apply` is the same shape targeting `.xtrm/hooks/` plus
+the settings.json sidecar.
+
+### Source-repo guard
+
+`xt migrate --apply` refuses to run on the `xtrm-tools` source repo itself:
+
+- `package.json.name === 'xtrm-tools'`, OR
+- `scripts/gen-registry.mjs` exists, OR
+- `scripts/vendor-specialists-skills.mjs` exists
+
+Failure mode is `exit 1` with an explicit refusal message naming the marker.
+Dry-run is always permitted. Maintainer escape hatch: `--force-source`
+(undocumented; do not use on the real source tree — you will corrupt the
+canonical payload).
+
+### Ordering caveat: restore only reverses migrate
+
+`migrate` → `restore` is a clean roundtrip: the tarball snapshots the
+pre-migrate `.xtrm/skills/` and extracts it back verbatim.
+
+`migrate` → `xt update --apply` → `restore` is **not** clean: the update
+between the two operations refreshes canonical `default/` with the current
+package payload, so a subsequent restore drops the older tarball on top
+and leaves a mixed working tree. If you need to fully revert after
+running an update, use `git checkout -- .xtrm/skills && git clean -fd
+.xtrm/skills` instead of `--restore`.
+
+### Repairing a broken `local-legacy` pack
+
+Repos migrated by an older `xt migrate` may have a `local-legacy/PACK.json`
+with the source pack's `name` (e.g. `"xt-optional"`), a flattened tree
+(all files collapsed to the pack root, only the last of each name
+surviving), and/or a `skills[]` listing dirs that lack a `SKILL.md`.
+Symptom: `xt update --apply` fails with `PACK_METADATA_MISMATCH` or
+"Invalid pack metadata: name must match directory 'local-legacy'".
+
+Surgical repair (no re-migrate needed):
+
+```bash
+LEGACY=<repo>/.xtrm/skills/user/packs/local-legacy
+SKILLS=$(for d in "$LEGACY"/*/; do
+  n=$(basename "$d")
+  [ -f "$d/SKILL.md" ] && echo "$n"
+done | jq -R . | jq -s .)
+jq --argjson skills "$SKILLS" \
+   '.name = "local-legacy"
+    | .schemaVersion = "1"
+    | .version = (.version // "0.0.0")
+    | .skills = $skills' \
+   "$LEGACY/PACK.json" > "$LEGACY/PACK.json.new"
+mv "$LEGACY/PACK.json.new" "$LEGACY/PACK.json"
+xt update --repo <repo>   # dry-run — expect clean, then --apply
+```
+
+New migrations (xtrm-tools ≥ this release) author the pack correctly on
+first run; the recipe above is only for pre-fix state on the disk.
 
 ## Migrating a dev-linked project to a real consumer install
 

--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -1,0 +1,111 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@earendil-works/pi-coding-agent", () => {
+  const tool = (name: string) => ({ name, description: name, parameters: {}, execute: vi.fn() });
+  return {
+    CustomEditor: class {},
+    createBashTool: () => tool("bash"),
+    createEditTool: () => tool("edit"),
+    createFindTool: () => tool("find"),
+    createGrepTool: () => tool("grep"),
+    createLsTool: () => tool("ls"),
+    createReadTool: () => tool("read"),
+    createWriteTool: () => tool("write"),
+  };
+});
+
+vi.mock("@earendil-works/pi-tui", () => ({
+  Box: class {},
+  Text: class {
+    constructor(private text: string) {}
+    render() { return this.text.split("\n"); }
+  },
+  truncateToWidth: (text: string) => text,
+  visibleWidth: (text: string) => text.length,
+}));
+
+const { default: xtrmUiExtension } = await import("../../../packages/pi-extensions/extensions/xtrm-ui/index");
+
+function loadExtension() {
+  const handlers: Record<string, Function[]> = {};
+  const tools: Record<string, any> = {};
+  const pi = new Proxy(
+    {
+      getThinkingLevel: () => "off",
+      on(event: string, handler: Function) {
+        (handlers[event] ??= []).push(handler);
+      },
+      registerTool(tool: any) {
+        tools[tool.name] = tool;
+      },
+      registerCommand() {},
+      registerMessageRenderer() {},
+    },
+    { get: (target, key) => key in target ? target[key as keyof typeof target] : () => {} },
+  );
+
+  xtrmUiExtension(pi as any);
+  return { handlers, tools };
+}
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+  bg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+const context = (args: Record<string, unknown>) => ({
+  args,
+  toolCallId: "call-1",
+  invalidate() {},
+  lastComponent: undefined,
+  state: {},
+  cwd: "/tmp",
+  executionStarted: true,
+  argsComplete: true,
+  isPartial: false,
+  expanded: false,
+  showImages: true,
+  isError: false,
+});
+
+describe("xtrm-ui built-in tool rendering", () => {
+  it("reads bash labels from render context args", () => {
+    const { tools } = loadExtension();
+    const component = tools.bash.renderResult(
+      { content: [{ type: "text", text: "ok" }], details: {} },
+      { expanded: false, isPartial: false },
+      theme,
+      context({ command: "echo context-label" }),
+    );
+
+    expect(component.render(200).join("\n")).toContain("$ echo context-label");
+  });
+
+  it("keeps pre-write diff data in renderer-local state", () => {
+    const { tools } = loadExtension();
+    const path = join(mkdtempSync(join(tmpdir(), "xtrm-ui-")), "probe.txt");
+    writeFileSync(path, "before\n");
+    const renderContext = context({ path, content: "after\n" });
+
+    tools.write.renderCall(renderContext.args, theme, renderContext);
+    const component = tools.write.renderResult(
+      { content: [{ type: "text", text: "ok" }], details: undefined },
+      { expanded: false, isPartial: false },
+      theme,
+      renderContext,
+    );
+
+    expect(component.render(200).join("\n")).toContain("+1 · -1");
+  });
+
+  it("does not register built-in lifecycle tracking hooks", () => {
+    const { handlers } = loadExtension();
+
+    expect(handlers.tool_call).toBeUndefined();
+    expect(handlers.tool_execution_end).toBeUndefined();
+  });
+});

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -479,6 +479,10 @@ function applyXtrmChrome(
   prefs: XtrmUiPrefs,
   getThinkingLevel: () => string
 ): void {
+  if (prefs.forceTheme) {
+    ctx.ui.setTheme(resolveThemeForPrefs(prefs));
+  }
+
   // Tool expansion
   ctx.ui.setToolsExpanded(!prefs.compactTools);
 
@@ -868,20 +872,19 @@ function registerCommands(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs, setPref
 
 type BuiltInTools = ReturnType<typeof createBuiltInTools>;
 
-type XtrmMeta<TArgs = Record<string, unknown>> = {
-  tool: string;
-  args: TArgs;
-  durationMs: number;
-};
-
 type XtrmWritePreview =
   | { kind: "created"; lineCount: number }
   | { kind: "updated"; diff: string; additions: number; removals: number }
   | { kind: "unchanged" };
 
-type DetailsWithXtrmMeta<TDetails, TArgs = Record<string, unknown>> = TDetails & {
-  xtrmMeta?: XtrmMeta<TArgs>;
-  xtrmWritePreview?: XtrmWritePreview;
+type XtrmToolRenderState = {
+  startedAt?: number;
+  writePreview?: XtrmWritePreview;
+};
+
+type XtrmToolRenderContext = {
+  isPartial: boolean;
+  state: XtrmToolRenderState;
 };
 
 const toolCache = new Map<string, BuiltInTools>();
@@ -905,22 +908,6 @@ function getTools(cwd: string): BuiltInTools {
     toolCache.set(cwd, tools);
   }
   return tools;
-}
-
-function withXtrmMeta<TDetails extends object, TArgs extends Record<string, unknown>>(
-  details: TDetails | undefined,
-  tool: string,
-  args: TArgs,
-  durationMs: number,
-): DetailsWithXtrmMeta<TDetails, TArgs> {
-  return { ...(details ?? ({} as TDetails)), xtrmMeta: { tool, args, durationMs } };
-}
-
-function getXtrmMeta<TDetails extends object, TArgs extends Record<string, unknown>>(
-  details: TDetails | undefined,
-): XtrmMeta<TArgs> | undefined {
-  if (!details || typeof details !== "object") return undefined;
-  return (details as DetailsWithXtrmMeta<TDetails, TArgs>).xtrmMeta;
 }
 
 function getTextContent(result: { content: Array<{ type: string; text?: string }> }): string {
@@ -954,10 +941,6 @@ function createWritePreview(path: string, nextContent: string): XtrmWritePreview
 
 function renderPendingCall(toolName: string, args: Record<string, unknown>, theme: any): Text {
   return new Text(renderToolSummary(theme, "pending", toolName, summarizeToolSubject(toolName, args), undefined), 0, 0);
-}
-
-function stableToolSignature(toolName: string, args: Record<string, unknown>): string {
-  return `${toolName}:${JSON.stringify(args)}`;
 }
 
 function summarizeToolSubject(toolName: string, args: Record<string, unknown>): string | undefined {
@@ -1389,8 +1372,7 @@ const PAYLOAD_TOOLS = new Set<string>([
 ]);
 
 function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): void {
-  const activeToolCalls = new Map<string, string>();
-
+  const tools = getTools(process.cwd());
   const toolRowText = (theme: any, text: string) =>
     new Text(
       text,
@@ -1398,69 +1380,37 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
       0,
       getPrefs().toolRowBg ? (line: string) => theme.bg("selectedBg", line) : undefined,
     );
-  const activeSignatureCounts = new Map<string, number>();
-  const toolCallStartTimes = new Map<string, number>();
-
-  const trackToolCallStart = (toolCallId: string, toolName: string, args: Record<string, unknown>) => {
-    const signature = stableToolSignature(toolName, args);
-    activeToolCalls.set(toolCallId, signature);
-    activeSignatureCounts.set(signature, (activeSignatureCounts.get(signature) ?? 0) + 1);
-    toolCallStartTimes.set(toolCallId, Date.now());
+  const renderCall = (
+    toolName: string,
+    args: Record<string, unknown>,
+    theme: any,
+    context: XtrmToolRenderContext,
+  ) => {
+    context.state.startedAt ??= Date.now();
+    return context.isPartial ? renderPendingCall(toolName, args, theme) : toolRowText(theme, "");
   };
+  const renderDuration = (context: XtrmToolRenderContext) =>
+    formatDuration(context.state.startedAt == null ? undefined : Date.now() - context.state.startedAt);
 
-  const trackToolCallEnd = (toolCallId: string) => {
-    const signature = activeToolCalls.get(toolCallId);
-    if (!signature) return;
-    activeToolCalls.delete(toolCallId);
-    const next = (activeSignatureCounts.get(signature) ?? 1) - 1;
-    if (next <= 0) activeSignatureCounts.delete(signature);
-    else activeSignatureCounts.set(signature, next);
-    toolCallStartTimes.delete(toolCallId);
-  };
-
-  const isToolCallActive = (toolName: string, args: Record<string, unknown>) =>
-    activeSignatureCounts.has(stableToolSignature(toolName, args));
-
-  const renderPendingCallIfActive = (toolName: string, args: Record<string, unknown>, theme: any) =>
-    isToolCallActive(toolName, args) ? renderPendingCall(toolName, args, theme) : toolRowText(theme, "");
-
-  pi.on("tool_call", async (event) => {
-    trackToolCallStart(event.toolCallId, event.toolName, event.input as Record<string, unknown>);
-  });
-
-  pi.on("tool_execution_end", async (event) => {
-    trackToolCallEnd(event.toolCallId);
-  });
-
-  pi.on("tool_result", async (event: ToolResultEvent, _ctx) => {
-    if (event.isError) return undefined;
-    if (XTRM_BUILTIN_TOOLS.has(event.toolName)) {
-      trackToolCallEnd(event.toolCallId);
-      return undefined;
-    }
+  pi.on("tool_result", async (event: ToolResultEvent) => {
+    if (XTRM_BUILTIN_TOOLS.has(event.toolName) || event.isError) return undefined;
     // Never compact read/inspect tools: the hook return replaces model-facing content,
     // so summarizing these would blind headless agents/specialists (no row to expand).
     if (PAYLOAD_TOOLS.has(event.toolName)) return undefined;
     if (!getPrefs().compactExternalToolResults) return undefined;
 
     const text = getTextContent({ content: event.content as Array<{ type: string; text?: string }> });
-    const startedAt = toolCallStartTimes.get(event.toolCallId);
-    const durationMs = startedAt != null ? Date.now() - startedAt : undefined;
-
-    const fallbackText = "[non-text result]";
-    const sourceText = text.trim() ? text : fallbackText;
-
+    const sourceText = text.trim() ? text : "[non-text result]";
     const safeInput =
       event.input && typeof event.input === "object" && !Array.isArray(event.input)
         ? (event.input as Record<string, unknown>)
         : {};
-
     const compactText = summarizeExternalToolResult(
       event.toolName,
       safeInput,
       sourceText,
       event.details,
-      durationMs,
+      undefined,
     );
 
     return {
@@ -1472,29 +1422,24 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
   pi.registerTool({
     name: "bash",
     label: "bash",
-    description: getTools(process.cwd()).bash.description,
-    parameters: getTools(process.cwd()).bash.parameters,
+    description: tools.bash.description,
+    parameters: tools.bash.parameters,
+    execute: tools.bash.execute,
     renderShell: "self",
-    async execute(toolCallId, params, signal, onUpdate, ctx) {
-      const started = Date.now();
-      const result = await getTools(ctx.cwd).bash.execute(toolCallId, params, signal, onUpdate);
-      return { ...result, details: withXtrmMeta(result.details as BashToolDetails | undefined, "bash", params as Record<string, unknown>, Date.now() - started) };
-    },
-    renderCall: (args, theme) => renderPendingCallIfActive("bash", args as Record<string, unknown>, theme),
-    renderResult(result, { expanded, isPartial }, theme) {
-      const details = (result.details ?? {}) as DetailsWithXtrmMeta<BashToolDetails, Record<string, unknown>>;
-      const meta = getXtrmMeta<BashToolDetails, Record<string, unknown>>(details);
-      const command = String(meta?.args.command ?? "");
+    renderCall: (args, theme, context) =>
+      renderCall("bash", args as Record<string, unknown>, theme, context),
+    renderResult(result, { expanded, isPartial }, theme, context) {
+      const details = (result.details ?? {}) as BashToolDetails;
+      const args = context.args as Record<string, unknown>;
+      const command = String(args.command ?? "");
       if (isPartial) {
         return toolRowText(theme, `${theme.fg("accent", TOOL_ROW_MARKER)} ${theme.fg("accent", "$")} ${theme.fg("accent", command)}`);
       }
       const output = getTextContent(result as any);
       const outputLines = cleanOutputLines(output);
-      const exitMatch = output.match(/exit code:\s*(-?\d+)/i);
-      const exitCode = exitMatch ? Number.parseInt(exitMatch[1] ?? "0", 10) : 0;
-      const statusColor = exitCode !== 0 ? "error" : "success";
+      const statusColor = context.isError ? "error" : "success";
       const summary = joinCompactMeta([
-        formatDuration(meta?.durationMs),
+        renderDuration(context),
         formatPayloadSize(output),
         formatLineLabel(outputLines.length, "line"),
         details.truncation?.truncated ? "truncated" : undefined,
@@ -1503,14 +1448,12 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
       if (summary) text += theme.fg("dim", ` · ${summary}`);
 
       if (!expanded && outputLines.length > 0) {
-        const previewStart = Math.max(0, outputLines.length - 4);
-        const preview = outputLines.slice(previewStart);
+        const preview = outputLines.slice(-4);
         text += "\n" + preview.map((line) => `  ${theme.fg("toolOutput", line)}`).join("\n");
         if (outputLines.length > 4) {
           text += `\n${theme.fg("dim", `  ... (${outputLines.length - 4} earlier lines, use ␣ to expand)`)}`;
         }
       }
-
       if (expanded && outputLines.length > 0) {
         text += "\n" + outputLines.map((line) => `  ${theme.fg("toolOutput", line)}`).join("\n");
       }
@@ -1521,42 +1464,40 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
   pi.registerTool({
     name: "read",
     label: "read",
-    description: getTools(process.cwd()).read.description,
-    parameters: getTools(process.cwd()).read.parameters,
+    description: tools.read.description,
+    parameters: tools.read.parameters,
+    execute: tools.read.execute,
     renderShell: "self",
-    async execute(toolCallId, params, signal, onUpdate, ctx) {
-      const started = Date.now();
-      const result = await getTools(ctx.cwd).read.execute(toolCallId, params, signal, onUpdate);
-      return { ...result, details: withXtrmMeta(result.details as ReadToolDetails | undefined, "read", params as Record<string, unknown>, Date.now() - started) };
-    },
-    renderCall: (args, theme) => renderPendingCallIfActive("read", args as Record<string, unknown>, theme),
-    renderResult(result, { expanded, isPartial }, theme) {
+    renderCall: (args, theme, context) =>
+      renderCall("read", args as Record<string, unknown>, theme, context),
+    renderResult(result, { expanded, isPartial }, theme, context) {
       if (isPartial) return toolRowText(theme, renderToolSummary(theme, "pending", "read", "loading", undefined));
-      const details = (result.details ?? {}) as DetailsWithXtrmMeta<ReadToolDetails, Record<string, unknown>>;
-      const meta = getXtrmMeta<ReadToolDetails, Record<string, unknown>>(details);
-      const subjectBase = shortenPath(String(meta?.args.path ?? ""));
-      const range = lineRange(meta?.args.offset as number | undefined, meta?.args.limit as number | undefined);
+      const details = (result.details ?? {}) as ReadToolDetails;
+      const args = context.args as Record<string, unknown>;
+      const subjectBase = shortenPath(String(args.path ?? ""));
+      const range = lineRange(args.offset as number | undefined, args.limit as number | undefined);
       const subject = range ? `${subjectBase}:${range}` : subjectBase;
       const first = result.content[0];
       if (first?.type === "image") {
-        return toolRowText(theme, renderToolSummary(theme, "success", "read", subject, joinMeta(["image", formatDuration(meta?.durationMs)])));
+        return toolRowText(theme, renderToolSummary(theme, "success", "read", subject, joinMeta(["image", renderDuration(context)])));
       }
       const textContent = getTextContent(result as any);
       const lines = textContent.split("\n");
       const totalLines = lines.length;
-      let text = renderToolSummary(theme, "success", "read", subject, joinMeta([formatLineLabel(totalLines, "line"), formatDuration(meta?.durationMs), details.truncation?.truncated ? `from ${details.truncation.totalLines}` : undefined]));
-
-      // Show content inline for small files (≤6 lines) even when not expanded
-      const showInline = !expanded && totalLines > 0 && totalLines <= 6;
-      const showExpanded = expanded && totalLines > 0;
-
-      if (showInline || showExpanded) {
+      let text = renderToolSummary(
+        theme,
+        context.isError ? "error" : "success",
+        "read",
+        subject,
+        joinMeta([
+          formatLineLabel(totalLines, "line"),
+          renderDuration(context),
+          details.truncation?.truncated ? `from ${details.truncation.totalLines}` : undefined,
+        ]),
+      );
+      if ((expanded || totalLines <= 6) && totalLines > 0) {
         text += "\n" + lines.map((line) => `  ${theme.fg("toolOutput", line)}`).join("\n");
-        if (!expanded && totalLines > 6) {
-          text += `\n${theme.fg("dim", `  ... (${totalLines - 6} more lines, use ␣ to expand)`)}`;
-        }
       }
-
       return toolRowText(theme, text);
     },
   });
@@ -1564,26 +1505,23 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
   pi.registerTool({
     name: "edit",
     label: "edit",
-    description: getTools(process.cwd()).edit.description,
-    parameters: getTools(process.cwd()).edit.parameters,
+    description: tools.edit.description,
+    parameters: tools.edit.parameters,
+    execute: tools.edit.execute,
     renderShell: "self",
-    async execute(toolCallId, params, signal, onUpdate, ctx) {
-      const started = Date.now();
-      const result = await getTools(ctx.cwd).edit.execute(toolCallId, params, signal, onUpdate);
-      return { ...result, details: withXtrmMeta(result.details as EditToolDetails | undefined, "edit", params as Record<string, unknown>, Date.now() - started) };
-    },
-    renderCall: (args, theme) => renderPendingCallIfActive("edit", args as Record<string, unknown>, theme),
-    renderResult(result, { expanded, isPartial }, theme) {
+    renderCall: (args, theme, context) =>
+      renderCall("edit", args as Record<string, unknown>, theme, context),
+    renderResult(result, { isPartial }, theme, context) {
       if (isPartial) return toolRowText(theme, renderToolSummary(theme, "pending", "edit", "applying", undefined));
-      const details = (result.details ?? {}) as DetailsWithXtrmMeta<EditToolDetails, Record<string, unknown>>;
-      const meta = getXtrmMeta<EditToolDetails, Record<string, unknown>>(details);
+      const details = (result.details ?? {}) as EditToolDetails;
+      const args = context.args as Record<string, unknown>;
+      const path = String(args.path ?? "");
       const textContent = getTextContent(result as any);
-      const path = String(meta?.args.path ?? "");
-      if (/^error/i.test(textContent.trim())) {
+      if (context.isError) {
         return toolRowText(theme, renderToolSummary(theme, "error", "edit", path, textContent.split("\n")[0]));
       }
       const stats = details.diff ? diffStats(details.diff) : { additions: 0, removals: 0 };
-      let text = renderToolSummary(theme, "success", "edit", path, joinMeta([`+${stats.additions}`, `-${stats.removals}`, formatDuration(meta?.durationMs)]));
+      let text = renderToolSummary(theme, "success", "edit", path, joinMeta([`+${stats.additions}`, `-${stats.removals}`, renderDuration(context)]));
       if (details.diff) text += `\n${renderRichDiffPreview(theme, details.diff, 18)}`;
       return toolRowText(theme, text);
     },
@@ -1592,64 +1530,44 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
   pi.registerTool({
     name: "write",
     label: "write",
-    description: getTools(process.cwd()).write.description,
-    parameters: getTools(process.cwd()).write.parameters,
+    description: tools.write.description,
+    parameters: tools.write.parameters,
+    execute: tools.write.execute,
     renderShell: "self",
-    async execute(toolCallId, params, signal, onUpdate, ctx) {
-      const started = Date.now();
-      const args = params as Record<string, unknown>;
+    renderCall(args, theme, context) {
+      const input = args as Record<string, unknown>;
+      const state = context.state as XtrmToolRenderState;
+      if (context.argsComplete && !state.writePreview) {
+        state.writePreview = createWritePreview(String(input.path ?? ""), String(input.content ?? ""));
+      }
+      return renderCall("write", input, theme, context);
+    },
+    renderResult(result, { expanded, isPartial }, theme, context) {
+      if (isPartial) return toolRowText(theme, renderToolSummary(theme, "pending", "write", "writing", undefined));
+      const args = context.args as Record<string, unknown>;
       const path = String(args.path ?? "");
       const content = String(args.content ?? "");
-      const preview = createWritePreview(path, content);
-      const result = await getTools(ctx.cwd).write.execute(toolCallId, params, signal, onUpdate);
-      const details = withXtrmMeta(result.details as Record<string, never> | undefined, "write", args, Date.now() - started);
-      return { ...result, details: { ...details, xtrmWritePreview: preview } };
-    },
-    renderCall: (args, theme) => renderPendingCallIfActive("write", args as Record<string, unknown>, theme),
-    renderResult(result, { expanded, isPartial }, theme) {
-      if (isPartial) return toolRowText(theme, renderToolSummary(theme, "pending", "write", "writing", undefined));
-      const details = (result.details ?? {}) as DetailsWithXtrmMeta<Record<string, never>, Record<string, unknown>>;
-      const meta = getXtrmMeta<Record<string, never>, Record<string, unknown>>(details);
       const textContent = getTextContent(result as any);
-      const path = String(meta?.args.path ?? "");
-      if (/^error/i.test(textContent.trim())) {
+      if (context.isError) {
         return toolRowText(theme, renderToolSummary(theme, "error", "write", path, textContent.split("\n")[0]));
       }
 
-      const preview = details.xtrmWritePreview;
-
+      const preview = (context.state as XtrmToolRenderState).writePreview;
       if (preview?.kind === "unchanged") {
-        return toolRowText(theme, renderToolSummary(theme, "success", "write", path, joinMeta(["no changes", formatDuration(meta?.durationMs)])));
+        return toolRowText(theme, renderToolSummary(theme, "success", "write", path, joinMeta(["no changes", renderDuration(context)])));
       }
-
       if (preview?.kind === "updated") {
-        let text = renderToolSummary(
-          theme,
-          "success",
-          "write",
-          path,
-          joinMeta([`+${preview.additions}`, `-${preview.removals}`, formatDuration(meta?.durationMs)]),
-        );
+        let text = renderToolSummary(theme, "success", "write", path, joinMeta([`+${preview.additions}`, `-${preview.removals}`, renderDuration(context)]));
         if (preview.diff) text += `\n${renderRichDiffPreview(theme, preview.diff, 18)}`;
         return toolRowText(theme, text);
       }
 
-      // created
-      const lines = preview?.kind === "created" ? preview.lineCount : lineCount(String(meta?.args.content ?? ""));
-      let text = renderToolSummary(theme, "success", "write", path, joinMeta([formatLineLabel(lines, "line"), formatDuration(meta?.durationMs)]));
-
-      const content = String(meta?.args.content ?? "");
-      if (content) {
-        const contentLines = content.split("\n");
-        const showInline = !expanded && contentLines.length <= 6;
-        if (showInline || expanded) {
-          text += "\n" + contentLines.map((line) => `  ${theme.fg("toolOutput", line)}`).join("\n");
-          if (!expanded && contentLines.length > 6) {
-            text += `\n${theme.fg("dim", `  ... (${contentLines.length - 6} more lines, use ␣ to expand)`)}`;
-          }
-        }
+      const lines = preview?.kind === "created" ? preview.lineCount : lineCount(content);
+      let text = renderToolSummary(theme, "success", "write", path, joinMeta([formatLineLabel(lines, "line"), renderDuration(context)]));
+      const contentLines = content.split("\n");
+      if (content && (expanded || contentLines.length <= 6)) {
+        text += "\n" + contentLines.map((line) => `  ${theme.fg("toolOutput", line)}`).join("\n");
       }
-
       return toolRowText(theme, text);
     },
   });
@@ -1657,22 +1575,25 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
   pi.registerTool({
     name: "find",
     label: "find",
-    description: getTools(process.cwd()).find.description,
-    parameters: getTools(process.cwd()).find.parameters,
+    description: tools.find.description,
+    parameters: tools.find.parameters,
+    execute: tools.find.execute,
     renderShell: "self",
-    async execute(toolCallId, params, signal, onUpdate, ctx) {
-      const started = Date.now();
-      const result = await getTools(ctx.cwd).find.execute(toolCallId, params, signal, onUpdate);
-      return { ...result, details: withXtrmMeta(result.details as FindToolDetails | undefined, "find", params as Record<string, unknown>, Date.now() - started) };
-    },
-    renderCall: (args, theme) => renderPendingCallIfActive("find", args as Record<string, unknown>, theme),
-    renderResult(result, { expanded, isPartial }, theme) {
+    renderCall: (args, theme, context) =>
+      renderCall("find", args as Record<string, unknown>, theme, context),
+    renderResult(result, { expanded, isPartial }, theme, context) {
       if (isPartial) return toolRowText(theme, renderToolSummary(theme, "pending", "find", "searching", undefined));
-      const details = (result.details ?? {}) as DetailsWithXtrmMeta<FindToolDetails, Record<string, unknown>>;
-      const meta = getXtrmMeta<FindToolDetails, Record<string, unknown>>(details);
+      const details = (result.details ?? {}) as FindToolDetails;
+      const args = context.args as Record<string, unknown>;
       const textContent = getTextContent(result as any);
       const count = summarizeCount(textContent);
-      let text = renderToolSummary(theme, "success", "find", String(meta?.args.pattern ?? ""), joinMeta([formatLineLabel(count, "match"), formatDuration(meta?.durationMs), details.resultLimitReached ? "limit reached" : undefined]));
+      let text = renderToolSummary(
+        theme,
+        context.isError ? "error" : "success",
+        "find",
+        String(args.pattern ?? ""),
+        joinMeta([formatLineLabel(count, "match"), renderDuration(context), details.resultLimitReached ? "limit reached" : undefined]),
+      );
       if (expanded && count > 0) text += `\n${renderOutputPreview(theme, previewLines(textContent, 10), 10)}`;
       return toolRowText(theme, text);
     },
@@ -1681,22 +1602,25 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
   pi.registerTool({
     name: "grep",
     label: "grep",
-    description: getTools(process.cwd()).grep.description,
-    parameters: getTools(process.cwd()).grep.parameters,
+    description: tools.grep.description,
+    parameters: tools.grep.parameters,
+    execute: tools.grep.execute,
     renderShell: "self",
-    async execute(toolCallId, params, signal, onUpdate, ctx) {
-      const started = Date.now();
-      const result = await getTools(ctx.cwd).grep.execute(toolCallId, params, signal, onUpdate);
-      return { ...result, details: withXtrmMeta(result.details as GrepToolDetails | undefined, "grep", params as Record<string, unknown>, Date.now() - started) };
-    },
-    renderCall: (args, theme) => renderPendingCallIfActive("grep", args as Record<string, unknown>, theme),
-    renderResult(result, { expanded, isPartial }, theme) {
+    renderCall: (args, theme, context) =>
+      renderCall("grep", args as Record<string, unknown>, theme, context),
+    renderResult(result, { expanded, isPartial }, theme, context) {
       if (isPartial) return toolRowText(theme, renderToolSummary(theme, "pending", "grep", "searching", undefined));
-      const details = (result.details ?? {}) as DetailsWithXtrmMeta<GrepToolDetails, Record<string, unknown>>;
-      const meta = getXtrmMeta<GrepToolDetails, Record<string, unknown>>(details);
+      const details = (result.details ?? {}) as GrepToolDetails;
+      const args = context.args as Record<string, unknown>;
       const textContent = getTextContent(result as any);
       const count = countPrefixedItems(textContent, ["-- "]) || summarizeCount(textContent);
-      let text = renderToolSummary(theme, "success", "grep", String(meta?.args.pattern ?? ""), joinMeta([formatLineLabel(count, "match"), formatDuration(meta?.durationMs), details.matchLimitReached ? "limit reached" : undefined]));
+      let text = renderToolSummary(
+        theme,
+        context.isError ? "error" : "success",
+        "grep",
+        String(args.pattern ?? ""),
+        joinMeta([formatLineLabel(count, "match"), renderDuration(context), details.matchLimitReached ? "limit reached" : undefined]),
+      );
       if (expanded && textContent.length > 0) text += `\n${renderOutputPreview(theme, previewLines(textContent, 12), 12)}`;
       return toolRowText(theme, text);
     },
@@ -1705,22 +1629,25 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
   pi.registerTool({
     name: "ls",
     label: "ls",
-    description: getTools(process.cwd()).ls.description,
-    parameters: getTools(process.cwd()).ls.parameters,
+    description: tools.ls.description,
+    parameters: tools.ls.parameters,
+    execute: tools.ls.execute,
     renderShell: "self",
-    async execute(toolCallId, params, signal, onUpdate, ctx) {
-      const started = Date.now();
-      const result = await getTools(ctx.cwd).ls.execute(toolCallId, params, signal, onUpdate);
-      return { ...result, details: withXtrmMeta(result.details as LsToolDetails | undefined, "ls", params as Record<string, unknown>, Date.now() - started) };
-    },
-    renderCall: (args, theme) => renderPendingCallIfActive("ls", args as Record<string, unknown>, theme),
-    renderResult(result, { expanded, isPartial }, theme) {
+    renderCall: (args, theme, context) =>
+      renderCall("ls", args as Record<string, unknown>, theme, context),
+    renderResult(result, { expanded, isPartial }, theme, context) {
       if (isPartial) return toolRowText(theme, renderToolSummary(theme, "pending", "ls", "listing", undefined));
-      const details = (result.details ?? {}) as DetailsWithXtrmMeta<LsToolDetails, Record<string, unknown>>;
-      const meta = getXtrmMeta<LsToolDetails, Record<string, unknown>>(details);
+      const details = (result.details ?? {}) as LsToolDetails;
+      const args = context.args as Record<string, unknown>;
       const textContent = getTextContent(result as any);
       const count = summarizeCount(textContent);
-      let text = renderToolSummary(theme, "success", "ls", shortenPath(String(meta?.args.path ?? ".")), joinMeta([formatLineLabel(count, "entry"), formatDuration(meta?.durationMs), details.entryLimitReached ? "limit reached" : undefined]));
+      let text = renderToolSummary(
+        theme,
+        context.isError ? "error" : "success",
+        "ls",
+        shortenPath(String(args.path ?? ".")),
+        joinMeta([formatLineLabel(count, "entry"), renderDuration(context), details.entryLimitReached ? "limit reached" : undefined]),
+      );
       if (expanded && count > 0) text += `\n${renderOutputPreview(theme, previewLines(textContent, 12), 12)}`;
       return toolRowText(theme, text);
     },


### PR DESCRIPTION
## Summary

Adds a **Migration to global scope (\`xt migrate\`)** section to \`update-xt/SKILL.md\` covering the surface shipped by the xtrm-bq7yd epic + follow-ups (svb0n, dm3hy, hzkdk):

- Full command list: migrate skills/hooks/all, dry-run vs apply, restore path (including the settings.json sidecar for hooks).
- \`XTRM_GLOBAL_SKILLS\` / \`XTRM_GLOBAL_HOOKS\` feature-flag gates.
- Step-by-step of what \`xt migrate skills --apply\` does (SHA-256 verify → preserve diverged files under local-legacy with nested paths → authoritative PACK.json → tarball backup → known-repos.json + JSONL log).
- Source-repo guard (three markers + \`--force-source\` escape hatch).
- **Ordering caveat**: \`restore\` only reverses \`migrate\`. If \`xt update --apply\` ran between, use \`git checkout\` to fully revert. Discovered during the release smoke pass on ~/dev/console and ~/projects/mercury/treasury-cb.
- Surgical repair recipe for \`local-legacy\` packs on repos migrated by the pre-fix code (broken name, flattened tree, stale skills[]).

Extends the remediation command table with three new rows for migrate/restore, expands the \`PACK_METADATA_MISMATCH\` failure row to point at the local-legacy repair, and updates the frontmatter description so the skill activates on 'xt migrate' intents.

## Test plan

- [x] \`node scripts/gen-registry.mjs\` — regenerated for new SKILL.md hash.
- [x] \`npm run check:registry-pack-parity\` — 353/353 ok.
- [x] \`npm run check:skills-symlinks\` — pass.
- [ ] CI.