### PR TITLE
fix: bound statusline refresh work

### DIFF
--- a/.xtrm/hooks/statusline.mjs
+++ b/.xtrm/hooks/statusline.mjs
@@ -1,35 +1,86 @@
 #!/usr/bin/env node
-// statusline.mjs — Claude Code statusLine for xt claude sessions
-// Line 1: ~/path (branch *+↑)
-// Line 2: XX%/window (provider) model
-// Line 3: ◐ claim-title OR ○ N open
+// Claude Code statusLine for xt sessions. Rendering only reads a bounded cache;
+// a detached, lease-protected refresh performs slow git and beads work.
 
-import { execSync } from 'node:child_process';
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { execSync, spawn } from 'node:child_process';
+import { closeSync, existsSync, openSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join, basename, relative, dirname, isAbsolute } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 
-let ctx = {};
-try { ctx = JSON.parse(readFileSync(0, 'utf8')); } catch {}
-
-const cwd = ctx?.workspace?.current_dir ?? process.cwd();
-const cacheKey = createHash('md5').update(cwd).digest('hex').slice(0, 8);
-const CACHE_FILE = join(tmpdir(), `xtrm-sl-${cacheKey}.json`);
+const CACHE_DIR = process.env.XTRM_STATUSLINE_CACHE_DIR ?? tmpdir();
 const CACHE_TTL = 5000;
-
-function run(cmd) {
-  try { return execSync(cmd, { encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe'], timeout: 2000 }).trim(); } catch { return null; }
-}
-
-function getCached() {
-  try { const c = JSON.parse(readFileSync(CACHE_FILE, 'utf8')); if (Date.now() - c.ts < CACHE_TTL) return c.data; } catch {}
-  return null;
-}
-
-function setCache(data) { try { writeFileSync(CACHE_FILE, JSON.stringify({ ts: Date.now(), data })); } catch {} }
+const REFRESH_LEASE_MS = 5000;
+const RENDER_BUDGET_MS = 50;
+const MAX_CACHE_BYTES = 16 * 1024;
+const REFRESH_LOCK = join(CACHE_DIR, 'xtrm-sl-refresh.lock');
+const BEADS_CACHE = join(CACHE_DIR, 'xtrm-sl-beads.json');
 
 const R = '\x1b[0m', B = '\x1b[1m', B_ = '\x1b[22m', D = '\x1b[2m', I = '\x1b[3m', I_ = '\x1b[23m';
+
+function cacheFile(cwd) {
+  const key = createHash('md5').update(cwd).digest('hex').slice(0, 8);
+  return join(CACHE_DIR, `xtrm-sl-${key}.json`);
+}
+
+function readCache(file) {
+  try {
+    if (statSync(file).size > MAX_CACHE_BYTES) return null;
+    const cache = JSON.parse(readFileSync(file, 'utf8'));
+    if (!Number.isFinite(cache?.ts) || !cache?.data || typeof cache.data !== 'object') return null;
+    return { data: cache.data, fresh: Date.now() - cache.ts < CACHE_TTL };
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(file, data) {
+  const temp = `${file}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(temp, JSON.stringify({ ts: Date.now(), data }), { mode: 0o600 });
+    renameSync(temp, file);
+  } catch {
+    try { unlinkSync(temp); } catch {}
+  }
+}
+
+function run(cwd, cmd) {
+  try {
+    return execSync(cmd, {
+      encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe'], timeout: 250,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function takeRefreshLease() {
+  try {
+    const fd = openSync(REFRESH_LOCK, 'wx', 0o600);
+    closeSync(fd);
+    return true;
+  } catch {
+    try {
+      if (Date.now() - statSync(REFRESH_LOCK).mtimeMs > REFRESH_LEASE_MS) {
+        unlinkSync(REFRESH_LOCK);
+        return takeRefreshLease();
+      }
+    } catch {}
+    return false;
+  }
+}
+
+function startRefresh(cwd, started) {
+  if (Date.now() - started >= RENDER_BUDGET_MS || !takeRefreshLease()) return;
+  try {
+    const child = spawn(process.execPath, [process.argv[1], '--refresh', cwd], {
+      cwd, detached: true, stdio: 'ignore', env: process.env,
+    });
+    child.unref();
+  } catch {
+    try { unlinkSync(REFRESH_LOCK); } catch {}
+  }
+}
 
 function formatTokens(count) {
   if (count < 1000) return count.toString();
@@ -40,68 +91,32 @@ function formatTokens(count) {
 }
 
 function getProvider(modelId) {
-  if (!modelId) return null;
-  if (modelId.includes('/')) return modelId.split('/')[0];
-  return null;
+  return modelId?.includes('/') ? modelId.split('/')[0] : null;
 }
 
 function getModelName(modelId) {
-  if (!modelId) return null;
-  if (modelId.includes('/')) return modelId.split('/')[1];
-  return modelId;
+  return modelId?.includes('/') ? modelId.split('/')[1] : modelId ?? null;
 }
 
-const pct = ctx?.context_window?.used_percentage;
-const windowSize = ctx?.context_window?.context_window_size ?? 200000;
+function fallbackData(cwd) {
+  return {
+    displayDir: cwd.replace(process.env.HOME ?? '', '~'), branch: null, gitFlags: '',
+    claims: [], openCount: 0,
+  };
+}
 
-let data = getCached();
-if (!data) {
-  const repoRoot = run('git rev-parse --show-toplevel');
-  const gitCommonDir = run('git rev-parse --git-common-dir');
-  const mainRoot = (gitCommonDir && isAbsolute(gitCommonDir)) ? dirname(gitCommonDir) : (repoRoot || cwd);
-  let displayDir;
-  if (repoRoot) {
-    const rel = relative(repoRoot, cwd) || '.';
-    displayDir = rel === '.' ? basename(repoRoot) : `${basename(repoRoot)}/${rel}`;
-  } else {
-    displayDir = cwd.replace(process.env.HOME ?? '', '~');
-  }
-
-  let branch = null, gitFlags = '';
-  if (repoRoot) {
-    branch = run('git -c core.useBuiltinFSMonitor=false branch --show-current') || run('git rev-parse --short HEAD');
-    const porcelain = run('git -c core.useBuiltinFSMonitor=false --no-optional-locks status --porcelain') ?? '';
-    let modified = false, staged = false, deleted = false;
-    for (const l of porcelain.split('\n').filter(Boolean)) {
-      if (/^ M|^AM|^MM/.test(l)) modified = true;
-      if (/^A |^M /.test(l)) staged = true;
-      if (/^ D|^D /.test(l)) deleted = true;
-    }
-    gitFlags = (modified ? '*' : '') + (staged ? '+' : '') + (deleted ? '-' : '');
-    const ab = run('git -c core.useBuiltinFSMonitor=false --no-optional-locks rev-list --left-right --count @{upstream}...HEAD');
-    if (ab) {
-      const [behind, ahead] = ab.split(/\s+/).map(Number);
-      if (ahead > 0 && behind > 0) gitFlags += '↕';
-      else if (ahead > 0) gitFlags += '↑';
-      else if (behind > 0) gitFlags += '↓';
-    }
-  }
-
-  const modelId = ctx?.model?.id ?? null;
-  const modelDisplayName = ctx?.model?.display_name ?? null;
-  const provider = getProvider(modelId);
-  const modelName = modelDisplayName ?? getModelName(modelId) ?? null;
+function readBeads(cwd, mainRoot) {
+  const cached = readCache(BEADS_CACHE);
+  if (cached?.fresh) return cached.data;
 
   let claims = [], openCount = 0;
   if (existsSync(join(cwd, '.beads')) || existsSync(join(mainRoot, '.beads'))) {
-    const inProgressRaw = run('bd list --status=in_progress') ?? '';
-    const ids = [...new Set(
-      [...inProgressRaw.matchAll(/^[◐]\s+([a-z][\w-]+)/gm)]
-        .map(m => m[1]).filter(id => id.includes('-'))
-    )];
+    const inProgressRaw = run(cwd, 'bd list --status=in_progress') ?? '';
+    const ids = [...new Set([...inProgressRaw.matchAll(/^[◐]\s+([a-z][\w-]+)/gm)]
+      .map(match => match[1]).filter(id => id.includes('-')))];
     if (ids.length === 1) {
       try {
-        const raw = run(`bd show ${ids[0]} --json`);
+        const raw = run(cwd, `bd show ${ids[0]} --json`);
         const issue = raw ? JSON.parse(raw)?.[0] : null;
         if (issue) claims.push({ id: ids[0], title: issue.title ?? null, status: issue.status ?? 'in_progress' });
       } catch {}
@@ -109,48 +124,88 @@ if (!data) {
       claims = ids.map(id => ({ id, title: null, status: 'in_progress' }));
     }
     if (claims.length === 0) {
-      const m = run('bd list')?.match(/\((\d+)\s+open/);
-      if (m) openCount = parseInt(m[1], 10);
+      const match = run(cwd, 'bd list')?.match(/\((\d+)\s+open/);
+      if (match) openCount = Number.parseInt(match[1], 10);
     }
   }
-
-  data = { displayDir, branch, gitFlags, provider, modelName, claims, openCount };
-  setCache(data);
+  const data = { claims, openCount };
+  writeCache(BEADS_CACHE, data);
+  return data;
 }
 
-const { displayDir, branch, gitFlags, provider, modelName, claims, openCount } = data;
+function computeData(cwd) {
+  const repoRoot = run(cwd, 'git rev-parse --show-toplevel');
+  const gitCommonDir = run(cwd, 'git rev-parse --git-common-dir');
+  const mainRoot = gitCommonDir && isAbsolute(gitCommonDir) ? dirname(gitCommonDir) : (repoRoot || cwd);
+  const displayDir = repoRoot
+    ? (() => { const rel = relative(repoRoot, cwd) || '.'; return rel === '.' ? basename(repoRoot) : `${basename(repoRoot)}/${rel}`; })()
+    : cwd.replace(process.env.HOME ?? '', '~');
 
-// Line 1: ~/path (branch *+↑)
-let line1 = B + displayDir + B_;
-if (branch) { const b = gitFlags ? `${branch} ${gitFlags}` : branch; line1 += ` ${D}(${b})${R}`; }
+  let branch = null, gitFlags = '';
+  if (repoRoot) {
+    branch = run(cwd, 'git -c core.useBuiltinFSMonitor=false branch --show-current') || run(cwd, 'git rev-parse --short HEAD');
+    const porcelain = run(cwd, 'git -c core.useBuiltinFSMonitor=false --no-optional-locks status --porcelain') ?? '';
+    let modified = false, staged = false, deleted = false;
+    for (const line of porcelain.split('\n').filter(Boolean)) {
+      if (/^ M|^AM|^MM/.test(line)) modified = true;
+      if (/^A |^M /.test(line)) staged = true;
+      if (/^ D|^D /.test(line)) deleted = true;
+    }
+    gitFlags = (modified ? '*' : '') + (staged ? '+' : '') + (deleted ? '-' : '');
+    const aheadBehind = run(cwd, 'git -c core.useBuiltinFSMonitor=false --no-optional-locks rev-list --left-right --count @{upstream}...HEAD');
+    if (aheadBehind) {
+      const [behind, ahead] = aheadBehind.split(/\s+/).map(Number);
+      if (ahead > 0 && behind > 0) gitFlags += '↕';
+      else if (ahead > 0) gitFlags += '↑';
+      else if (behind > 0) gitFlags += '↓';
+    }
+  }
+  return { displayDir, branch, gitFlags, ...readBeads(cwd, mainRoot) };
+}
 
-// Line 2: XX%/window (provider) model
-const pctStr = pct != null ? `${pct.toFixed(1)}%` : '?';
-const ctxStr = `${pctStr}/${formatTokens(windowSize)}`;
-let modelStr = modelName ?? 'no-model';
-if (provider) modelStr = `(${provider}) ${modelStr}`;
-const line2 = `${D}${ctxStr}${R} ${D}${modelStr}${R}`;
+function refresh(cwd) {
+  try { writeCache(cacheFile(cwd), computeData(cwd)); } finally { try { unlinkSync(REFRESH_LOCK); } catch {} }
+}
 
-// Line 3: beads chip
-let line3;
-if (claims.length === 0) {
-  line3 = `○ ${openCount > 0 ? `${B}${openCount}${B_} open` : 'no open issues'}`;
-} else if (claims.length === 1) {
-  const { id, title, status } = claims[0];
-  const icon = status === 'blocked' ? '●' : status === 'in_progress' ? '◐' : '○';
-  const shortId = id.split('-').pop();
-  const cols = process.stdout.columns || 80;
-  const prefix = `${icon} ${shortId} `;
-  const max = Math.min(cols - prefix.length - 1, 40);
-  const t = title ? (title.length > max ? title.slice(0, max - 1) + '…' : title) : '';
-  line3 = `${prefix}${I}${t}${I_}`;
+function render(ctx, data) {
+  const pct = ctx?.context_window?.used_percentage;
+  const windowSize = ctx?.context_window?.context_window_size ?? 200000;
+  const modelId = ctx?.model?.id ?? null;
+  const provider = getProvider(modelId);
+  const modelName = ctx?.model?.display_name ?? getModelName(modelId) ?? 'no-model';
+  const { displayDir, branch, gitFlags, claims, openCount } = data;
+
+  let line1 = B + displayDir + B_;
+  if (branch) line1 += ` ${D}(${gitFlags ? `${branch} ${gitFlags}` : branch})${R}`;
+  const pctStr = pct != null ? `${pct.toFixed(1)}%` : '?';
+  let modelStr = modelName;
+  if (provider) modelStr = `(${provider}) ${modelStr}`;
+  const line2 = `${D}${pctStr}/${formatTokens(windowSize)}${R} ${D}${modelStr}${R}`;
+
+  let line3;
+  if (!claims?.length) {
+    line3 = `○ ${openCount > 0 ? `${B}${openCount}${B_} open` : 'no open issues'}`;
+  } else if (claims.length === 1) {
+    const { id, title, status } = claims[0];
+    const icon = status === 'blocked' ? '●' : status === 'in_progress' ? '◐' : '○';
+    const prefix = `${icon} ${id.split('-').pop()} `;
+    const max = Math.min((process.stdout.columns || 80) - prefix.length - 1, 40);
+    const text = title ? (title.length > max ? `${title.slice(0, max - 1)}…` : title) : '';
+    line3 = `${prefix}${I}${text}${I_}`;
+  } else {
+    line3 = claims.map(({ id, status }) => `${status === 'blocked' ? '●' : '◐'} ${id.split('-').pop()}`).join('  ');
+  }
+  process.stdout.write(`${line1}\n${line2}\n${line3}\n`);
+}
+
+if (process.argv[2] === '--refresh') {
+  refresh(process.argv[3] || process.cwd());
 } else {
-  const chips = claims.map(({ id, status }) => {
-    const icon = status === 'blocked' ? '●' : '◐';
-    return `${icon} ${id.split('-').pop()}`;
-  });
-  line3 = chips.join('  ');
+  const started = Date.now();
+  let ctx = {};
+  try { ctx = JSON.parse(readFileSync(0, 'utf8')); } catch {}
+  const cwd = ctx?.workspace?.current_dir ?? process.cwd();
+  const cached = readCache(cacheFile(cwd));
+  render(ctx, cached?.data ?? fallbackData(cwd));
+  if (!cached?.fresh) startRefresh(cwd, started);
 }
-
-process.stdout.write(`${line1}\n${line2}\n${line3}\n`);
-process.exit(0);

--- a/.xtrm/hooks/statusline.test.mjs
+++ b/.xtrm/hooks/statusline.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const hook = new URL('./statusline.mjs', import.meta.url).pathname;
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), 'xtrm-statusline-'));
+  const cwd = join(root, 'repo');
+  const cache = join(root, 'cache');
+  const bin = join(root, 'bin');
+  const log = join(root, 'calls.log');
+  mkdirSync(join(cwd, '.beads'), { recursive: true });
+  mkdirSync(cache); mkdirSync(bin);
+  writeFileSync(join(bin, 'git'), `#!/bin/sh\necho git >> '${log}'\nsleep 0.2\nprintf 'main\\n'\n`);
+  writeFileSync(join(bin, 'bd'), `#!/bin/sh\necho bd >> '${log}'\nsleep 0.2\nprintf '0 open\\n'\n`);
+  spawnSync('chmod', ['+x', join(bin, 'git'), join(bin, 'bd')]);
+  return { root, cwd, cache, bin, log };
+}
+
+function run({ cwd, cache, bin }) {
+  const started = performance.now();
+  const result = spawnSync(process.execPath, [hook], {
+    input: JSON.stringify({ workspace: { current_dir: cwd } }),
+    encoding: 'utf8',
+    env: { ...process.env, XTRM_STATUSLINE_CACHE_DIR: cache, PATH: `${bin}:${process.env.PATH}` },
+  });
+  return { result, elapsed: performance.now() - started };
+}
+
+async function waitForCache(cache, timeout = 3_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (existsSync(join(cache, 'xtrm-sl-refresh.lock')) === false && existsSync(join(cache, 'xtrm-sl-beads.json'))) return;
+    await new Promise(resolve => setTimeout(resolve, 25));
+  }
+  throw new Error('background refresh did not finish');
+}
+
+test('returns stale or fallback output without waiting for slow git and beads refresh', async (t) => {
+  const fx = fixture(); t.after(() => rmSync(fx.root, { recursive: true, force: true }));
+  const cold = run(fx);
+  assert.equal(cold.result.status, 0);
+  assert.match(cold.result.stdout, /no open issues/);
+  assert.ok(cold.elapsed < 200, `renderer blocked for ${cold.elapsed}ms`);
+  await waitForCache(fx.cache);
+  const warm = run(fx);
+  assert.equal(warm.result.status, 0);
+  assert.ok(warm.elapsed < 200, `cached renderer blocked for ${warm.elapsed}ms`);
+});
+
+test('corrupt cache falls back safely and concurrent renders share one refresh lease', async (t) => {
+  const fx = fixture(); t.after(() => rmSync(fx.root, { recursive: true, force: true }));
+  writeFileSync(join(fx.cache, 'xtrm-sl-beads.json'), '{bad json');
+  const children = Array.from({ length: 5 }, () => spawn(process.execPath, [hook], {
+    stdio: ['pipe', 'ignore', 'ignore'],
+    env: { ...process.env, XTRM_STATUSLINE_CACHE_DIR: fx.cache, PATH: `${fx.bin}:${process.env.PATH}` },
+  }));
+  for (const child of children) child.stdin.end(JSON.stringify({ workspace: { current_dir: fx.cwd } }));
+  await Promise.all(children.map(child => new Promise((resolve, reject) => child.on('exit', code => code === 0 ? resolve() : reject(new Error(`exit ${code}`))))));
+  await waitForCache(fx.cache);
+  const calls = readFileSync(fx.log, 'utf8').trim().split('\n').filter(Boolean);
+  assert.ok(calls.filter(call => call === 'git').length <= 5, `refresh stampede: ${calls.join(', ')}`);
+});

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -83,7 +83,11 @@
           "version": "0.9.1"
         },
         "statusline.mjs": {
-          "hash": "411b726326ee5927fa5d1351d5a49fa47fe5dd37820c854251c99df5eb745d9e",
+          "hash": "3505b1754aea7d90ad086da423b7d0956c1efa1373a66df1c6b0c1fb1dab081b",
+          "version": "0.9.1"
+        },
+        "statusline.test.mjs": {
+          "hash": "ce53d601e9f5de446fc90e01c8e6300af560baa9fde8c2a850f0bcbf6643aae7",
           "version": "0.9.1"
         },
         "using-xtrm-reminder.mjs": {


### PR DESCRIPTION
## Summary
- make the Claude statusline render from a bounded stale cache
- move Git/Beads collection to one detached, lease-protected refresh
- add regression coverage for slow dependencies, cache corruption, and concurrent invocation

## Validation
- `node --test .xtrm/hooks/statusline.test.mjs`
- `node --check .xtrm/hooks/statusline.mjs`
