### PR TITLE
Fix custom footer refresh scheduling

### DIFF
--- a/cli/test/extensions/custom-footer-parity.test.ts
+++ b/cli/test/extensions/custom-footer-parity.test.ts
@@ -1,9 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock the @earendil-works Pi runtime packages before importing the extension —
-// Pi provides these at runtime, but CI's npm install does not pull them in.
-// Without these mocks, vitest fails the entire test file at module-load time.
-// See xtrm-qdsx.
 vi.mock("@earendil-works/pi-coding-agent", () => ({
 	isToolCallEventType: vi.fn(() => false),
 	isBashToolResult: vi.fn(() => false),
@@ -14,7 +10,7 @@ vi.mock("@earendil-works/pi-tui", () => ({
 }));
 
 import customFooterExtension from "../../../packages/pi-extensions/extensions/custom-footer/index";
-import { SubprocessRunner, EventAdapter } from "../../../packages/pi-extensions/src/core";
+import { EventAdapter, SubprocessRunner } from "../../../packages/pi-extensions/src/core";
 
 vi.mock("../../../packages/pi-extensions/src/core", async () => {
 	const actual = await vi.importActual<any>("../../../packages/pi-extensions/src/core");
@@ -30,20 +26,29 @@ describe("custom-footer parity", () => {
 	let footerRenderer: any;
 	let ctx: any;
 	let setFooterSpy: any;
+	let requestRenderSpy: any;
+	let branchChangeHandler: (() => void) | null;
 
 	beforeEach(() => {
 		vi.useFakeTimers();
 		vi.resetAllMocks();
 		handlers = {};
 		footerRenderer = null;
+		requestRenderSpy = vi.fn();
+		branchChangeHandler = null;
 
 		setFooterSpy = vi.fn((factory: any) => {
 			footerRenderer = factory(
-				{ requestRender: vi.fn() },
+				{ requestRender: requestRenderSpy },
 				{ fg: (_c: string, text: string) => text },
 				{
 					getGitBranch: () => "xt/demo",
-					onBranchChange: () => () => {},
+					onBranchChange: (handler: () => void) => {
+						branchChangeHandler = handler;
+						return () => {
+							if (branchChangeHandler === handler) branchChangeHandler = null;
+						};
+					},
 					getAvailableProviderCount: () => 1,
 				},
 			);
@@ -59,7 +64,30 @@ describe("custom-footer parity", () => {
 		};
 	});
 
-	it("renders two lines with claim title parity", async () => {
+	const createPi = () => ({
+		on: (event: string, fn: Function) => {
+			if (!handlers[event]) handlers[event] = [];
+			handlers[event].push(fn);
+		},
+	});
+
+	it("render does not invoke SubprocessRunner", async () => {
+		(SubprocessRunner.run as any).mockResolvedValue({ code: 1, stdout: "", stderr: "" });
+
+		customFooterExtension(createPi() as any);
+		await handlers.session_start[0]({}, ctx);
+		await vi.runOnlyPendingTimersAsync();
+		await Promise.resolve();
+		vi.clearAllMocks();
+
+		footerRenderer.render(120);
+		await vi.advanceTimersByTimeAsync(6000);
+		footerRenderer.render(120);
+
+		expect(SubprocessRunner.run).not.toHaveBeenCalled();
+	});
+
+	it("renders three lines with claim title parity", async () => {
 		(EventAdapter.isBeadsProject as any).mockReturnValue(true);
 		(SubprocessRunner.run as any).mockImplementation(async (cmd: string, args: string[]) => {
 			if (cmd === "git" && args[0] === "rev-parse") return { code: 0, stdout: "/repo\n", stderr: "" };
@@ -74,19 +102,11 @@ describe("custom-footer parity", () => {
 			return { code: 1, stdout: "", stderr: "" };
 		});
 
-		const pi = {
-			on: (event: string, fn: Function) => {
-				if (!handlers[event]) handlers[event] = [];
-				handlers[event].push(fn);
-			},
-		};
+		customFooterExtension(createPi() as any);
+		await handlers.session_start[0]({}, ctx);
+		await vi.runOnlyPendingTimersAsync();
+		await Promise.resolve();
 
-		customFooterExtension(pi as any);
-		await handlers["session_start"][0]({}, ctx);
-		await vi.advanceTimersByTimeAsync(45);
-
-		footerRenderer.render(120);
-		await vi.advanceTimersByTimeAsync(1);
 		const lines = footerRenderer.render(120);
 		expect(lines).toHaveLength(3);
 		expect(lines[0]).toContain("xt/demo");
@@ -107,41 +127,62 @@ describe("custom-footer parity", () => {
 			return { code: 1, stdout: "", stderr: "" };
 		});
 
-		const pi = {
-			on: (event: string, fn: Function) => {
-				if (!handlers[event]) handlers[event] = [];
-				handlers[event].push(fn);
-			},
-		};
+		customFooterExtension(createPi() as any);
+		await handlers.session_start[0]({}, ctx);
+		await vi.runOnlyPendingTimersAsync();
+		await Promise.resolve();
 
-		customFooterExtension(pi as any);
-		await handlers["session_start"][0]({}, ctx);
-		await vi.advanceTimersByTimeAsync(45);
-
-		footerRenderer.render(100);
-		await vi.advanceTimersByTimeAsync(1);
 		const lines = footerRenderer.render(100);
 		expect(lines[2]).toContain("○ 5 open");
+	});
+
+	it("coalesces lifecycle refresh triggers and redraws on state update", async () => {
+		(EventAdapter.isBeadsProject as any).mockReturnValue(true);
+		let resolveRefresh: (() => void) | null = null;
+		const refreshGate = new Promise<void>((resolve) => {
+			resolveRefresh = resolve;
+		});
+		(SubprocessRunner.run as any).mockImplementation(async (cmd: string, args: string[]) => {
+			await refreshGate;
+			if (cmd === "git" && args[0] === "rev-parse") return { code: 0, stdout: "/repo\n", stderr: "" };
+			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "xt/demo\n", stderr: "" };
+			if (cmd === "git" && args.includes("status")) return { code: 0, stdout: "", stderr: "" };
+			if (cmd === "git" && args.includes("rev-list")) return { code: 0, stdout: "0 0\n", stderr: "" };
+			if (cmd === "bd" && args[0] === "list" && args[1] === "--status=in_progress") return { code: 0, stdout: "", stderr: "" };
+			if (cmd === "bd" && args[0] === "list") return { code: 0, stdout: "(5 open, 0 in progress)", stderr: "" };
+			return { code: 1, stdout: "", stderr: "" };
+		});
+
+		customFooterExtension(createPi() as any);
+		await handlers.session_start[0]({}, ctx);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(SubprocessRunner.run).toHaveBeenCalledTimes(2);
+
+		await handlers.tool_result[0]({ input: { command: "git status" } });
+		await handlers.tool_result[0]({ input: { command: "git commit -m test" } });
+		branchChangeHandler?.();
+		await vi.advanceTimersByTimeAsync(250);
+		expect(SubprocessRunner.run).toHaveBeenCalledTimes(2);
+
+		resolveRefresh?.();
+		await Promise.resolve();
+		await Promise.resolve();
+		await vi.runOnlyPendingTimersAsync();
+		expect(SubprocessRunner.run).toHaveBeenCalledTimes(6);
+		expect(requestRenderSpy).toHaveBeenCalled();
 	});
 
 	it("reapplies footer on model/session refresh events", async () => {
 		(SubprocessRunner.run as any).mockResolvedValue({ code: 1, stdout: "", stderr: "" });
 
-		const pi = {
-			on: (event: string, fn: Function) => {
-				if (!handlers[event]) handlers[event] = [];
-				handlers[event].push(fn);
-			},
-		};
-
-		customFooterExtension(pi as any);
-		await handlers["session_start"][0]({}, ctx);
+		customFooterExtension(createPi() as any);
+		await handlers.session_start[0]({}, ctx);
 		await vi.advanceTimersByTimeAsync(45);
 		const initialCalls = setFooterSpy.mock.calls.length;
 
-		await handlers["model_select"][0]({}, ctx);
+		await handlers.model_select[0]({}, ctx);
 		await vi.advanceTimersByTimeAsync(45);
-		await handlers["session_switch"][0]({}, ctx);
+		await handlers.session_switch[0]({}, ctx);
 		await vi.advanceTimersByTimeAsync(45);
 
 		expect(setFooterSpy.mock.calls.length).toBeGreaterThan(initialCalls);

--- a/cli/test/extensions/custom-footer-parity.test.ts
+++ b/cli/test/extensions/custom-footer-parity.test.ts
@@ -172,6 +172,44 @@ describe("custom-footer parity", () => {
 		expect(requestRenderSpy).toHaveBeenCalled();
 	});
 
+	it("schedules beads refresh from relevant tool results", async () => {
+		(EventAdapter.isBeadsProject as any).mockReturnValue(true);
+		(SubprocessRunner.run as any).mockImplementation(async (cmd: string, args: string[]) => {
+			if (cmd === "git" && args[0] === "rev-parse") return { code: 0, stdout: "/repo\n", stderr: "" };
+			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "xt/demo\n", stderr: "" };
+			if (cmd === "git" && args.includes("status")) return { code: 0, stdout: "", stderr: "" };
+			if (cmd === "git" && args.includes("rev-list")) return { code: 0, stdout: "0 0\n", stderr: "" };
+			if (cmd === "bd" && args[0] === "list" && args[1] === "--status=in_progress") return { code: 0, stdout: "", stderr: "" };
+			if (cmd === "bd" && args[0] === "list") return { code: 0, stdout: "(5 open, 0 in progress)", stderr: "" };
+			return { code: 1, stdout: "", stderr: "" };
+		});
+
+		customFooterExtension(createPi() as any);
+		await handlers.session_start[0]({}, ctx);
+		await vi.runOnlyPendingTimersAsync();
+		await Promise.resolve();
+		const settledCalls = (SubprocessRunner.run as any).mock.calls.length;
+
+		await handlers.tool_result[0]({ input: { command: "bd update xtrm-123" } });
+		await vi.advanceTimersByTimeAsync(250);
+		await Promise.resolve();
+
+		expect(SubprocessRunner.run).toHaveBeenCalledTimes(settledCalls + 2);
+		expect(requestRenderSpy).toHaveBeenCalled();
+	});
+
+	it("cleans pending footer timers on session shutdown", async () => {
+		(SubprocessRunner.run as any).mockResolvedValue({ code: 1, stdout: "", stderr: "" });
+
+		customFooterExtension(createPi() as any);
+		await handlers.session_start[0]({}, ctx);
+		await handlers.session_shutdown[0]();
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(SubprocessRunner.run).not.toHaveBeenCalled();
+		expect(setFooterSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("reapplies footer on model/session refresh events", async () => {
 		(SubprocessRunner.run as any).mockResolvedValue({ code: 1, stdout: "", stderr: "" });
 
@@ -186,5 +224,54 @@ describe("custom-footer parity", () => {
 		await vi.advanceTimersByTimeAsync(45);
 
 		expect(setFooterSpy.mock.calls.length).toBeGreaterThan(initialCalls);
+	});
+
+	it("keeps latest branch listener and redraw after footer reapply race", async () => {
+		let activeBranchChangeHandler: (() => void) | null = null;
+		let previousRenderer: any = null;
+		const racySetFooterSpy = vi.fn((factory: any) => {
+			const renderer = factory(
+				{ requestRender: requestRenderSpy },
+				{ fg: (_c: string, text: string) => text },
+				{
+					getGitBranch: () => "xt/demo",
+					onBranchChange: (handler: () => void) => {
+						activeBranchChangeHandler = handler;
+						return () => {
+							if (activeBranchChangeHandler === handler) activeBranchChangeHandler = null;
+						};
+					},
+					getAvailableProviderCount: () => 1,
+				},
+			);
+			const staleRenderer = previousRenderer;
+			previousRenderer = renderer;
+			footerRenderer = renderer;
+			staleRenderer?.dispose();
+		});
+		ctx.ui.setFooter = racySetFooterSpy;
+		(SubprocessRunner.run as any).mockImplementation(async (cmd: string, args: string[]) => {
+			if (cmd === "git" && args[0] === "rev-parse") return { code: 0, stdout: "/repo\n", stderr: "" };
+			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "xt/demo\n", stderr: "" };
+			if (cmd === "git" && args.includes("status")) return { code: 0, stdout: "", stderr: "" };
+			if (cmd === "git" && args.includes("rev-list")) return { code: 0, stdout: "0 0\n", stderr: "" };
+			return { code: 1, stdout: "", stderr: "" };
+		});
+
+		customFooterExtension(createPi() as any);
+		await handlers.session_start[0]({}, ctx);
+		await vi.runOnlyPendingTimersAsync();
+		await Promise.resolve();
+		expect(racySetFooterSpy).toHaveBeenCalledTimes(2);
+		vi.clearAllMocks();
+
+		expect(activeBranchChangeHandler).not.toBeNull();
+		activeBranchChangeHandler?.();
+		await vi.runOnlyPendingTimersAsync();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(SubprocessRunner.run).toHaveBeenCalledTimes(4);
+		expect(requestRenderSpy).toHaveBeenCalled();
 	});
 });

--- a/packages/pi-extensions/extensions/custom-footer/index.ts
+++ b/packages/pi-extensions/extensions/custom-footer/index.ts
@@ -266,23 +266,26 @@ export default function (pi: ExtensionAPI) {
 
 	const attachBranchChangeListener = (footerData: any) => {
 		branchChangeUnsub?.();
-		branchChangeUnsub = footerData.onBranchChange(() => {
+		const unsubscribe = footerData.onBranchChange(() => {
 			runtimeState.lastFetch = 0;
 			scheduleRefresh(["runtime"]);
 		});
+		branchChangeUnsub = unsubscribe;
+		return unsubscribe;
 	};
 
 	const applyCustomFooter = (ctx: any) => {
 		capturedCtx = ctx;
 		ctx.ui.setFooter((tui, theme, footerData) => {
-			requestRender = () => tui.requestRender();
-			attachBranchChangeListener(footerData);
+			const instanceRequestRender = () => tui.requestRender();
+			requestRender = instanceRequestRender;
+			const instanceBranchChangeUnsub = attachBranchChangeListener(footerData);
 
 			return {
 				dispose() {
-					branchChangeUnsub?.();
-					branchChangeUnsub = null;
-					requestRender = null;
+					instanceBranchChangeUnsub?.();
+					if (branchChangeUnsub === instanceBranchChangeUnsub) branchChangeUnsub = null;
+					if (requestRender === instanceRequestRender) requestRender = null;
 				},
 				invalidate() {},
 				render(width: number): string[] {
@@ -405,6 +408,7 @@ export default function (pi: ExtensionAPI) {
 		scheduledRefreshKinds.clear();
 		branchChangeUnsub?.();
 		branchChangeUnsub = null;
+		requestRender = null;
 	});
 
 	pi.on("tool_result", async (event: any) => {

--- a/packages/pi-extensions/extensions/custom-footer/index.ts
+++ b/packages/pi-extensions/extensions/custom-footer/index.ts
@@ -10,7 +10,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
-import { SubprocessRunner, EventAdapter } from "../../src/core";
+import { EventAdapter, SubprocessRunner } from "../../src/core";
 
 export default function (pi: ExtensionAPI) {
 	interface BeadClaim {
@@ -32,6 +32,8 @@ export default function (pi: ExtensionAPI) {
 		lastFetch: number;
 	}
 
+	type RefreshKind = "runtime" | "beads";
+
 	const STATUS_ICONS: Record<string, string> = {
 		open: "○",
 		in_progress: "◐",
@@ -39,7 +41,6 @@ export default function (pi: ExtensionAPI) {
 		closed: "✓",
 	};
 
-	// Chip background colours (raw ANSI — theme has no bg() API)
 	const CHIP_BG_NEUTRAL = "\x1b[48;5;238m";
 	const CHIP_BG_ACTIVE = "\x1b[48;5;39m";
 	const CHIP_BG_BLOCKED = "\x1b[48;5;88m";
@@ -52,13 +53,22 @@ export default function (pi: ExtensionAPI) {
 		blocked: CHIP_BG_BLOCKED,
 	};
 
+	const CACHE_TTL = 5000;
+	const REFRESH_TIMEOUT_MS = 2000;
+	const TOOL_RESULT_REFRESH_DELAY_MS = 200;
+	const FOOTER_REAPPLY_DELAY_MS = 40;
+
 	const chip = (text: string, bg = CHIP_BG_NEUTRAL): string => `${bg}${CHIP_FG} ${text} ${CHIP_RESET}`;
 
 	let capturedPi: ExtensionAPI = pi;
 	let capturedCtx: any = null;
 	let requestRender: (() => void) | null = null;
+	let footerReapplyTimer: ReturnType<typeof setTimeout> | null = null;
+	let scheduledRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+	let scheduledRefreshKinds = new Set<RefreshKind>();
+	let runningRefreshPromise: Promise<void> | null = null;
+	let branchChangeUnsub: (() => void) | null = null;
 
-	const CACHE_TTL = 5000;
 	let refreshingBeads = false;
 	let refreshingRuntime = false;
 
@@ -76,10 +86,9 @@ export default function (pi: ExtensionAPI) {
 
 	const getCwd = () => capturedCtx?.cwd || process.cwd();
 	const getShortId = (id: string) => id.split("-").pop() ?? id;
+	const runCommand = (command: string, args: string[], cwd: string) =>
+		SubprocessRunner.run(command, args, { cwd, timeoutMs: REFRESH_TIMEOUT_MS });
 
-	/**
-	 * Parse git status --porcelain output into status flags
-	 */
 	const parseGitFlags = (porcelain: string): string => {
 		let modified = false;
 		let staged = false;
@@ -92,9 +101,6 @@ export default function (pi: ExtensionAPI) {
 		return `${modified ? "*" : ""}${staged ? "+" : ""}${deleted ? "-" : ""}`;
 	};
 
-	/**
-	 * Fetch git branch and status
-	 */
 	const refreshRuntimeState = async () => {
 		if (refreshingRuntime || Date.now() - runtimeState.lastFetch < CACHE_TTL) return;
 		refreshingRuntime = true;
@@ -103,25 +109,21 @@ export default function (pi: ExtensionAPI) {
 			let branch: string | null = null;
 			let gitStatus = "";
 
-			const rootResult = await SubprocessRunner.run("git", ["rev-parse", "--show-toplevel"], { cwd });
+			const rootResult = await runCommand("git", ["rev-parse", "--show-toplevel"], cwd);
 			const repoRoot = rootResult.code === 0 ? rootResult.stdout.trim() : null;
 
 			if (repoRoot) {
-				const branchResult = await SubprocessRunner.run("git", ["branch", "--show-current"], { cwd });
+				const branchResult = await runCommand("git", ["branch", "--show-current"], cwd);
 				branch = branchResult.code === 0 ? branchResult.stdout.trim() || null : null;
 
-				const porcelainResult = await SubprocessRunner.run(
-					"git",
-					["--no-optional-locks", "status", "--porcelain"],
-					{ cwd },
-				);
+				const porcelainResult = await runCommand("git", ["--no-optional-locks", "status", "--porcelain"], cwd);
 				const baseFlags = porcelainResult.code === 0 ? parseGitFlags(porcelainResult.stdout) : "";
 
 				let upstreamFlags = "";
-				const abResult = await SubprocessRunner.run(
+				const abResult = await runCommand(
 					"git",
 					["--no-optional-locks", "rev-list", "--left-right", "--count", "@{upstream}...HEAD"],
-					{ cwd },
+					cwd,
 				);
 				if (abResult.code === 0) {
 					const [behindRaw, aheadRaw] = abResult.stdout.trim().split(/\s+/);
@@ -148,9 +150,6 @@ export default function (pi: ExtensionAPI) {
 		}
 	};
 
-	/**
-	 * Format token counts (from original footer)
-	 */
 	const formatTokens = (count: number): string => {
 		if (count < 1000) return count.toString();
 		if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
@@ -165,14 +164,14 @@ export default function (pi: ExtensionAPI) {
 		if (!EventAdapter.isBeadsProject(cwd)) return;
 		refreshingBeads = true;
 		try {
-			const inProgressResult = await SubprocessRunner.run("bd", ["list", "--status=in_progress"], { cwd });
+			const inProgressResult = await runCommand("bd", ["list", "--status=in_progress"], cwd);
 			const inProgressRaw = inProgressResult.code === 0 ? inProgressResult.stdout : "";
 			const ids = [...new Set([...inProgressRaw.matchAll(/^◐\s+([a-z][\w-]+)/gm)].map((m) => m[1]).filter((id) => id.includes("-")))];
 
 			let claims: BeadClaim[] = [];
 			if (ids.length === 1) {
 				const [id] = ids;
-				const showResult = await SubprocessRunner.run("bd", ["show", id, "--json"], { cwd });
+				const showResult = await runCommand("bd", ["show", id, "--json"], cwd);
 				if (showResult.code === 0) {
 					try {
 						const issue = JSON.parse(showResult.stdout)?.[0];
@@ -189,10 +188,10 @@ export default function (pi: ExtensionAPI) {
 
 			let openCount = 0;
 			if (claims.length === 0) {
-				const listResult = await SubprocessRunner.run("bd", ["list"], { cwd });
+				const listResult = await runCommand("bd", ["list"], cwd);
 				if (listResult.code === 0) {
-					const m = listResult.stdout.match(/\((\d+)\s+open/);
-					if (m) openCount = parseInt(m[1], 10);
+					const match = listResult.stdout.match(/\((\d+)\s+open/);
+					if (match) openCount = parseInt(match[1], 10);
 				}
 			}
 
@@ -209,9 +208,35 @@ export default function (pi: ExtensionAPI) {
 		}
 	};
 
-	/**
-	 * Build beads line: ◐ 4843.5 Rework project bootstrap... or ○ 6 open
-	 */
+	const runRefreshKinds = async (refreshKinds: ReadonlySet<RefreshKind>) => {
+		await Promise.all([
+			refreshKinds.has("runtime") ? refreshRuntimeState() : Promise.resolve(),
+			refreshKinds.has("beads") ? refreshBeadState() : Promise.resolve(),
+		]);
+	};
+
+	const flushScheduledRefreshes = async () => {
+		if (runningRefreshPromise) return runningRefreshPromise;
+		const refreshKinds = scheduledRefreshKinds;
+		scheduledRefreshKinds = new Set<RefreshKind>();
+		runningRefreshPromise = runRefreshKinds(refreshKinds).finally(async () => {
+			runningRefreshPromise = null;
+			if (scheduledRefreshKinds.size > 0) {
+				await flushScheduledRefreshes();
+			}
+		});
+		return runningRefreshPromise;
+	};
+
+	const scheduleRefresh = (kinds: readonly RefreshKind[], delayMs = 0) => {
+		for (const kind of kinds) scheduledRefreshKinds.add(kind);
+		if (scheduledRefreshTimer) return;
+		scheduledRefreshTimer = setTimeout(() => {
+			scheduledRefreshTimer = null;
+			void flushScheduledRefreshes();
+		}, delayMs);
+	};
+
 	const buildBeadsLine = (width: number, theme: any): string => {
 		const { claims, openCount } = beadState;
 
@@ -239,55 +264,47 @@ export default function (pi: ExtensionAPI) {
 		return truncateToWidth(`○ no open issues`, width);
 	};
 
-	let footerReapplyTimer: ReturnType<typeof setTimeout> | null = null;
+	const attachBranchChangeListener = (footerData: any) => {
+		branchChangeUnsub?.();
+		branchChangeUnsub = footerData.onBranchChange(() => {
+			runtimeState.lastFetch = 0;
+			scheduleRefresh(["runtime"]);
+		});
+	};
 
 	const applyCustomFooter = (ctx: any) => {
 		capturedCtx = ctx;
 		ctx.ui.setFooter((tui, theme, footerData) => {
 			requestRender = () => tui.requestRender();
-			const unsub = footerData.onBranchChange(() => {
-				runtimeState.lastFetch = 0;
-				tui.requestRender();
-			});
+			attachBranchChangeListener(footerData);
 
 			return {
 				dispose() {
-					unsub();
+					branchChangeUnsub?.();
+					branchChangeUnsub = null;
 					requestRender = null;
 				},
 				invalidate() {},
 				render(width: number): string[] {
-					refreshRuntimeState().catch(() => {});
-					refreshBeadState().catch(() => {});
-
-					// === LINE 1: ~/path (branch *+↑) ===
-					// Like original, no session name, but with git status flags
 					let pwd = process.cwd();
 					const home = process.env.HOME || process.env.USERPROFILE;
 					if (home && pwd.startsWith(home)) {
 						pwd = `~${pwd.slice(home.length)}`;
 					}
 
-					// Use runtimeState branch (with git status) or fallback to footerData
 					const branch = runtimeState.branch || footerData.getGitBranch();
 					if (branch) {
-						const branchWithStatus = runtimeState.gitStatus
-							? `${branch} ${runtimeState.gitStatus}`
-							: branch;
+						const branchWithStatus = runtimeState.gitStatus ? `${branch} ${runtimeState.gitStatus}` : branch;
 						pwd = `${pwd} (${branchWithStatus})`;
 					}
 
 					const pwdLine = truncateToWidth(theme.fg("dim", pwd), width, theme.fg("dim", "..."));
 
-					// === LINE 2: XX%/window (provider) model • thinking ===
 					const usage = ctx.getContextUsage();
 					const model = ctx.model;
-
 					const contextWindow = usage?.contextWindow ?? model?.contextWindow ?? 0;
 					const contextPercentValue = usage?.percent ?? 0;
 					const contextPercent = usage?.percent !== null ? contextPercentValue.toFixed(1) : "?";
-
-					// Build left side: context %/window (color-coded like original)
 					const contextDisplay =
 						contextPercent === "?"
 							? `?/${formatTokens(contextWindow)}`
@@ -299,11 +316,8 @@ export default function (pi: ExtensionAPI) {
 						return text;
 					};
 
-					// Build right side: (provider) model • thinking
 					const modelName = model?.id || "no-model";
 					const providerCount = footerData.getAvailableProviderCount();
-
-					// Thinking level if model supports reasoning
 					let rightSideWithoutProvider = modelName;
 					if (model?.reasoning) {
 						const thinkingLevel = capturedPi.getThinkingLevel() || "off";
@@ -311,7 +325,6 @@ export default function (pi: ExtensionAPI) {
 							thinkingLevel === "off" ? `${modelName} • thinking off` : `${modelName} • ${thinkingLevel}`;
 					}
 
-					// Prepend provider if >1
 					let rightSide = rightSideWithoutProvider;
 					if (providerCount > 1 && model) {
 						rightSide = `(${model.provider}) ${rightSideWithoutProvider}`;
@@ -320,7 +333,6 @@ export default function (pi: ExtensionAPI) {
 						}
 					}
 
-					// Keep provider/model adjacent to usage (no right-bound alignment)
 					const separator = " ";
 					const leftWidth = visibleWidth(contextDisplay);
 					const separatorWidth = visibleWidth(separator);
@@ -334,16 +346,14 @@ export default function (pi: ExtensionAPI) {
 						line2 = `${colorizeUsage(contextDisplay)}${theme.fg("dim", separator)}${theme.fg("dim", truncatedRight)}`;
 					}
 
-					// === LINE 3: ◐ 4843.5 Rework project bootstrap... ===
 					const line3 = buildBeadsLine(width, theme);
-
 					return [pwdLine, line2, line3];
 				},
 			};
 		});
 	};
 
-	const scheduleFooterReapply = (ctx: any, delayMs = 40) => {
+	const scheduleFooterReapply = (ctx: any, delayMs = FOOTER_REAPPLY_DELAY_MS) => {
 		if (footerReapplyTimer) clearTimeout(footerReapplyTimer);
 		footerReapplyTimer = setTimeout(() => {
 			applyCustomFooter(ctx);
@@ -351,25 +361,35 @@ export default function (pi: ExtensionAPI) {
 		}, delayMs);
 	};
 
-	pi.on("session_start", async (_event, ctx) => {
-		capturedCtx = ctx;
+	const resetRefreshCaches = () => {
 		runtimeState.lastFetch = 0;
 		beadState.lastFetch = 0;
+	};
+
+	pi.on("session_start", async (_event, ctx) => {
+		capturedCtx = ctx;
+		resetRefreshCaches();
 		applyCustomFooter(ctx);
 		scheduleFooterReapply(ctx);
+		scheduleRefresh(["runtime", "beads"]);
 	});
 
 	pi.on("session_switch", async (_event, ctx) => {
-		runtimeState.lastFetch = 0;
+		capturedCtx = ctx;
+		resetRefreshCaches();
 		scheduleFooterReapply(ctx);
+		scheduleRefresh(["runtime", "beads"]);
 	});
 
 	pi.on("session_fork", async (_event, ctx) => {
-		runtimeState.lastFetch = 0;
+		capturedCtx = ctx;
+		resetRefreshCaches();
 		scheduleFooterReapply(ctx);
+		scheduleRefresh(["runtime", "beads"]);
 	});
 
 	pi.on("model_select", async (_event, ctx) => {
+		capturedCtx = ctx;
 		scheduleFooterReapply(ctx);
 	});
 
@@ -378,20 +398,30 @@ export default function (pi: ExtensionAPI) {
 			clearTimeout(footerReapplyTimer);
 			footerReapplyTimer = null;
 		}
+		if (scheduledRefreshTimer) {
+			clearTimeout(scheduledRefreshTimer);
+			scheduledRefreshTimer = null;
+		}
+		scheduledRefreshKinds.clear();
+		branchChangeUnsub?.();
+		branchChangeUnsub = null;
 	});
 
-	// Bust caches immediately after relevant writes
 	pi.on("tool_result", async (event: any) => {
 		const cmd = event?.input?.command;
 		if (!cmd) return undefined;
 
+		const refreshKinds: RefreshKind[] = [];
 		if (/\bbd\s+(close|update|create|claim)\b/.test(cmd)) {
 			beadState.lastFetch = 0;
-			setTimeout(() => refreshBeadState().catch(() => {}), 200);
+			refreshKinds.push("beads");
 		}
 		if (/\bgit\s+/.test(cmd)) {
 			runtimeState.lastFetch = 0;
-			setTimeout(() => refreshRuntimeState().catch(() => {}), 200);
+			refreshKinds.push("runtime");
+		}
+		if (refreshKinds.length > 0) {
+			scheduleRefresh(refreshKinds, TOOL_RESULT_REFRESH_DELAY_MS);
 		}
 		return undefined;
 	});


### PR DESCRIPTION
## Summary
- move Git/Beads refresh scheduling out of the footer render path
- coalesce lifecycle, tool-result, and branch-change refreshes with 2s command bounds
- fix footer-reapply listener ownership and redraw cleanup race
- add render-purity, lifecycle, shutdown, and reapply-race regressions

## Validation
- `npm test --workspace cli -- custom-footer-parity.test.ts`
- `npm run verify:runtime --workspace @jaggerxtrm/pi-extensions`
- source-loaded Pi prompt smoke with explicit custom-footer extension
- `git diff --check main...HEAD`

Fixes xtrm-638rc