### PR TITLE
Release @jaggerxtrm/pi-extensions v0.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,9 +99,19 @@ xt migrate skills --apply     # Execute
 | v-next-3 (enforced) | ON (locked) | Per-repo scaffold code removed; global-only model |
 
 ### Changed
-- xtrm-ui now owns XTRM-named themes and one native/external tool renderer; retired footer, external compaction, and box-chrome preferences/commands, with legacy Pi theme migration. Pi launch preflight materializes the four owned theme files before settings are resolved, preventing startup fallback to dark.
-
 - **Add `## Code restraint (when implementing directly)` to `agents-top.md` and `claude-top.md`.** Companion to specialists PR #173 (unitAI-pzmwf) which introduced a unified code-restraint discipline at the mandatory-rule level and in the orchestrator skill. This layer is for when the agent implements directly without delegating to a specialist. Compact 3-bullet section fits the "managed block" style the file's own header enforces (`This is a compact managed block. Use CLI --help and skills for details; do not paste full manuals here.`): the ladder in one line (YAGNI → reuse → stdlib → native → one line → minimum), the "never simplify away" boundary (input validation at trust boundaries, error handling that prevents data loss, security, accessibility, explicitly requested behavior, understanding the problem), and the deliberate-shortcut marker `// SIMPLIFIED: <ceiling>. upgrade when <trigger>.` The full ladder + rules + tag vocabulary specifics live in the specialists mandatory rule and are not repeated here (reuse over rewrite — the same discipline being taught). Identical text in both files so all downstream propagation (~30 consumer repos via existing `xt update` flow) picks up the same rule regardless of runtime. Zero external plugin brand references in shipped text.
+
+## [pi-extensions v0.9.5] — 2026-07-11
+
+### Changed
+
+- **Canonical XTRM UI themes and rendering.** `xtrm-ui` now owns the `xtrm-dark`/`xtrm-light` theme family and one renderer for native and external tools; obsolete footer, result-compaction, and box-chrome controls were removed. Legacy `pidex-*` preferences migrate to canonical names.
+
+### Fixed
+
+- **Theme startup fallback.** Pi launch preflight materializes the four owned XTRM theme files before settings resolve, preventing fallback when `xtrm-dark-flattools` is configured.
+- **Managed `xtprompt` behavior.** Restored its package enrollment and hardened context, prompt-guidance, escaping, and legacy-branding checks.
+- **Custom-footer refresh reliability.** Git and Beads refresh work is scheduled outside the render path, coalesced and timeout-bounded; footer reapply no longer detaches the active branch listener or redraw callback.
 
 ## [pi-extensions v0.9.3] — 2026-07-05
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xtrm-tools",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtrm-tools",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "workspaces": [
         "cli",
@@ -31,7 +31,7 @@
     },
     "cli": {
       "name": "xtrm-cli",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "boxen": "^8.0.1",
         "cli-table3": "^0.6.5",
@@ -4155,7 +4155,7 @@
     },
     "packages/pi-extensions": {
       "name": "@jaggerxtrm/pi-extensions",
-      "version": "0.9.3",
+      "version": "0.9.5",
       "license": "MIT"
     },
     "packages/pi-extensions/extensions/core": {

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
## Release
- publish `@jaggerxtrm/pi-extensions@0.9.5` only
- root `xtrm-tools` and CLI remain at `0.9.1`

## Included
- canonical XTRM theme/rendering migration and startup materialization
- managed xtprompt fixes
- custom-footer refresh scheduling and lifecycle reliability

## Validation
- workspace runtime verification
- npm pack dry-run for `0.9.5`
- root CLI build
- release-only diff scope