### PR TITLE
docs: xt-pi-role docs + CHANGELOG catch-up for PRs #380/#381/#386/#387/#388 (xtmux-c5g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `xt pi/claude --role` — runtime prefix in session name (xtmux-3h8, PR #388)
+
+Session names now include the runtime so `xt pi --role X` and `xt claude --role X` produce distinguishable sessions: `role-pi-<slug>[-<bead>]` vs `role-claude-<slug>[-<bead>]`. Both coexist in `tmux ls` without `--reuse` or auto-suffix. Backwards-incompatible for anyone relying on the pre-flip `role-<slug>[-<bead>]` shape; nobody parses this format programmatically, so no migration needed beyond re-launching.
+
+### `xt claude --role` — remove leftover pi-only runtime guard (xtmux-1lb.1 followup, PR #387)
+
+PR #383 shipped the CLI surface but missed removing an up-front guard that hard-refused `runtime !== 'pi'`. `xt claude --role X` now actually launches instead of erroring with `"--role is currently only supported for pi"`.
+
+### `xt pi --role` session-name collision handling (xtmux-1lb.6, PR #386)
+
+Prior refusal on session-name collision replaced by two operator-friendly outcomes:
+
+- `--reuse` — attach to the existing session (or with `--no-attach`, print its coordinates + exit). Does NOT emit `agent.role.launched` — the session isn't ours and metadata isn't guaranteed to be current.
+- default — auto-suffix `-<hex>` and create a fresh sibling. Uses the same 4-char random slug as the worktree layer. Retries up to 10 times before erroring loudly.
+
+`--reuse` only makes sense with `--new-session` (or outside `$TMUX`).
+
+### `xt pi --help` documents `--` passthrough (xtmux-1lb.2, PR #381)
+
+`xt pi --help` now surfaces the `--` passthrough contract with two concrete examples. Same treatment lands on `xt claude` via the shared parity work above.
+
+### `xt pi --role` switch-client inside `$TMUX` (xtmux-1lb.5, PR #380 — superseded by xtmux-1lb.5.1)
+
+Intermediate fix that used `tmux switch-client` when `xt pi --role` runs inside `$TMUX`, avoiding the pre-fix nested-attach refusal. Superseded by the current-pane default in xtmux-1lb.5.1 (see entry below); `--new-session` still uses `chooseAttachCommand` to pick `switch-client` vs `attach-session` correctly.
+
 ### `xt claude` — full role-launcher parity with `xt pi` (xtmux-1lb.1)
 
 `xt claude` now accepts the same role-launcher surface as `xt pi`:

--- a/docs/xt-pi-role.md
+++ b/docs/xt-pi-role.md
@@ -25,7 +25,7 @@ Inside `$TMUX`, both commands **run in the current pane** by default — no nest
 | Flag | Meaning | Notes |
 | --- | --- | --- |
 | `--role <name>` | Resolve `<name>` via `sp view <name> --raw` and boot the runtime with the specialist's system prompt, skills, model, and thinking level. | The role's `execution.model` / `execution.thinking_level` from `sp view` are the defaults; CLI flags override. |
-| `--bead <id>` | Attach `<id>` to the pane via `@agent_bead`; also included in the session name slug (`role-<slug>-<bead>`). | Optional. Enables `bv` claim discovery and hook-based gating. |
+| `--bead <id>` | Attach `<id>` to the pane via `@agent_bead`; also included in the session name slug (`role-<runtime>-<slug>-<bead>`). | Optional. Enables `bv` claim discovery and hook-based gating. |
 | `--no-attach` | New-session mode only. Print `session_name:pane_id` on stdout and exit — orchestrator-capture pattern. | Inside `$TMUX` without `--new-session`, `--no-attach` **errors** with a clear hint. |
 | `--model <name>` | Forward `--model <name>` to the runtime; overrides `specialist.execution.model`. | Both pi and claude accept `--model`. |
 | `--thinking <level>` | pi only. Forward `--thinking <level>`; overrides `specialist.execution.thinking_level`. | claude has no `--thinking` flag — `xt claude --thinking X` warns loudly and drops. |
@@ -44,17 +44,28 @@ Run `xt pi --help` or `xt claude --help` for the canonical (auto-generated) flag
 | Context | Flags | Result |
 | --- | --- | --- |
 | inside `$TMUX` | (none) | Runtime runs in the **current pane**; pane options + `XTMUX_AGENT_*` env set on this pane. `tmux ls` unchanged. |
-| inside `$TMUX` | `--new-session` | New session (`role-<slug>-<bead>`); `switch-client` moves the current client to it. |
+| inside `$TMUX` | `--new-session` | New session (`role-<runtime>-<slug>-<bead>`); `switch-client` moves the current client to it. |
 | inside `$TMUX` | `--new-session --no-attach` | New session detached; prints `session_name:pane_id` on stdout. Exit 0. |
 | inside `$TMUX` | `--no-attach` alone | **Error** — `--no-attach requires --new-session (or exit tmux first)`. |
 | outside `$TMUX` | (any) | New session; `attach-session` attaches. `--no-attach` still valid. |
 
-**Session-name collision.** When the resolved session name (`role-<slug>[-<bead>]`) is already in use, the launcher does one of two things:
+**Session-name collision.** When the resolved session name (`role-<runtime>-<slug>[-<bead>]`, e.g. `role-pi-chain-coordinator-xyz-1` vs `role-claude-chain-coordinator-xyz-1`) is already in use, the launcher does one of two things:
 
 - `--reuse` passed → attach to the existing session (or print `session:pane` with `--no-attach`) and exit. Skips the pane-option write + `agent.role.launched` emission since the pane is not fresh.
-- otherwise → auto-suffix a 4-char hex slug and retry up to 10 times (`role-<slug>[-<bead>]-<hex>`). If all 10 candidates collide, errors with a hint to pass `--reuse` or free some session names.
+- otherwise → auto-suffix a 4-char hex slug and retry up to 10 times (`role-<runtime>-<slug>[-<bead>]-<hex>`). If all 10 candidates collide, errors with a hint to pass `--reuse` or free some session names.
 
 ---
+
+## Session names
+
+Session names encode both the runtime and the specialist role so `xt pi --role X` and `xt claude --role X` produce distinguishable sessions:
+
+```
+role-pi-<role-slug>[-<bead-slug>]
+role-claude-<role-slug>[-<bead-slug>]
+```
+
+Example: `xt pi --role chain-coordinator --bead xyz-1` → `role-pi-chain-coordinator-xyz-1`; `xt claude --role chain-coordinator --bead xyz-1` → `role-claude-chain-coordinator-xyz-1`. Both coexist without `--reuse` or auto-suffix.
 
 ## Pane options set at launch
 


### PR DESCRIPTION
## Summary

Two doc gaps this thread's PRs left behind:

**1. `docs/xt-pi-role.md` staleness.** Written for #385 before #388 flipped session names to include the runtime prefix. The flag reference, behavior matrix, and collision callout still showed the old `role-<slug>[-<bead>]` shape. Also missing was a callout showing pi and claude produce distinct names for the same role+bead — the reason #388 shipped.

Fix: replace all four occurrences with `role-<runtime>-<slug>[-<bead>]`, add a concrete example (`role-pi-chain-coordinator-xyz-1` vs `role-claude-chain-coordinator-xyz-1`), and insert a short "Session names" section.

**2. CHANGELOG gaps.** 5 of 8 xtmux-1lb-era feature PRs shipped without an Unreleased entry:

| PR | Bead | Had CHANGELOG? |
|---|---|---|
| #380 | xtmux-1lb.5 switch-client | no |
| #381 | xtmux-1lb.2 --help | no |
| #386 | xtmux-1lb.6 --reuse | no |
| #387 | xtmux-1lb.1 runtime guard | no |
| #388 | xtmux-3h8 runtime prefix | no |

Fix: one Unreleased stanza per PR, most-recent-first, with links back to originating beads. #380's entry notes it was superseded by xtmux-1lb.5.1.

No code changes.

## Test plan

- [x] Docs render (markdown parse).
- [x] Grep confirms no lingering pre-#388 `role-<slug>[-<bead>]` references.

Ref bead: xtmux-c5g.