### PR TITLE
fix(service-skills): sync shipped mirror with v2-aware source (y0tdg.1 followup)

### DIFF
--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -630,7 +630,7 @@
           "version": "0.9.1"
         },
         "multiplexing/SKILL.md": {
-          "hash": "e2763e178ceea1db027cea4171c559fee528fee4e72ca97f2789d9688b1afd08",
+          "hash": "9d6e7868999f6bb841cf4156cafd60876b0dac6006ffece3437faa7abb822e97",
           "version": "0.9.1"
         },
         "planning/SKILL.md": {
@@ -758,19 +758,19 @@
           "version": "0.9.1"
         },
         "service-skills/install/git-hooks/post_merge_drift_sweep.py": {
-          "hash": "e42d8b01b014210cd79d28fbe8178d8a2c5d4385f0227f307604f6c025d1346f",
+          "hash": "39d6f4e0afe7946636e47b2877cfc71afe6589b7ab045f86f0f739a8ccc886b9",
           "version": "0.9.1"
         },
         "service-skills/install/git-hooks/skill_staleness.py": {
-          "hash": "adcf0d2608431fd643bce318ef03e12049af305225808d48793a9cddd8628676",
+          "hash": "39d1ac16dee329bab34a646216e2d851856a07d53f6c0f909709fe217f2ba22f",
           "version": "0.9.1"
         },
         "service-skills/install/install-service-skills.py": {
-          "hash": "7fae9df312614b019504a5a01160f2d0416b537db5871c090d478ffb71599468",
+          "hash": "e89bc2fd5fe9cb463f9e56360fcd5f8994479e5fc665044af76404b1ddc3eb29",
           "version": "0.9.1"
         },
         "service-skills/install/service-skills-readme.md": {
-          "hash": "46a2b378bab1fd9a43d30c93c05c69a45280f1606afa5ce17241058cbb279b27",
+          "hash": "95d31a8ae4241255c988d0aa35009070b63ac08fbf31e2cb8025e05f9a8ed585",
           "version": "0.9.1"
         },
         "service-skills/install/settings.json": {
@@ -778,15 +778,15 @@
           "version": "0.9.1"
         },
         "service-skills/references/creating.md": {
-          "hash": "a83beb006a82fcceb7b9dd1e604010006af6af34660bf0d910d286d9e41e365b",
+          "hash": "6952c0d0f98f91fa7f3619d6db0925f4d628c583fb84997bb2c87aa05d777441",
           "version": "0.9.1"
         },
         "service-skills/references/routing.md": {
-          "hash": "df5cb6072d9aaf439c33af3cacb14347dec6a09d98822a4ffad7c74d4c842c54",
+          "hash": "69e5d873bb35bf680cdd568c65963fcb72ee1acc7cb9d86f395c37d8edb8e515",
           "version": "0.9.1"
         },
         "service-skills/references/script_quality_standards.md": {
-          "hash": "e932bcfc98dc267ec235eaf84fdd26b1db0c538344a3569f91d833919e64fdd6",
+          "hash": "964476a17aea08505edddae1616899ebcc9f6f1f990e060cf37c1676a7f54b7c",
           "version": "0.9.1"
         },
         "service-skills/references/service_skill_contract.json": {
@@ -794,23 +794,23 @@
           "version": "0.9.1"
         },
         "service-skills/references/system-guide.md": {
-          "hash": "4e856daf5707543b89d9b1dcc8020a496bf34017677f8a74a2c1a8325d52b705",
+          "hash": "3f07f08f740ea5d3261c1d39f0942064a84a0e40a67a1ccf130cad96f8cbf6da",
           "version": "0.9.1"
         },
         "service-skills/references/updating.md": {
-          "hash": "c648c20615ecb05bfa51a0fa26b56bfe14d99d3c586cb554e9185f54aa3cc00b",
+          "hash": "a6db70b6e91e405827e9c31718032a68571d3b38f8932605d7fd1ef089bc7e50",
           "version": "0.9.1"
         },
         "service-skills/references/using.md": {
-          "hash": "98f452c8a537f054ad057759e370ed17d6991b2c2e1ecb07919d415bcbd1d3cb",
+          "hash": "b6876929a55c7c326d0214b6f06afe2967373e01826bef370bd1d97c19cc5662",
           "version": "0.9.1"
         },
         "service-skills/scripts/bootstrap.py": {
-          "hash": "6d5d52dd9b0449a935fd8043ac9bcea29b7fa63fe6f38eef5775c6707e106e7a",
+          "hash": "0fb9b2dc142c54bf62abaeb80d92aa61491745ab77ba2bd0576950a603ef7016",
           "version": "0.9.1"
         },
         "service-skills/scripts/cataloger.py": {
-          "hash": "9728570197cb260832a77c7b9775cf38bec285362e0e0734b45890b33c0d28fb",
+          "hash": "764e7e2684b31ad674ad3d2b0f2b430bbd8e2eef0d513949d963d82e3c508af1",
           "version": "0.9.1"
         },
         "service-skills/scripts/deep_dive.py": {
@@ -818,11 +818,11 @@
           "version": "0.9.1"
         },
         "service-skills/scripts/drift_detector.py": {
-          "hash": "228907a1f04b6c60964cb979eb8d9a864d120a2c67c6361df32f871f4b27c70c",
+          "hash": "23e805110571cc7c9527259044d5d1c2728aae225110ff1d83ffd50bdf464aec",
           "version": "0.9.1"
         },
         "service-skills/scripts/layout_migrator.py": {
-          "hash": "8f98fb15f7feffd8de7e58491aee17b195bd82e8413bc2525ca416835e8cd38f",
+          "hash": "c14712c262ba5c5b6bc33fbce759a33a8b0e61632d2382d31107d5a18cf287c8",
           "version": "0.9.1"
         },
         "service-skills/scripts/reconcile.py": {
@@ -830,11 +830,11 @@
           "version": "0.9.1"
         },
         "service-skills/scripts/scaffolder.py": {
-          "hash": "689bd65bfd8d42dccdcd05c9e9cdaff4e50e3c06da7258363172145c4e6981a7",
+          "hash": "07071c8a14b5dd493e095dbba3db70e93a4aa73ff9180811f91480d33c47a384",
           "version": "0.9.1"
         },
         "service-skills/scripts/scope.py": {
-          "hash": "b59634db12d797e4830a5796cdc0f571d3afe306751a5b086b1926cdd1fc6842",
+          "hash": "2f0f5a4d6f4af4a93e3a4fa5db18e32f5aba87743bafc0105905cccbb2f41cf6",
           "version": "0.9.1"
         },
         "service-skills/scripts/skill_activator.py": {
@@ -846,11 +846,11 @@
           "version": "0.9.1"
         },
         "service-skills/scripts/umbrella_generator.py": {
-          "hash": "4205856f6fbaeb2865c42676f7f87fcbc632d6c9819a4b531c28ff14cfa35f38",
+          "hash": "842890132fbb5f69c33bf2f5b5f51291ca8f931afce034426724959b15ad71fd",
           "version": "0.9.1"
         },
         "service-skills/SKILL.md": {
-          "hash": "51c89385d6380d9eb4d5fb9eae74a57939f072ceaac347bc7ee48b772aea1385",
+          "hash": "ca9d1e2ce74b69f2cda6d71995674bcd5f0454e16fc1d6c20311a419fd6e5d30",
           "version": "0.9.1"
         },
         "session-close-report/SKILL.md": {
@@ -1006,7 +1006,7 @@
           "version": "0.9.1"
         },
         "update-xt/SKILL.md": {
-          "hash": "585509cbea7a5865d690767a49be4f3d0517a88425bb6a52ea65dd357c1bf758",
+          "hash": "ef48ca32b8d9add09aaaed14ca5704e967d2e9a86f5d9a4310bf609f1db89754",
           "version": "0.9.1"
         },
         "updating-dependencies/schemas/dependency_update_case.schema.json": {

--- a/.xtrm/skills/default/service-skills/SKILL.md
+++ b/.xtrm/skills/default/service-skills/SKILL.md
@@ -126,7 +126,7 @@ Install machinery (hooks + settings + git-hooks) lives under `install/`; see
 ## Per-Repo Umbrella (generated)
 
 Each repo gets **one** umbrella skill — `name: <repo>-services` — at
-`.xtrm/skills/user/packs/<pack>/service-skills/SKILL.md`. It is **generated from
+`.xtrm/skills/<pack>/service-skills/SKILL.md`. It is **generated from
 `service-registry.json`** (service table + cross-service health + navigation) so it
 can never drift from the registered services. The human cross-service narrative lives
 in a `<!-- SEMANTIC_START -->` / `<!-- SEMANTIC_END -->` block preserved verbatim across

--- a/.xtrm/skills/default/service-skills/install/git-hooks/post_merge_drift_sweep.py
+++ b/.xtrm/skills/default/service-skills/install/git-hooks/post_merge_drift_sweep.py
@@ -7,7 +7,7 @@ default branch (master/main) — that is the single moment the code is final, an
 v2 design measures drift semantically from each service's `last_sync_ref`
 (committed range `last_sync_ref..HEAD`). The in-session PostToolUse nudge is
 best-effort and only fires on edits made inside an agent session, so drift can
-accumulate silently (dogfood: ~5000 items observed in an early consumer since 2026-04-23).
+accumulate silently (dogfood: market-data, ~5000 items since 2026-04-23).
 
 This hook is the proactive backstop. On a default-branch merge it:
   1. self-gates: no-op unless a service-registry is present AND HEAD is the
@@ -102,11 +102,16 @@ def _run_sp_subprocess(cmd: list[str], env: dict[str, str], timeout_s: float) ->
 
 
 def _resolve_pack(root: Path) -> str | None:
-    """Return the first pack name under .xtrm/skills/user/packs that owns a service-registry."""
-    packs = root / ".xtrm" / "skills" / "user" / "packs"
-    if packs.is_dir():
+    """Return first v2 pack, with v1 user/packs fallback, owning a service registry."""
+    packs_roots = [
+        root / ".xtrm" / "skills",
+        root / ".xtrm" / "skills" / "user" / "packs",
+    ]
+    for packs in packs_roots:
+        if not packs.is_dir():
+            continue
         for pack in sorted(packs.iterdir()):
-            if not pack.is_dir():
+            if not pack.is_dir() or pack.name in {"default", "optional", "user", "active", "local-legacy"}:
                 continue
             if (pack / "service-skills" / "service-registry.json").exists() or (pack / "service-registry.json").exists():
                 return pack.name
@@ -129,7 +134,7 @@ def _auto_reconcile(root: Path) -> tuple[bool, str]:
 
     pack = _resolve_pack(root)
     if not pack:
-        return (False, "no pack with service-registry resolvable under .xtrm/skills/user/packs")
+        return (False, "no pack with service-registry resolvable under .xtrm/skills")
 
     try:
         timeout_ms = int(os.environ.get(AUTO_RECONCILE_TIMEOUT_MS_ENV, AUTO_RECONCILE_TIMEOUT_MS_DEFAULT))
@@ -185,13 +190,17 @@ def _append_runlog(root: Path, line: str) -> None:
 
 
 def _has_registry(root: Path) -> bool:
-    packs = root / ".xtrm" / "skills" / "user" / "packs"
-    if packs.is_dir():
-        for pack in packs.iterdir():
-            if not pack.is_dir():
-                continue
-            if (pack / "service-skills" / "service-registry.json").exists() or (pack / "service-registry.json").exists():
-                return True
+    packs_roots = [
+        root / ".xtrm" / "skills",
+        root / ".xtrm" / "skills" / "user" / "packs",
+    ]
+    for packs in packs_roots:
+        if packs.is_dir():
+            for pack in packs.iterdir():
+                if not pack.is_dir() or pack.name in {"default", "optional", "user", "active", "local-legacy"}:
+                    continue
+                if (pack / "service-skills" / "service-registry.json").exists() or (pack / "service-registry.json").exists():
+                    return True
     return (root / "service-registry.json").exists() or (root / ".claude" / "skills" / "service-registry.json").exists()
 
 

--- a/.xtrm/skills/default/service-skills/install/git-hooks/skill_staleness.py
+++ b/.xtrm/skills/default/service-skills/install/git-hooks/skill_staleness.py
@@ -20,18 +20,26 @@ from pathlib import Path
 # A skill is flagged as potentially stale if any changed file in the push
 # starts with one of these paths for that service.
 #
-# Populate this dict to match your project's layout. Example shape:
-#
-#   SERVICE_SOURCE_PATHS = {
-#       "api":            ["src/api/", "src/schema/"],
-#       "worker":         ["src/worker/", "src/tasks/"],
-#       "migrations":     ["alembic/", "scripts/migrations/"],
-#       "db":             ["docker-compose.yml"],
-#   }
-#
-# Empty by default — the hook no-ops until you fill this in.
+# Customise this dict to match your project's layout.
 # ---------------------------------------------------------------------------
-SERVICE_SOURCE_PATHS: dict[str, list[str]] = {}
+SERVICE_SOURCE_PATHS: dict[str, list[str]] = {
+    "mmd-data-feed":          ["scripts/data/import_unified.py",
+                                "scripts/database/unified_import.py"],
+    "mmd-snapshot-feed":      ["scripts/data/feeds/snapshot_feed.py",
+                                "scripts/core/"],
+    "mmd-curve-feed":         ["scripts/data/feeds/spread_feed.py"],
+    "mmd-curve-backfill":     ["scripts/data/feeds/spread_feed.py"],
+    "mmd-stir-feed":          ["scripts/data/feeds/stir_feed.py"],
+    "mmd-api":                ["mcp_server/"],
+    "mmd-mcp-server":         ["mcp_server/mcp_server.py",
+                                "mcp_server/docstrings/"],
+    "mmd-cme-ingestion":      ["scripts/ingestion/cme/"],
+    "mmd-migrations":         ["alembic/", "scripts/data/migrations.py",
+                                "scripts/database/run_migrations.py"],
+    "mmd-tick-ingestor-rust": ["rust_ingestor/"],
+    "mmd-backup-service":     ["scripts/backup/"],
+    "mmd-timescaledb":        ["docker-compose.yml"],
+}
 
 # These files, if changed, flag ALL skills for review
 GLOBAL_TRIGGERS = [

--- a/.xtrm/skills/default/service-skills/install/install-service-skills.py
+++ b/.xtrm/skills/default/service-skills/install/install-service-skills.py
@@ -122,15 +122,28 @@ def install_git_hooks(project_root: Path) -> None:
     print(f"{GREEN}  ✓{NC} activated in .git/hooks/")
 
 
+RESERVED_PACK_NAMES = {"default", "optional", "user", "active", "local-legacy"}
+
+
+def _pack_roots(project_root: Path) -> list[Path]:
+    skills_root = project_root / ".xtrm" / "skills"
+    return [skills_root, skills_root / "user" / "packs"]
+
+
 def _packs_with_registry(project_root: Path) -> list[Path]:
-    """Packs that carry a service registry (umbrella or legacy flat location)."""
-    packs_root = project_root / ".xtrm" / "skills" / "user" / "packs"
-    if not packs_root.exists():
-        return []
-    out = []
-    for pack in sorted(p for p in packs_root.iterdir() if p.is_dir()):
-        if (pack / "service-skills" / "service-registry.json").exists() or (pack / "service-registry.json").exists():
-            out.append(pack)
+    """Packs that carry a service registry; v2 root wins over v1 shim."""
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for packs_root in _pack_roots(project_root):
+        if not packs_root.exists():
+            continue
+        for pack in sorted(p for p in packs_root.iterdir() if p.is_dir() and p.name not in RESERVED_PACK_NAMES):
+            resolved = pack.resolve()
+            if resolved in seen:
+                continue
+            if (pack / "service-skills" / "service-registry.json").exists() or (pack / "service-registry.json").exists():
+                seen.add(resolved)
+                out.append(pack)
     return out
 
 
@@ -208,15 +221,13 @@ def generate_umbrellas(project_root: Path) -> None:
     Idempotent — prints only when a file actually changes."""
     print("\n── Umbrella ────────────────────────────")
     generator = project_root / ".claude" / "skills" / "service-skills" / "scripts" / "umbrella_generator.py"
-    packs_root = project_root / ".xtrm" / "skills" / "user" / "packs"
-    if not generator.exists() or not packs_root.exists():
+    packs = _packs_with_registry(project_root)
+    if not generator.exists() or not packs:
         print(f"{YELLOW}  ○{NC} nothing to generate (no generator or packs)")
         return
     repo_name = project_root.name
     wrote = 0
-    for pack in sorted(p for p in packs_root.iterdir() if p.is_dir()):
-        if not (pack / "service-registry.json").exists() and not (pack / "service-skills" / "service-registry.json").exists():
-            continue
+    for pack in packs:
         env = {**os.environ, "XTRM_PACK": pack.name}
         r = subprocess.run(["python3", str(generator), repo_name],
                            cwd=str(project_root), env=env, capture_output=True, text=True, check=False)

--- a/.xtrm/skills/default/service-skills/install/service-skills-readme.md
+++ b/.xtrm/skills/default/service-skills/install/service-skills-readme.md
@@ -1,6 +1,6 @@
 # Service Skills
 
-> **Path model:** the canonical home for per-service skills is `.xtrm/skills/user/packs/<pack>/<service>/`; `.claude/skills/<service>/` is a Claude-Code **view** (symlink). Scripts resolve real paths via `bootstrap` (`get_service_skill_path_str`) — they never hardcode `.claude/skills`. The machinery skill itself is at `.claude/skills/service-skills/` (active view) ↔ `.xtrm/skills/default/service-skills/`.
+> **Path model:** the canonical home for per-service skills is `.xtrm/skills/<pack>/<service>/`; `.claude/skills/<service>/` is a Claude-Code **view** (symlink). Scripts resolve real paths via `bootstrap` (`get_service_skill_path_str`) — they never hardcode `.claude/skills`. The machinery skill itself is at `.claude/skills/service-skills/` (active view) ↔ `.xtrm/skills/default/service-skills/`.
 
 A system that gives Claude persistent, project-specific operational knowledge about your Docker services. Instead of re-explaining your architecture every session, each service has a dedicated skill package that Claude loads on demand.
 

--- a/.xtrm/skills/default/service-skills/references/creating.md
+++ b/.xtrm/skills/default/service-skills/references/creating.md
@@ -3,7 +3,7 @@
 
 > Detailed **create** flow for the `service-skills` router. Invoked via `/service-skills` (create) or `/creating-service-skills` muscle-memory.
 >
-> **Path model:** `.claude/skills/<service>/SKILL.md` shown below is the **Claude-Code view** (a symlink). The canonical home for per-service skills is under `.xtrm/skills/user/packs/<pack>/` — scripts resolve it via `bootstrap.get_service_skill_path_str`. Machinery scripts live at `.claude/skills/service-skills/scripts/` (the active view of this skill).
+> **Path model:** `.claude/skills/<service>/SKILL.md` shown below is the **Claude-Code view** (a symlink). The canonical home for per-service skills is under `.xtrm/skills/<pack>/` — scripts resolve it via `bootstrap.get_service_skill_path_str`. Machinery scripts live at `.claude/skills/service-skills/scripts/` (the active view of this skill).
 
 ## Role: The Architect
 

--- a/.xtrm/skills/default/service-skills/references/routing.md
+++ b/.xtrm/skills/default/service-skills/references/routing.md
@@ -3,7 +3,7 @@
 
 > Detailed **scope / route** flow (intent detection, scope plan, regression-test binding) for the `service-skills` router.
 >
-> **Path model:** `.claude/skills/<service>/SKILL.md` shown below is the **Claude-Code view** (a symlink). The canonical home for per-service skills is under `.xtrm/skills/user/packs/<pack>/` — scripts resolve it via `bootstrap.get_service_skill_path_str`. Machinery scripts live at `.claude/skills/service-skills/scripts/` (the active view of this skill).
+> **Path model:** `.claude/skills/<service>/SKILL.md` shown below is the **Claude-Code view** (a symlink). The canonical home for per-service skills is under `.xtrm/skills/<pack>/` — scripts resolve it via `bootstrap.get_service_skill_path_str`. Machinery scripts live at `.claude/skills/service-skills/scripts/` (the active view of this skill).
 
 Ground every task in the right expert context **before any files are touched**.
 

--- a/.xtrm/skills/default/service-skills/references/script_quality_standards.md
+++ b/.xtrm/skills/default/service-skills/references/script_quality_standards.md
@@ -1,6 +1,7 @@
 # Script Quality Standards for Service Skills
 
-> Distilled from early consumer implementations (Feb 2026).
+> Distilled from the mercury-market-data implementation (Feb 2026).
+> Updated with lessons from the processing-papers implementation (Feb 2026).
 > Apply these standards to every script generated in Phase 2 of the service-skill-builder workflow.
 
 ---

--- a/.xtrm/skills/default/service-skills/references/system-guide.md
+++ b/.xtrm/skills/default/service-skills/references/system-guide.md
@@ -179,7 +179,7 @@ Classify before writing scripts. The service type determines which scripts to wr
 
 > **Runtime views are managed, not hand-synced.** Per-runtime skill views
 > (`.claude/skills`, `.agent/skills`, `.gemini/skills`, `.qwen/skills`) are derived
-> from `.xtrm/skills/default` + `.xtrm/skills/user/packs` and rebuilt by
+> from `.xtrm/skills/default` + `.xtrm/skills/<pack>` and rebuilt by
 > `xt update --apply` (or `xt init`). Never `cp` skills into them by hand — that
 > drifts from what the materializer produces.
 

--- a/.xtrm/skills/default/service-skills/references/updating.md
+++ b/.xtrm/skills/default/service-skills/references/updating.md
@@ -3,7 +3,7 @@
 
 > Detailed **update / drift-sync** flow for the `service-skills` router.
 >
-> **Path model:** `.claude/skills/<service>/SKILL.md` shown below is the **Claude-Code view** (a symlink). The canonical home for per-service skills is under `.xtrm/skills/user/packs/<pack>/` — scripts resolve it via `bootstrap.get_service_skill_path_str`. Machinery scripts live at `.claude/skills/service-skills/scripts/` (the active view of this skill).
+> **Path model:** `.claude/skills/<service>/SKILL.md` shown below is the **Claude-Code view** (a symlink). The canonical home for per-service skills is under `.xtrm/skills/<pack>/` — scripts resolve it via `bootstrap.get_service_skill_path_str`. Machinery scripts live at `.claude/skills/service-skills/scripts/` (the active view of this skill).
 
 ## Role: The Librarian
 

--- a/.xtrm/skills/default/service-skills/references/using.md
+++ b/.xtrm/skills/default/service-skills/references/using.md
@@ -3,7 +3,7 @@
 
 > Detailed **discover / activate** flow for the `service-skills` router.
 >
-> **Path model:** `.claude/skills/<service>/SKILL.md` shown below is the **Claude-Code view** (a symlink). The canonical home for per-service skills is under `.xtrm/skills/user/packs/<pack>/` — scripts resolve it via `bootstrap.get_service_skill_path_str`. Machinery scripts live at `.claude/skills/service-skills/scripts/` (the active view of this skill).
+> **Path model:** `.claude/skills/<service>/SKILL.md` shown below is the **Claude-Code view** (a symlink). The canonical home for per-service skills is under `.xtrm/skills/<pack>/` — scripts resolve it via `bootstrap.get_service_skill_path_str`. Machinery scripts live at `.claude/skills/service-skills/scripts/` (the active view of this skill).
 
 ## Role: The Concierge
 
@@ -127,4 +127,4 @@ Read-only — no write access:
 
 ## Per-repo umbrella (load first for cross-service tasks)
 
-Each repo has a generated umbrella skill `<repo>-services` at `.xtrm/skills/user/packs/<pack>/service-skills/SKILL.md` — the service map + cross-service health story. When a task spans services, load the umbrella first; it links every per-service skill. It is regenerated from the registry (`umbrella_generator.py`); only its `<!-- SEMANTIC_START -->` block is hand-edited.
+Each repo has a generated umbrella skill `<repo>-services` at `.xtrm/skills/<pack>/service-skills/SKILL.md` — the service map + cross-service health story. When a task spans services, load the umbrella first; it links every per-service skill. It is regenerated from the registry (`umbrella_generator.py`); only its `<!-- SEMANTIC_START -->` block is hand-edited.

--- a/.xtrm/skills/default/service-skills/scripts/bootstrap.py
+++ b/.xtrm/skills/default/service-skills/scripts/bootstrap.py
@@ -5,23 +5,17 @@ Bootstrap module for Service Skill Trinity.
 Provides root-discovery and registry CRUD operations shared across all
 service-skill workflow scripts. All scripts in the trinity import from here.
 
-Path model: the canonical home for service skills + registry is under .xtrm
-(``.xtrm/skills/user/packs/<pack>/...``). ``.claude/skills`` is a Claude-Code
-VIEW only — kept solely as a legacy READ fallback for pre-migration installs.
-No code path EMITS a ``.claude/skills`` path for cross-tool consumption; use the
-resolver helpers (get_service_skill_dir / get_service_skill_path_str) instead.
+Path model: the canonical home for service skills + registry is under
+``.xtrm/skills/<pack>/``. ``.claude/skills`` is a Claude-Code VIEW only — kept
+solely as a legacy READ fallback for pre-migration installs.
 
 Registry resolution order:
   1) $SERVICE_REGISTRY_PATH override
   2) <root>/service-registry.json
-  3) <root>/.claude/skills/service-registry.json   (legacy Claude-view read; back-compat)
-  4) <root>/.xtrm/skills/user/packs/*/service-registry.json
+  3) <root>/.claude/skills/service-registry.json (legacy view)
+  4) <root>/.xtrm/skills/*/service-registry.json
 
-For pack glob, first hit wins after disambiguation:
-- If active pack discoverable, matching pack registry preferred
-- Else lexicographically first registry used with stderr warning
-
-Skills location: .xtrm/skills/user/packs/<pack>/<service-id>/
+Skills location: .xtrm/skills/<pack>/service-skills/services/<service-id>/
 """
 
 import json
@@ -33,7 +27,8 @@ from pathlib import Path
 from typing import Any
 
 SERVICE_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-_]{0,63}$")
-PACKS_ROOT_SUFFIX = Path(".xtrm") / "skills" / "user" / "packs"
+SKILLS_ROOT_SUFFIX = Path(".xtrm") / "skills"
+RESERVED_PACK_NAMES = {"default", "optional", "user", "active", "local-legacy"}
 
 
 class BootstrapError(Exception):
@@ -71,10 +66,20 @@ def get_skills_root(project_root: str | None = None) -> Path:
     return Path(project_root) / ".claude" / "skills"
 
 
+def resolveRepoPackRoot(project_root: str, pack_name: str) -> Path:
+    if not SERVICE_ID_PATTERN.fullmatch(pack_name) or pack_name in RESERVED_PACK_NAMES:
+        raise RootResolutionError(f"Invalid or reserved pack name: {pack_name}")
+    return (Path(project_root) / SKILLS_ROOT_SUFFIX / pack_name).resolve(strict=False)
+
+
+def resolve_repo_pack_root(project_root: str, pack_name: str) -> Path:
+    return resolveRepoPackRoot(project_root, pack_name)
+
+
 def _packs_root(project_root: str | None = None) -> Path:
     if project_root is None:
         project_root = get_project_root()
-    return Path(project_root) / PACKS_ROOT_SUFFIX
+    return Path(project_root) / SKILLS_ROOT_SUFFIX
 
 
 def _ensure_within_root(candidate: Path, root: Path, label: str) -> Path:
@@ -94,16 +99,24 @@ def get_pack_path(project_root: str | None = None) -> Path | None:
     packs_root = _packs_root(project_root)
     env_pack = os.environ.get("XTRM_PACK")
 
+    legacy_packs_root = packs_root / "user" / "packs"
     if env_pack:
         pack_path = Path(env_pack)
         if not pack_path.is_absolute():
             pack_path = packs_root / env_pack
-        return _ensure_within_root(pack_path, packs_root, "XTRM_PACK path")
+            if not pack_path.exists():
+                pack_path = legacy_packs_root / env_pack
+        validation_root = packs_root if pack_path.parent == packs_root else legacy_packs_root
+        return _ensure_within_root(pack_path, validation_root, "XTRM_PACK path")
 
-    if not packs_root.exists():
-        return None
-
-    pack_dirs = [path for path in packs_root.iterdir() if path.is_dir()]
+    pack_dirs = []
+    for candidate_root in (packs_root, legacy_packs_root):
+        if not candidate_root.exists():
+            continue
+        pack_dirs.extend(
+            path for path in candidate_root.iterdir()
+            if path.is_dir() and path.name not in RESERVED_PACK_NAMES
+        )
     if len(pack_dirs) == 1:
         return pack_dirs[0].resolve()
 
@@ -114,8 +127,8 @@ def get_service_skill_dir(service_id: str, project_root: str | None = None) -> P
     """Resolve a service's skill-package directory (absolute, under .xtrm — never .claude).
 
     Single source of truth for *where a service skill lives*. Today that is
-    ``<pack>/<service_id>`` under ``.xtrm/skills/user/packs``. Child .4 (layout
-    migrator) re-points this to ``<pack>/service-skills/services/<service_id>``;
+    ``<pack>/<service_id>`` under ``.xtrm/skills``. Service skills live under
+    ``<pack>/service-skills/services/<service_id>``;
     every emitter (scaffolder bodies, activator/cataloger fallbacks, registry
     skill_path) routes through here, so they all follow automatically — no
     emitter hardcodes a path.
@@ -188,16 +201,16 @@ def get_registry_path(project_root: str | None = None) -> Path:
 
     # Precedence — the canonical .xtrm umbrella location wins, so a stale root or
     # legacy .claude registry can NEVER shadow a migrated repo (the bug that made
-    # an earlier consumer's migration not stick):
+    # market-data's migration not stick):
     #   1) umbrella-owned registry           (post-migration canonical)
     #   2) flat pack-root registry           (pre-migration .xtrm layout)
     #   3) <root>/service-registry.json      (legacy back-compat)
     #   4) .claude/skills/service-registry.json  (legacy Claude-view back-compat)
-    umbrella_registries = sorted(root.glob(".xtrm/skills/user/packs/*/service-skills/service-registry.json"))
+    umbrella_registries = sorted(root.glob(".xtrm/skills/*/service-skills/service-registry.json"))
     if umbrella_registries:
         return _select_pack_registry(umbrella_registries, project_root)
 
-    pack_registries = sorted(root.glob(".xtrm/skills/user/packs/*/service-registry.json"))
+    pack_registries = sorted(root.glob(".xtrm/skills/*/service-registry.json"))
     if pack_registries:
         return _select_pack_registry(pack_registries, project_root)
 
@@ -327,7 +340,7 @@ def _gitnexus_repo_name(project_root: str | None = None) -> str:
     """Resolve the repo label gitnexus indexed under — the MAIN worktree's basename.
 
     In a linked git worktree ``get_project_root()`` returns the worktree dir, whose basename
-    (e.g. ``consumer-repo-uh1r-service-skills-sync``) gitnexus has NOT indexed; injecting it as
+    (e.g. ``market-data-uh1r-service-skills-sync``) gitnexus has NOT indexed; injecting it as
     ``--repo`` makes every gitnexus call fail → drift silently degrades to mtime-only tiering.
     The service-skills-sync librarian ALWAYS runs in such an auto-provisioned worktree, so it
     would otherwise never get semantic enrichment. ``git rev-parse --git-common-dir`` points at

--- a/.xtrm/skills/default/service-skills/scripts/cataloger.py
+++ b/.xtrm/skills/default/service-skills/scripts/cataloger.py
@@ -17,7 +17,7 @@ machinery skill):
 Output format (per-service Path resolves under .xtrm packs, not .claude/skills):
   <project_service_catalog>
   Available expert personas:
-  - db-expert: SQL & schema expert (Path: .xtrm/skills/user/packs/<pack>/db-expert/SKILL.md)
+  - db-expert: SQL & schema expert (Path: .xtrm/skills/<pack>/db-expert/SKILL.md)
   </project_service_catalog>
   <instruction>To activate an expert, read its SKILL.md from the provided path.</instruction>
 """

--- a/.xtrm/skills/default/service-skills/scripts/drift_detector.py
+++ b/.xtrm/skills/default/service-skills/scripts/drift_detector.py
@@ -47,7 +47,7 @@ def _print_missing_registry_hint(project_root: str | None = None) -> None:
     root = Path(project_root)
     # Diagnostic only: lists the registry search order. The .claude/skills entry
     # is the legacy Claude-view read (back-compat); the canonical home is .xtrm packs.
-    print(f"Registry not found. Expected one of: {root / 'service-registry.json'}, {root / '.claude/skills/service-registry.json (legacy view)'}, {root / '.xtrm/skills/user/packs/*/service-registry.json'}", file=sys.stderr)
+    print(f"Registry not found. Expected one of: {root / 'service-registry.json'}, {root / '.claude/skills/service-registry.json (legacy view)'}, {root / '.xtrm/skills/*/service-registry.json'}", file=sys.stderr)
 
 def update_sync_time(service_id: str, project_root: str | None = None) -> bool:
     try:

--- a/.xtrm/skills/default/service-skills/scripts/layout_migrator.py
+++ b/.xtrm/skills/default/service-skills/scripts/layout_migrator.py
@@ -3,11 +3,11 @@
 layout_migrator.py — one-time migration of a service-skills pack from the FLAT
 layout to the UMBRELLA layout.
 
-    FROM:  .xtrm/skills/user/packs/<pack>/<svc>/SKILL.md
-           .xtrm/skills/user/packs/<pack>/service-registry.json
-    TO:    .xtrm/skills/user/packs/<pack>/service-skills/services/<svc>/SKILL.md
-           .xtrm/skills/user/packs/<pack>/service-skills/service-registry.json
-           .xtrm/skills/user/packs/<pack>/service-skills/SKILL.md   (generated umbrella)
+    FROM:  .xtrm/skills/<pack>/<svc>/SKILL.md
+           .xtrm/skills/<pack>/service-registry.json
+    TO:    .xtrm/skills/<pack>/service-skills/services/<svc>/SKILL.md
+           .xtrm/skills/<pack>/service-skills/service-registry.json
+           .xtrm/skills/<pack>/service-skills/SKILL.md   (generated umbrella)
 
 This is DISTINCT from skill_migrator.py: that edits a SKILL.md's headings; this
 *moves files* and *relocates/rewrites the registry*, then generates the umbrella.
@@ -69,39 +69,6 @@ def _new_skill_dir_str(project_root: Path, pack: Path, service_id: str) -> str:
         return str(new_dir.resolve(strict=False).relative_to(project_root.resolve())).replace(os.sep, "/")
     except ValueError:
         return str(new_dir).replace(os.sep, "/")
-
-
-def _sync_pack_json(pack: Path) -> str | None:
-    """Sync ``PACK.json`` ``skills[]`` to the post-migration filesystem (xtrm-x8b5g).
-
-    The active-view materializer validates a pack's ``PACK.json`` ``skills[]`` against the
-    filesystem: an entry is a *direct child dir of the pack that contains a SKILL.md* (dir name
-    is the identity). After migration the moved per-service dirs live under
-    ``service-skills/services/`` (no longer direct children) and the new ``service-skills``
-    umbrella is a direct child — so a stale ``PACK.json`` lists ghost services (metadata-only) and
-    omits the umbrella (filesystem-only), tripping ``PACK_METADATA_MISMATCH`` which BLOCKS the
-    active-view rebuild. Recompute ``skills[]`` from the filesystem (idempotent). Returns a note,
-    or None when there is no ``PACK.json`` or it is already in sync.
-    """
-    pack_json = pack / "PACK.json"
-    if not pack_json.exists():
-        return None
-    try:
-        data = json.loads(pack_json.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-    fs_skills = sorted(
-        child.name for child in pack.iterdir()
-        if child.is_dir() and (child / "SKILL.md").exists()
-    )
-    if data.get("skills") == fs_skills:
-        return None
-    data["skills"] = fs_skills
-    try:
-        pack_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    except OSError:
-        return None
-    return f"pack-json: synced PACK.json skills -> {', '.join(fs_skills) or '(none)'}"
 
 
 def _rewrite_claude_refs(body: str, new_dir_for: Any) -> tuple[str, int, set[str]]:
@@ -217,9 +184,10 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
     # Generate the umbrella (preserves any existing SEMANTIC block).
     umbrella_changed = write_umbrella(umbrella_dir / "SKILL.md", registry, repo_name)
 
-    # Sync PACK.json AFTER the umbrella exists + services have moved, so the recomputed
-    # skills[] reflects the final layout (umbrella in, ghost services out) — xtrm-x8b5g.
-    pack_json_note = _sync_pack_json(pack)
+    # PACK.json is retired; discovery derives skills from filesystem shape.
+    pack_json = pack / "PACK.json"
+    if pack_json.exists():
+        pack_json.unlink()
 
     return {
         "pack": pack.name,
@@ -229,7 +197,6 @@ def migrate_pack(project_root: Path, pack: Path, repo_name: str) -> dict[str, An
         "registry": str(new_registry),
         "refs_rewritten": refs_rewritten,
         "stale_refs": sorted(stale_refs),
-        "pack_json_note": pack_json_note,
     }
 
 
@@ -268,7 +235,7 @@ def main() -> None:
 
     pack = get_pack_path(project_root_str)
     if pack is None:
-        print("Error: unable to resolve pack path. Set XTRM_PACK or leave only one pack under .xtrm/skills/user/packs.", file=sys.stderr)
+        print("Error: unable to resolve pack path. Set XTRM_PACK or leave only one pack under .xtrm/skills.", file=sys.stderr)
         sys.exit(1)
 
     try:
@@ -285,8 +252,6 @@ def main() -> None:
         print(f"{prefix}: {sid} ({outcome})")
     print(f"registry: {result['registry']}")
     print(f"umbrella: {'written' if result['umbrella_written'] else 'unchanged'}")
-    if result.get("pack_json_note"):
-        print(result["pack_json_note"])
     if result.get("refs_rewritten"):
         print(f"refs: rewrote {result['refs_rewritten']} legacy .claude/skills path(s) in SKILL.md bodies")
     for seg in result.get("stale_refs", []):

--- a/.xtrm/skills/default/service-skills/scripts/scaffolder.py
+++ b/.xtrm/skills/default/service-skills/scripts/scaffolder.py
@@ -6,7 +6,7 @@ Phase 1 of the two-phase workflow: generates a structural skeleton for a new
 service skill by parsing docker-compose.yml, Dockerfiles, and dependency files.
 The skeleton contains [PENDING RESEARCH] markers for the agent to fill in Phase 2.
 
-Output location: .xtrm/skills/user/packs/<pack>/<service-id>/
+Output location: .xtrm/skills/<pack>/<service-id>/
 """
 
 import json
@@ -98,7 +98,7 @@ def scaffold_service_skill(service_id: str, compose_data: dict) -> Path:
 
     pack_path = get_pack_path(project_root)
     if pack_path is None:
-        print("Error: unable to resolve pack path. Set XTRM_PACK or leave only one pack under .xtrm/skills/user/packs.")
+        print("Error: unable to resolve pack path. Set XTRM_PACK or leave only one pack under .xtrm/skills.")
         sys.exit(1)
 
     # New layout: <pack>/service-skills/services/<service_id> (single source: bootstrap).

--- a/.xtrm/skills/default/service-skills/scripts/scope.py
+++ b/.xtrm/skills/default/service-skills/scripts/scope.py
@@ -22,8 +22,8 @@ def find_registry() -> Path | None:
 
     Precedence (see bootstrap.get_registry_path):
       1. $SERVICE_REGISTRY_PATH override
-      2. <root>/.xtrm/skills/user/packs/<pack>/service-skills/service-registry.json  (canonical)
-      3. <root>/.xtrm/skills/user/packs/<pack>/service-registry.json                 (pre-umbrella)
+      2. <root>/.xtrm/skills/<pack>/service-skills/service-registry.json  (canonical)
+      3. <root>/.xtrm/skills/<pack>/service-registry.json                 (pre-umbrella)
       4. <root>/service-registry.json                                                (root symlink)
       5. <root>/.claude/skills/service-registry.json                                  (legacy)
 

--- a/.xtrm/skills/default/service-skills/scripts/umbrella_generator.py
+++ b/.xtrm/skills/default/service-skills/scripts/umbrella_generator.py
@@ -166,7 +166,7 @@ def main() -> None:
     repo_name = args[0] if args else Path(project_root).name
     pack = get_pack_path(project_root)
     if pack is None:
-        print("Error: unable to resolve pack path. Set XTRM_PACK or leave only one pack under .xtrm/skills/user/packs.", file=sys.stderr)
+        print("Error: unable to resolve pack path. Set XTRM_PACK or leave only one pack under .xtrm/skills.", file=sys.stderr)
         sys.exit(1)
     registry = load_registry(project_root)
     umbrella_path = pack / "service-skills" / "SKILL.md"


### PR DESCRIPTION
## Summary

Post-y0tdg.1 finding while migrating mercury repos (all have real service-skills registries): the shipped `.xtrm/skills/default/service-skills/` payload had drifted from the source at `skills/service-skills/`. Source was already v2-aware (understands both `<repo>/.xtrm/skills/<pack>/service-skills/` flat layout AND the legacy `user/packs/` layout), but the shipped mirror still had v1-only path resolution.

On any repo migrated via `xt migrate skills-layout --apply`, the shipped bootstrap couldn't discover the relocated `service-registry.json`. Every downstream service-skills tool (cataloger, scaffolder, drift detector, skill activator, layout migrator, umbrella generator) would fail to resolve services on migrated consumers.

## Change

- rsync source → shipped mirror across: `bootstrap.py`, `cataloger.py`, `drift_detector.py`, `layout_migrator.py`, `scaffolder.py`, `scope.py`, `umbrella_generator.py`, `SKILL.md`, `references/*.md`, `install/`
- Kept shipped-only files intact (`reconcile.py` + `scripts/tests/test_reconcile.py`, both from the auto-reconcile epic)
- Regenerated `.xtrm/registry.json` for hash parity
- Rebuilt `cli/dist/`

## Verification

**Migrated consumer (v2)**: `~/projects/mercury/treasury-cb`
- `get_registry_path` → `.xtrm/skills/treasury-cb/service-skills/service-registry.json` ✓
- `get_pack_path` → `.xtrm/skills/treasury-cb` ✓
- All 4 registered services resolve to real dirs ✓

**Unmigrated consumer (v1)**: `~/projects/mercury/market-data`
- `get_registry_path` → `.xtrm/skills/user/packs/market-data/service-skills/service-registry.json` ✓
- All 16 registered services resolve ✓

## Test plan

- [x] `pytest skills/service-skills/tests/` — 65 passed
- [x] `npm test --workspace cli` — 769 passed / 98 skipped / 0 fail
- [x] `npm run --workspace cli typecheck` — clean
- [x] `npm run check:registry-pack-parity` — ok, 354 files

## Related

Follow-up to #392 (`xtrm-y0tdg.1`) and #393. Enables safe migration of mercury service-skills repos.
Epic: `xtrm-y0tdg` (still open for operator post-verify)