### PR TITLE
ci(publish): also publish @jaggerxtrm/pi-extensions on release (xtrm-ij4mo)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,8 +96,13 @@ jobs:
       - name: Check asset contract
         run: node scripts/verify-asset-contract.mjs --contract ./specialists-src/dist/asset-contract.json --vendor-root .xtrm/skills/default
 
-      - name: Publish to npm
+      - name: Publish xtrm-tools to npm
         run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           SPECIALISTS_REPO_PATH: ${{ github.workspace }}/specialists-src
+
+      - name: Publish @jaggerxtrm/pi-extensions to npm
+        run: npm publish -w @jaggerxtrm/pi-extensions --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

publish.yml currently runs only \`npm publish --provenance\` at repo root — the pi-extensions workspace was never touched. Every coordinated release (v0.10.1 pattern: \`npm version X.Y.Z --workspaces=false\` bumps both packages in lockstep) required an operator to manually run \`npm publish -w @jaggerxtrm/pi-extensions --access public\` after \`gh release create\` fired.

## Fix

Add a second publish step that publishes the pi-extensions workspace with sigstore provenance and public access. Runs **after** the root publish so a root failure aborts the workflow before pi-extensions publishes (matches consumer expectation that a \`v<X>\` release atomically contains both packages).

\`\`\`yaml
- name: Publish xtrm-tools to npm
  run: npm publish --provenance
  env:
    NODE_AUTH_TOKEN: ...
    SPECIALISTS_REPO_PATH: ...

- name: Publish @jaggerxtrm/pi-extensions to npm
  run: npm publish -w @jaggerxtrm/pi-extensions --provenance --access public
  env:
    NODE_AUTH_TOKEN: ...
\`\`\`

## Safety

- pi-extensions workspace has its own \`prepublishOnly\` (\`verify:runtime\`) asserting \`src/index.ts\`, \`src/registry.ts\`, \`extensions/\`, \`themes/\` are present — safe to run in CI.
- \`cli\` workspace is marked \`private: true\` in its \`package.json\` and is intentionally NOT included in this step; \`xtrm-cli\` stays unpublished.
- Sigstore provenance for pi-extensions now validates against \`xtrm-dev/core\` after v0.10.1's \`repository.url\` fix.
- Root publish failure short-circuits pi-extensions publish (default \`fail-fast\` step behavior).

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))\"\` parses clean
- [x] Manual publish of \`@jaggerxtrm/pi-extensions@0.10.1\` yesterday confirmed the workspace prepublishOnly + auth + provenance work end-to-end from local
- [ ] CI green (semgrep/gitleaks/osv only — no test job on this file)
- [ ] Next coordinated release (v0.10.2 or v0.11.0) publishes BOTH packages via a single \`gh release create\` — no manual step needed
- [ ] \`npm view xtrm-cli\` still returns 404 (not published)

Closes xtrm-ij4mo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)