### PR TITLE
release: v0.10.3 — shared beads-status cache + xtmux V2 SQLite + bd v1.1.0 instructions

### DIFF
--- a/.xtrm/config/instructions/agents-top.md
+++ b/.xtrm/config/instructions/agents-top.md
@@ -35,6 +35,8 @@ Use these as the minimal operational surface; use `--help` for full syntax.
 - `bd prime`, `bd ready`, `bd list --status=in_progress`, `bd show <id>`
 - `bd update <id> --claim`, `bd remember "<insight>"`, `bd close <id> --reason="..."`
 - `bd set-state <id> <dim>=<val> --reason="..."`, `bd state <id> <dim>` — operational state labels (e.g. `contract=ready`, `patrol=muted`, `health=healthy`)
+- `bd ready --claim` — atomic claim-on-ready; `bd ready --explain` — why an issue is ready/blocked
+- `bd create --graph <plan.json> --dry-run` — issue-graph decomposition; `--waits-for <id> --waits-for-gate all-children|any-children` for fan-in/out; `--spec-id`/`--skills` to link specs/required skills
 - `bv --robot-triage --format toon`, `bv --robot-next` — never bare `bv`
 - `xt report list` / latest report file, `xt update --apply`, `xt end`
 - `xt worktree --help` — PR/branch/restart audit primitives (`audit-prs`, `branch-gc`, `restart-audit`); pair with specialists `doctor --pr-drift` / `doctor --reap-dead-jobs`. Details: `/using-xtrm`.
@@ -75,4 +77,5 @@ Use these as the minimal operational surface; use `--help` for full syntax.
 ## Worktree sessions
 
 - `xt pi` — launch Pi in a sandboxed worktree.
+- `xt pi --role <specialist>` — spawn an interactive specialist session (e.g. `chain-coordinator` for tracking epic chains, `pr-reviewer`, `sre-triage`). Coordination and escalation live in `/multiplexing` Pattern 7 and `/using-specialists`.
 - `xt end` — close session: commit / push / PR / cleanup when appropriate.

--- a/.xtrm/config/instructions/claude-top.md
+++ b/.xtrm/config/instructions/claude-top.md
@@ -35,6 +35,8 @@ Use these as the minimal operational surface; use `--help` for full syntax.
 - `bd prime`, `bd ready`, `bd list --status=in_progress`, `bd show <id>`
 - `bd update <id> --claim`, `bd remember "<insight>"`, `bd close <id> --reason="..."`
 - `bd set-state <id> <dim>=<val> --reason="..."`, `bd state <id> <dim>` — operational state labels (e.g. `contract=ready`, `patrol=muted`, `health=healthy`)
+- `bd ready --claim` — atomic claim-on-ready; `bd ready --explain` — why an issue is ready/blocked
+- `bd create --graph <plan.json> --dry-run` — issue-graph decomposition; `--waits-for <id> --waits-for-gate all-children|any-children` for fan-in/out; `--spec-id`/`--skills` to link specs/required skills
 - `bv --robot-triage --format toon`, `bv --robot-next` — never bare `bv`
 - `xt report list` / latest report file, `xt update --apply`, `xt end`
 - `xt worktree --help` — PR/branch/restart audit primitives (`audit-prs`, `branch-gc`, `restart-audit`); pair with specialists `doctor --pr-drift` / `doctor --reap-dead-jobs`. Details: `/using-xtrm`.
@@ -62,14 +64,18 @@ Use these as the minimal operational surface; use `--help` for full syntax.
 - Prefer targeted symbol/file reads and precise edits over whole-tree dumps.
 - When Serena is available, prefer symbolic tools (`find_symbol` → `get_symbols_overview` → `replace_symbol_body`; `find_referencing_symbols`/`rename_symbol` for LSP-accurate references) over grep-read-sed for code reads and edits.
 
+## Context and output management
+
+- Use context-mode automatically to keep command/file output compact: `ctx_execute` for logs, tests, large command output, and structured data processing; `ctx_execute_file` for deriving facts from files without dumping contents; `ctx_batch_execute` for multi-command research; `ctx_search` for previously indexed material.
+- Use normal read/edit tools only when exact file text is needed for a patch. Do not `cat`/dump large outputs into the conversation when a context-mode tool can summarize or index them.
+
 ## Quality gates
 
 - Run targeted tests/build/typecheck relevant to changed files.
-- Use `structured_return` for tests, builds, linters, type checkers, and package checks.
-- Use `process` for long-running servers, watchers, and log tails.
 - Fix quality failures before commit.
 
 ## Worktree sessions
 
 - `xt claude` — launch Claude Code in a sandboxed worktree.
+- `xt claude --role <specialist>` — spawn an interactive specialist session (e.g. `chain-coordinator` for tracking epic chains, `pr-reviewer`, `sre-triage`). Coordination and escalation live in `/multiplexing` Pattern 7 and `/using-specialists`.
 - `xt end` — close session: commit / push / PR / cleanup when appropriate.

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -8,115 +8,115 @@
       "files": {
         "beads-claim-sync.mjs": {
           "hash": "a9663671113f8fd540e6588d6825963a0301679bac8a661c9cc35a2d6b474eed",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-commit-gate.mjs": {
           "hash": "84a52001625c569d08cace34fa742338c80c19d73f507d7d308b4cbf3c9e13ce",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-compact-restore.mjs": {
           "hash": "6ed590f3da0725328c9fc5502104bef76ae4acba2643b39771326ddc563fe95c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-compact-save.mjs": {
           "hash": "d83e77e9c88050663b1e7bc3fc9b1843268a0eb7b5c54f8990a44d6fef1f1c5b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-edit-gate.mjs": {
           "hash": "6ad0ed59d6d512881d2e9de33b8abf40a2ee4619e2d9960dcebdfff1b9170e95",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-gate-core.mjs": {
           "hash": "a410303f8c44ac25c72ab7e0f13e6fa3b0a47c2b5ebf13cebe5184695517fec3",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-gate-messages.mjs": {
           "hash": "941cb07e8e649c3a958c0d0604199b4cd105fadf238d9fda449fb41812fc8d9c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-gate-utils.mjs": {
           "hash": "4bd24486e5e6ef65c79fbea6f4fb615b1cf0426e0adbb0ec4d540d609309225b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-memory-gate.mjs": {
           "hash": "c2c7875c85d2e174caceac0b2399dac485d50aa3ddfab5988a0410577b99585e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-status-cache.mjs": {
           "hash": "fe532221f7526eb32162e8e1cd96e3848cb96b1241dfc5f9515ae2c60585045d",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-status-cache.test.mjs": {
           "hash": "59d256d3d906bbb19cded4bfedeb21c763670489728c7d868c2e65eda1fefef6",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "beads-stop-gate.mjs": {
           "hash": "5f75d0dccd724dc30b67a9f964b47c94b457f9174806a4e5f1a9ee21b16e40e5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "gitnexus/gitnexus-hook.cjs": {
           "hash": "d0f88b78c6723d6b6a45dbbd85e37d935bea4461046fd286d658951b16f68680",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "quality-check-env.mjs": {
           "hash": "cb2c483ad0f23b48f5832c4abc62d3490d7e2d79a2ae0f880525952fbcbe3106",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "quality-check.cjs": {
           "hash": "afab38dcba961b566d58ccc5578021827749b749225713e0bbc0bb4303cf09df",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "quality-check.py": {
           "hash": "beaee2b67eeb938a8af5839f910a6c07fa66b8233f7e3bfbb43c36814abf0ca5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "README.md": {
           "hash": "5916b6b480c70dfbe67af09c4c14288f2d7f0397bcb407f9dea070d124f751fe",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "specialists-agent-guard.mjs": {
           "hash": "ef4755858eae64e8a0830d1dcbaa4e08962d9ae107729d4797154acad687621c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "specialists/specialists-complete.mjs": {
           "hash": "bfb398987a2338836ddd4ecf5a590e357c7905a2e81c20bc4e4f6c15c2e7ee4a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "specialists/specialists-memory-cache-sync.mjs": {
           "hash": "2c76e6dea71a0eaf3367656fcd9d0cd7aa5815e3cf87511e3dcee313f467f192",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "specialists/specialists-session-start.mjs": {
           "hash": "44293d88f2c997b70309170b33fc34fa5565910e1f35045163398150bb6e3b5d",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "statusline.mjs": {
           "hash": "bb01a0e5934b68b9ae972216fae23f4c17f11624599149e1e1ccae6725a091f1",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "statusline.test.mjs": {
           "hash": "47a2cc09495ff6fee7c2d30a6f1efafdf2bfeb5f97b87ae867f345dae9020d31",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "using-xtrm-reminder.mjs": {
           "hash": "0d8e7a837cc267544e1dd408341e7daa3f1842500b8ccd2a79a6023fb9e0d1a6",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "worktree-boundary.mjs": {
           "hash": "4a0daf11ca6733d620bcf60f0411ecffd81dfc086a22f84a6a9c5ff452567d37",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xtrm-logger.mjs": {
           "hash": "b39e9e7b48a5585782924b35365004a96c58e10012db6b91f3ca9101cc34f61a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xtrm-session-logger.mjs": {
           "hash": "50bcd95a80b5e2174e9ecc498813917910d31a4cf19d46f44f9534e9004e3c15",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xtrm-tool-logger.mjs": {
           "hash": "e562a304a12561e76131838c6b4a6b34c31b8e792f06bcaa5f9d37fe9a3ede21",
-          "version": "0.10.2"
+          "version": "0.10.3"
         }
       }
     },
@@ -127,971 +127,971 @@
       "files": {
         "agent-docs-maintainer/references/agents-template.md": {
           "hash": "1c1f9b93ad13c2c76245fb13ff9f2663043bc6cc5fb0448dc16ab11cb4001e01",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "agent-docs-maintainer/references/audit-rules.md": {
           "hash": "db39cd9c881b756f83fd27276f183404405983482072b24bb7bd1e7414d5ed98",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "agent-docs-maintainer/references/claude-template.md": {
           "hash": "ea8b5b0d45c5559704b7b2aa0cbfbe38f3c29abf5e4a1ec3c4170e587e292718",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "agent-docs-maintainer/references/stack-overview-template.md": {
           "hash": "afc85b41baf7738f93c561667117b2e287f0a6e63bc83265458a9ed6b812fdea",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "agent-docs-maintainer/scripts/audit_agent_docs.py": {
           "hash": "ffd6ebd0ac2ed3b447672641088fc8d2115d43fcd1b48677d55cdf0d1ef8a5e2",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "agent-docs-maintainer/SKILL.md": {
           "hash": "a80ff7960f24889f49e3a213cc7f5a191319aa04fbecca2fd1681c8323c09f63",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "clean-code/SKILL.md": {
           "hash": "1b212a0a59f8162587a681b16e20af5bd793e4f6c7fb7c7af2d32a7deef553fb",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "code-review/SKILL.md": {
           "hash": "2bb38343f0a377c3a950cb8f11ce618e719628832ed1da276f28a7dfdb9783ed",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "deepwiki/SKILL.md": {
           "hash": "cd0dadf31266cdf2ecbe9c129357133f105078d93e9c714d929378feaf3c4e63",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "delegating/config.yaml": {
           "hash": "74ab621ffdb27c2c4dbf897220117c14dc30536d342c40df37143f0a7727ecd4",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "delegating/references/orchestration-protocols.md": {
           "hash": "010165d814d660116d72e4860ed0bf5aba68945202112de4a31747c1416cd571",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "delegating/SKILL.md": {
           "hash": "bb1c8ed316735afb98d1d5b8f32e07f869091f8a56d079c9a1ac359f8ee67a9b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "deploy-monitor/SKILL.md": {
           "hash": "05235b7db5fa2a150a4cd59964acff8fff23ad17c81e81cc628df985f7df1712",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/CHANGELOG.md": {
           "hash": "a3990e4ae7d5b509d8da9ca0dc08c2837e10db63f04711cb53159817ecf0ed00",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/examples/example_pattern.md": {
           "hash": "1cdfbdbd50f1e125269d5da24b133b015ae3bd85fc04bd29997aa69efafe0323",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/examples/example_reference.md": {
           "hash": "3387c352022798a8496e98980d964505fef6c44a8b3a61fcfdfaf26cd3eb66ea",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/examples/example_ssot_analytics.md": {
           "hash": "cbfe9b274aeb9da9e7a7761c02f99abda359ba6be704d0257d2678a4f712d7be",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/examples/example_workflow.md": {
           "hash": "8bcd40bceee97b1ffeb917dc408a9fd39d19853796fc36d3f18f3003c4de3459",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/README.md": {
           "hash": "780e6a9770377f5a654c178b02ff13c72687aaa517e86d6bbc600cb5fb6dcd10",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/references/changelog-format.md": {
           "hash": "579b44c929cbde7b34726e67d45df260ab5c5ca1acf327b484bd18d4449d8e48",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/references/metadata-schema.md": {
           "hash": "ba7ff3dfe7b8c0c8411d236df7aed2b30b9e45ebf5d80d56f32a9e0cd9bb0095",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/references/taxonomy.md": {
           "hash": "0dcab3a9b71297894cd255530ff18554c267988288fbff3aa33d0cfa6909bc4b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/references/versioning-rules.md": {
           "hash": "e68746671820ea1b709e9419fc8c5f6bbb13d34a4fd1f55e8a2b56238ee2372f",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/bump_version.sh": {
           "hash": "04a81bcd8eab78ec8332f58647152212a9989b9abc62dfebaebf64cdb82c8c71",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/changelog/__init__.py": {
           "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/changelog/add_entry.py": {
           "hash": "c9d2c3d637acbfcb193f05a13a4d67704881f786e4c0291787f6b010abfdfcd7",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/changelog/bump_release.py": {
           "hash": "130414f48399de5e9f573ffd50dbf913f6b52c46ae34bafd1766b84563ab8759",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/changelog/init_changelog.py": {
           "hash": "18547212ea8d8a381f7b079579c95ec116137c3fbbf2216349353e2718486601",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/changelog/validate_changelog.py": {
           "hash": "90a6e225b769e01921d31f379faec0bb95a87d6ae43822c1e566b809bcfebb6e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/drift_detector.py": {
           "hash": "778d44db176099411abbe4af88e8bc0743817cdd6e3a06832964083c31f0a5ce",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/generate_template.py": {
           "hash": "00063dc81497664c39c6f74782db5a0c1f63c11b422e3506fc0a3af451430475",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/list_by_category.sh": {
           "hash": "358f1dda01637caf2599424418280f6f341f6fbf0e7e3cde248b1c9ebe8845cd",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/orchestrator.py": {
           "hash": "e7521584adc9adda5b9557f1b50eb9fc2622f91d8e3cb7d1da559a3d7fcf7e13",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/scripts/validate_metadata.py": {
           "hash": "f694803e069bda7064d67d8fc02002420c205c9126ae7a22b2c9abeff101b6b0",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/SKILL.md": {
           "hash": "39e342ff2edc75f74c5905b0aa6aaa9477285c1d31619821ae0e3e9ad0661b07",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "documenting/templates/CHANGELOG.md.template": {
           "hash": "148a1e54e5b646a6909bd40dcb5ab0a8f0825a35a68fd2449bca51b5f476abb4",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "find-docs/SKILL.md": {
           "hash": "344d9b44f573c1ef28ab56754a9cf6f08cf4521fb95babbc2e509be38f65333f",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "find-skills/SKILL.md": {
           "hash": "54b44dc9539df865fbb060f62fb062e8232e765852a0cf14c38301fe0c1eb264",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "github-search/SKILL.md": {
           "hash": "1d49ba782bf2efde90a3896d0a03e1c79ecdbab41d89bf881f3c75a549af523d",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "gitnexus-cli/SKILL.md": {
           "hash": "e28f79d4ea2473efa0f197611a75bc25428fb4296aeeb54d1e31de2e39ccd8ad",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "gitnexus-debugging/SKILL.md": {
           "hash": "4a1e82aa835c52e38227d853c20ef05ea33be1dfb6aa6511474d15357f1d3f2e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "gitnexus-exploring/SKILL.md": {
           "hash": "ffafeaa0ce52be079e4d4b3a48c0a166728c009380a243c394c4e08f728527bb",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "gitnexus-guide/SKILL.md": {
           "hash": "40b047beeb9a7c5d47f17426b4061d2c2562c85c11288fa7f8da376d910e4f91",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "gitnexus-impact-analysis/SKILL.md": {
           "hash": "a4d6e8003c4a822c380b0e81b2fa0d642612236c734a9d51834e362c4be52f33",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "gitnexus-pr-review/SKILL.md": {
           "hash": "f7bac200a4752191d2e3aa7a2273720ca436d25df88cb2ef48dc19f92ae0934e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "gitnexus-refactoring/SKILL.md": {
           "hash": "6aab994ee0266063245245483ee3280645aca66c0c5e56730ffad3f32ecbbc5c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/examples/load-context.sh": {
           "hash": "0d614599e711c087b381a4ac7ee3c40758af1022669fc998649d199b9dfe15ed",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/examples/quality-check.js": {
           "hash": "a1f6ebdf11f2fac83116b20e5c66b8e0ea515395edfe7ec156cfeae4900329a9",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/examples/validate-bash.sh": {
           "hash": "348c58f4cf38a2e7080ea5272935a7658c7122d83dd6c52d0a1f2ef599c176ab",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/examples/validate-write.sh": {
           "hash": "89a8ef9bb7508e4819080e65834d6783afa5a5a614d458a3821b80a329eb32e5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/references/advanced.md": {
           "hash": "dc2ce5a7777ce5cb6ca4256239fa509f75f645806e1fa15e03594c4b970d2086",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/references/migration.md": {
           "hash": "7f8e7a795829837f46a0c058c26c8f5c4aa8be5c9fb5316b828229d1802ded77",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/references/patterns.md": {
           "hash": "d5dc513af7756dff436bcf5fe09ee4d9a87dfb7d410b83029c64492c90da377c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/scripts/hook-linter.sh": {
           "hash": "85a7d55488f8f38f9b98350b5cb597fb306432d5e61eaa3444e7226ca9309e0b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/scripts/README.md": {
           "hash": "08a28b12ffa9fcb16f257ea685c70a920f4f835978b9ffbbac055137c6f6aca0",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/scripts/test-hook.sh": {
           "hash": "ded642e811b4731f6a2c90c73b02e00c937511d9ee65236bb8cf9964f0069393",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/scripts/validate-hook-schema.sh": {
           "hash": "e7785d6c61d368f5ea5270c979753aea02f776f5b6aa220137ec4585abd720c2",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hook-development/SKILL.md": {
           "hash": "5d2c2d85e7bbe091ba394817f4a1b200570e259af765131440f80f270b7fe0ee",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "init-session/SKILL.md": {
           "hash": "861e5134c41aba3504374cbb522d225b8bdbf065e352009fea11a89593e0040e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "issue-triage/SKILL.md": {
           "hash": "73e69f9611bd5b4cc11c68a27de0cf5c37f49ed769c3d0ad32ed3fa6aa6299da",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/briefing.py": {
           "hash": "58c895621b028f3d265dd4a98d2ab8169d2256c468bd73e6dd3adf765dca2e67",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/evaluate_search_quality.py": {
           "hash": "8f33a48768936091df02aa4d3746576cd3c3e935d93d109607404ea801b8152a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/evaluate-synthesis.py": {
           "hash": "59ee7918109b96dc2668412ddc02e9308ebb94b522bbaa5a2b81b3e3849bf7a4",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/generate-synthesis-inputs.py": {
           "hash": "5382064ea64f04ee0a1dd1e5a284487f3f1a5a940854129d8745b197d077a7e0",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/last30days.py": {
           "hash": "7259e3ebb0b8d71ef711ecbb822ff86d718b98fdf9c0d5fef7f1c2ef058ec23d",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/__init__.py": {
           "hash": "3fb925405f898201188f9b5eea04e214ea8c8a64643397fd727f08ffeea234d9",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/bird_x.py": {
           "hash": "12f3ea370143c74ae1e9294602f3dccdc20ebe9ad725646c56947530eee20480",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/bluesky.py": {
           "hash": "271837db1fe14acbd5a9645f84570bf15ae6332786ad067e4fb7e9a80dda39eb",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/brave_search.py": {
           "hash": "8d7d8a5d4a5a53ebbbd581af6259570752e0c9face7f154d7a68a92b28614b7f",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/cache.py": {
           "hash": "2ff8a3fb3fc24cfe1eb543d82c29ef5565f2115af1822033d93abeb6e7bf6904",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/chrome_cookies.py": {
           "hash": "f1d2555e0ea2cbb3d7be61764e83755d3647a7f9f4a322ffc1f254cbc0469491",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/cookie_extract.py": {
           "hash": "a28ece47b1eee31c19ad375613482b5efb155df265304c4deb3a5c1b5de3e0fb",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/dates.py": {
           "hash": "c5b1f01dd4e28ea385cb5a0b10259cce7a642e308575df12424242d3779435af",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/dedupe.py": {
           "hash": "270aaead1c61341a24a003760afbd7727178d207316b403fc3fece99feaef81a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/entity_extract.py": {
           "hash": "cefa39feeeea8b9d4a37abb10a5c1d0693abec19cf51d7fb565a8f5d620a7cf5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/env.py": {
           "hash": "f880066eeb524ab51121174885920de7e47d6763ab91265f1e0fb19a45750a8e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/exa_search.py": {
           "hash": "fde043d73366d7a7d7a9cb53d00e1ae30e09643842d218109b1ab31c550bd63b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/hackernews.py": {
           "hash": "d59d4bd21a11f32f85584a22253e9c2aa0e3c0b840b9eecda06b3d8d03f49ce3",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/http.py": {
           "hash": "adf7aba56fe9b478ee5c6d226eb0248e4ebdfb2d025edaeaa8ab45e6cd16009c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/instagram.py": {
           "hash": "aefe19ef7db5f7ab8c74f2e5bf5ee082cdeb7dfebb4a0979d25109daf85f7fae",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/models.py": {
           "hash": "639c2b5fe58d241fb3a9713e07748e0034526c68ad55082fff64be54cca1d16e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/normalize.py": {
           "hash": "dce13bb1378ced07c5f1afeeb51ba05a6250928da8935e610f0fd70b96ad58fa",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/openai_reddit.py": {
           "hash": "baf706ea08b9b839f95d1e14079db65ba06cccc30abbd9fe897c3a9efc047bae",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/openrouter_search.py": {
           "hash": "e85b2e57370c5903f3b02ef766ddcdad469be61ce59f81754ae6f4cf2ada6743",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/parallel_search.py": {
           "hash": "d04fda409eb0d29843bb596e889343d90b842465074fbc53950939323ed35a04",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/polymarket.py": {
           "hash": "940531d5cfd6196d9b39d3a49e25103757d0a2a4b8a84fcf4d8703c75db4884b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/quality_nudge.py": {
           "hash": "b3865cbb343d64fcc89965af93f41f8015ee6df87759ee14118e2c8392ec6bcd",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/query_type.py": {
           "hash": "021073dc45df000ff3f6412aea82a6a3c33de2f732bf1b0b7b23390db02c6b9e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/query.py": {
           "hash": "6bc2e0649034cdb28471346a66e2448ba58762cb7774c4fce45c055ab160912a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/reddit_enrich.py": {
           "hash": "74bcb8dcbabb9a02a3b69d263575adcb0b2e18527498ec06dc3b0a0e1c8d829e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/reddit_public.py": {
           "hash": "8c18f9a7896b167377e86f0125247dd823cd904512808d570e0da48ccd4b80ce",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/reddit.py": {
           "hash": "aa22eb72e74753f352f4b638e032d8a737f1696f1bd0e6875ab2b4b9886059cb",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/relevance.py": {
           "hash": "730d86c3e205932bfe6edf82e20ef133e5083ad07eb3301c403011ec327e52b4",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/render.py": {
           "hash": "612fc920b83d1e37a97901b78344d26c324fe657e777cc7fe158d08a80193598",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/safari_cookies.py": {
           "hash": "398f6aee95db4f68a0de2e5525295096bbb572f9c22b37daee8d296876d853b6",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/schema.py": {
           "hash": "d5621791a78572bb4a9c987595f0fa71d7853603ee808f155d05cd1d46929d7c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/score.py": {
           "hash": "1ec2712fea1f7f35a81c3d021bd506d5fbf24a96e07610d2defff5602472a285",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/scrapecreators_x.py": {
           "hash": "5e0946e7e4733a8647e0e3aec85e658ad270b62e67e7f4b500a68850b23be0bd",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/setup_wizard.py": {
           "hash": "9ea739515d2625220b616cdb21f84db3993990e4b11603f06eff7fdd74b70f85",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/tiktok.py": {
           "hash": "d6aa2496efd92f278d8a21dfa047276d76b65f30caa4e3ed6490bb887bfc2ef3",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/truthsocial.py": {
           "hash": "5383b161aaaf8508e15a915125368c291e41e02fa35878f3ea737e54ae18ba03",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/ui.py": {
           "hash": "a1267ec37871f33125c5c83d52de645167158044785178f9f87bf6464404b4c3",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/bird-search.mjs": {
           "hash": "428bb621c7f28eb00c59d5cda6ada9d834f53e4e106ca8f812b95ed8d92b6342",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/cookies.js": {
           "hash": "caf52fa2cf9a6ee730f50c192a01fa7a2955df9147676a7f0e96bbebff5e7644",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/features.json": {
           "hash": "36361f4cae0040255f84709459ebb1f0131566a567269ed7b99d073cad930f66",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/paginate-cursor.js": {
           "hash": "5f20227de1d68250ad59b7ad593db4bfb1d0f1a21694963eab3ed413c2d0d5c0",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/query-ids.json": {
           "hash": "eba47a9d26f87d0b4eb8a4f554833ed8d11b3d8728e363deeae702d09f87fc02",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/runtime-features.js": {
           "hash": "f41614d62b6c91dfc85fc4af389e6f49435324bf26460b715a991486609579d8",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/runtime-query-ids.js": {
           "hash": "0f5c61dbaad3de7fb44a14c57ed005228e51f9fc361472eff59bff4cb2a1199e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-base.js": {
           "hash": "ea972b7894458e78edd1927d102a052ae45726a7c967b376ac7f5544f5b65499",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-constants.js": {
           "hash": "27bd1416ff1f5d4f4516d784a8fb9ee08a87413f07b375752821a32e5b0cd6e3",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-features.js": {
           "hash": "4b4f2048069f751a821777cb2084f3b9126d99a958494fef71f0699d8145c4dd",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-search.js": {
           "hash": "3dfbe18ea54215d9a6393ff0884d9977dd9ddf0884a06486bdaee8a4e30d4616",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-types.js": {
           "hash": "6450f74c664db958d703e09288184ef1ca5f622782f9e11a5a9bfa3d3c78c534",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-utils.js": {
           "hash": "b230db5583760ccd0b5b5fb1592f449a7d0bc92f6184808e8ffb6f8968df20e9",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/LICENSE": {
           "hash": "62316704df7426e5a79d2827ff8aca36e9abb3a73b8e68557030749ebefec667",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/vendor/bird-search/package.json": {
           "hash": "96b65305969a179ee7a7735f1b475599d6035f32fda1fd030ea57ee09380cdb5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/websearch.py": {
           "hash": "e613d0f484878309824603a09baf3c4a8d3e20d16a6f67079cda1167bb9a0858",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/xai_x.py": {
           "hash": "7ff1a0987e0896ecf150731c2e995788d1e9535295461acddc9cf998534113c6",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/xiaohongshu_api.py": {
           "hash": "c7a29dfa03f871993dc13a8ad528beed8a648102404b658242ca57878077ef60",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/lib/youtube_yt.py": {
           "hash": "239dc12d68103b05803da5d2dc491b6611d24794aeaab091a725c47bb90bffab",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/store.py": {
           "hash": "eca9d7870804cf31c535a08d7c7391a2f16f4bee5fc533cb7bf15b01e9912cdf",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/sync.sh": {
           "hash": "81af533d0e438994ebc0ee88dc8526264b52fe565e05f641677f62c66be8ff15",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/test-v1-vs-v2.sh": {
           "hash": "01013eda215cf8979ceac30e6ad2ca54da2f7669faeba67640793408825a1a40",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/scripts/watchlist.py": {
           "hash": "2c03ac8e72e07a917bdaa413080bda3c8a3eaeadbf9f55980b9048b76a4c19cd",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "last30days/SKILL.md": {
           "hash": "a437a67e7ae741b2ceaee35740a535a65e8f8aadf14d479d378616c7ccc46232",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "multiplexing-team/SKILL.md": {
           "hash": "ef13a2f6d9d15298edced8e8ba74037f43891408cf21396295d9dc2795203913",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "multiplexing/scripts/verify-deploy-applied.sh": {
           "hash": "a7ed4ebeafb4c87c9c6870e39ba5de0db737bb85b2261eb76480d96b70902f06",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "multiplexing/SKILL.md": {
           "hash": "0d2d4588259299f4749204f93f9c4d1a6519e1f7f2bfa988d43e5a761e290a79",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "planning/SKILL.md": {
           "hash": "1483058d23b4e3332eaf36b05107dc69edd5e9110c163abff75d8415f7023cc6",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "pr-reviewer/SKILL.md": {
           "hash": "858562aa02a3d9b0c754580d48016f1243113aa1e7bddbb48f3f1a70f81dab61",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "premortem/SKILL.md": {
           "hash": "25890f164b64076865f504c943b3890ebd73140f16c1f54726163ddfac709fc6",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "prompt-improving/README.md": {
           "hash": "3eaf7f7249096c4892b4cdadf0c67fb978d65efc92572376fe30fcbe34f3a467",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "prompt-improving/references/analysis_commands.md": {
           "hash": "ad407c4b5eafada95bb6b732a13f65ebd36ba801a8f1717150d16b8dfb6b4ad0",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "prompt-improving/references/chain_of_thought.md": {
           "hash": "31e8f49ad40d011eeee7a407aa8b4c45a8d44327cbeadbb7cc09ca585562fa9b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "prompt-improving/references/mcp_definitions.md": {
           "hash": "44dc479b19955b63fff86be354b880b081310759a43d93f99b7d78ec5ed7375e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "prompt-improving/references/multishot.md": {
           "hash": "b1fd4a0f8b7b2cf96ffc3d14731ad1274966866566e2d1d8f86c58dbd93749fd",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "prompt-improving/references/xml_core.md": {
           "hash": "d4c8115983056d595da2afdeceeb3839c688087ed2ddc05b1516a70fe97284fe",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "prompt-improving/SKILL.md": {
           "hash": "3eb21391e4512e6dfa47051159cb6f68d130bba068dbe5b6b4744c422ed18387",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "quality-gates/.claude/hooks/hook-config.json": {
           "hash": "f29b118917ec714bfa2dfefe478ea512f84b8f7ad80aebf647011b22d18a2717",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "quality-gates/.claude/hooks/quality-check.cjs": {
           "hash": "c6bbff2b05dcb810a5dc7437104a253398ef162b4a2403ba676ee136fe698dfb",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "quality-gates/.claude/hooks/quality-check.py": {
           "hash": "b46e1361dcdc0b41401c3a2b5872356391b2bc9877c4a72c058bc158eee82118",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "quality-gates/.claude/settings.json": {
           "hash": "78922a784ee78e9e50587e93628cd3b9d4dfbe49087adc4514e6781cea38cbb9",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "quality-gates/.claude/skills/using-quality-gates/SKILL.md": {
           "hash": "0570f34a7fbca7f4a53fd751503a78152401b0697e95baf06bf1c221b1000f83",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "quality-gates/README.md": {
           "hash": "f161db6c1c6b6cea904057bb89dba559d8518d8e1bdbba7838a343162c4e6cf5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "README.txt": {
           "hash": "d28484cda62e8712fecbaf0fa8871d4f72fb7188557e5bc362caca79ef72cd45",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "releasing/scripts/xt-reports.ts": {
           "hash": "34592dc1bdc2207330270919108b1b89f08c85736192d02d69171249a8898f5c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "releasing/SKILL.md": {
           "hash": "7a128078b5bbfaa12c1c2b2ed7d993e8264aa2431747a972cd50b5f680a5ff35",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/scripts/security-bootstrap.sh": {
           "hash": "344b9be1ae5d4d7d83eab1e07ac583f262d73badbbad1b534182bfe806c64619",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/SKILL.md": {
           "hash": "cfd328ce7a831270a393fcc12e0a0645d2dab101eb81cde0ac4c7d599e13c90f",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/templates/.githooks/pre-push.template": {
           "hash": "71e86abf117b91ed38b8231eb663b4aca4a028ea9a875bdf77b57856de721b80",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/templates/.github/workflows/gitleaks.yml": {
           "hash": "02ecc97f3ae2b360e574c9d47cbc40651f47b17d611ad8cdd84f3988b4d06b87",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/templates/.github/workflows/osv-scanner.yml": {
           "hash": "ad3b92c911957b96635dcb63e2f094b34bfa23fa0d5230f39199dd297851fd7a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/templates/.github/workflows/semgrep.yml": {
           "hash": "75abab6e7aad57a4204fcc0202568e03f8526ca4fcc7f685c067839cd37776f1",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/templates/.gitleaks.toml": {
           "hash": "e6e95082ba3660689c2020d2fc26093b751df158409dbaf96a816ac4c287038d",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/templates/.pre-commit-config.yaml": {
           "hash": "6ede8e2c8a509e15236003d53773cd7fd63021a4f01f4ea9ab80a0ef550f7479",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/templates/.semgrepignore": {
           "hash": "5bd16c26cbf023420e86387b9d266785369a193e75ba396cfd807e3f2812cf6b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/templates/scripts/security-scan.sh": {
           "hash": "a5160b0954989eb11adc69c316acab5fc19cf4727de505e1cbb1ec679be80434",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-pipeline/templates/scripts/semgrep-diff.sh": {
           "hash": "e4efc20d218e6f6689725a4a9aca37958384216ba080bf89ba2307cd529d6dc2",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/install/git-hooks/doc_reminder.py": {
           "hash": "90d33305dcc8fcc73bae2f9ad7390be118617743dbb38808d61710dc1662879b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/install/git-hooks/post_merge_drift_sweep.py": {
           "hash": "39d6f4e0afe7946636e47b2877cfc71afe6589b7ab045f86f0f739a8ccc886b9",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/install/git-hooks/skill_staleness.py": {
           "hash": "39d1ac16dee329bab34a646216e2d851856a07d53f6c0f909709fe217f2ba22f",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/install/install-service-skills.py": {
           "hash": "e89bc2fd5fe9cb463f9e56360fcd5f8994479e5fc665044af76404b1ddc3eb29",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/install/service-skills-readme.md": {
           "hash": "95d31a8ae4241255c988d0aa35009070b63ac08fbf31e2cb8025e05f9a8ed585",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/install/settings.json": {
           "hash": "dd832d6f054bda8e82b389b257d923944761f4c28d09ba8b28c7e7196784a657",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/references/creating.md": {
           "hash": "6952c0d0f98f91fa7f3619d6db0925f4d628c583fb84997bb2c87aa05d777441",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/references/routing.md": {
           "hash": "69e5d873bb35bf680cdd568c65963fcb72ee1acc7cb9d86f395c37d8edb8e515",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/references/script_quality_standards.md": {
           "hash": "964476a17aea08505edddae1616899ebcc9f6f1f990e060cf37c1676a7f54b7c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/references/service_skill_contract.json": {
           "hash": "8df02e365d539651f4cff1f8999407c1be2c5a2f895a9f14c9efc65af87855d5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/references/system-guide.md": {
           "hash": "3f07f08f740ea5d3261c1d39f0942064a84a0e40a67a1ccf130cad96f8cbf6da",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/references/updating.md": {
           "hash": "a6db70b6e91e405827e9c31718032a68571d3b38f8932605d7fd1ef089bc7e50",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/references/using.md": {
           "hash": "b6876929a55c7c326d0214b6f06afe2967373e01826bef370bd1d97c19cc5662",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/bootstrap.py": {
           "hash": "0fb9b2dc142c54bf62abaeb80d92aa61491745ab77ba2bd0576950a603ef7016",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/cataloger.py": {
           "hash": "764e7e2684b31ad674ad3d2b0f2b430bbd8e2eef0d513949d963d82e3c508af1",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/deep_dive.py": {
           "hash": "fb28936c7c690566960b63bab419a54588fe55495f009da00b5b153e77f42597",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/drift_detector.py": {
           "hash": "23e805110571cc7c9527259044d5d1c2728aae225110ff1d83ffd50bdf464aec",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/layout_migrator.py": {
           "hash": "c14712c262ba5c5b6bc33fbce759a33a8b0e61632d2382d31107d5a18cf287c8",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/reconcile.py": {
           "hash": "735416ab8c1198ea2ed9941732b4c1b23de02de9883e1bd7ca0511edd30a3da0",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/scaffolder.py": {
           "hash": "07071c8a14b5dd493e095dbba3db70e93a4aa73ff9180811f91480d33c47a384",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/scope.py": {
           "hash": "2f0f5a4d6f4af4a93e3a4fa5db18e32f5aba87743bafc0105905cccbb2f41cf6",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/skill_activator.py": {
           "hash": "b76f7861dacf302f9d958202e8dd60bf54ad1265d098e5f3072423beac0a25a2",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/skill_migrator.py": {
           "hash": "d874fbc829e4da6c4f47526f9d2f914aad9d3e5e1c1a51347b2b38c0211e3c29",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/scripts/umbrella_generator.py": {
           "hash": "842890132fbb5f69c33bf2f5b5f51291ca8f931afce034426724959b15ad71fd",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "service-skills/SKILL.md": {
           "hash": "ca9d1e2ce74b69f2cda6d71995674bcd5f0454e16fc1d6c20311a419fd6e5d30",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "session-close-report/SKILL.md": {
           "hash": "98c170dded2b9ec88e2f38da6cb99d07b40cda7c0df5cd9b8e176747231e9d2c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/agents/analyzer.md": {
           "hash": "bf68f4cac5a56c673a928c2e6d619586c5b93ea364026ab37547772cb45a663a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/agents/comparator.md": {
           "hash": "fe1fc9787c495d864c5d6eada47396478572325fde1b33a96d78bf4b849b7a3e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/agents/grader.md": {
           "hash": "57134da0c1a4eea33fbd74a1c9c44aa814f07d6bc64de303edb586f941e5d21a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/assets/eval_review.html": {
           "hash": "ce477dcc74dc1c0d1d3352646a79167b5a63634e936b1019160025065974e452",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/eval-viewer/generate_review.py": {
           "hash": "fc9d1b9243fe5ab6012ebd579bd76d0035de1b79fd3b969de114defab26478fb",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/eval-viewer/viewer.html": {
           "hash": "a53213426ee1100441d701a3a0d49cda7a842f992d2c36463f4d3cc0258575fa",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/LICENSE.txt": {
           "hash": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/references/schemas.md": {
           "hash": "8e8876180a8989b406a4d3edddf875b04cdfd5805cc8616686d552b11ce4455f",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/scripts/__init__.py": {
           "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/scripts/aggregate_benchmark.py": {
           "hash": "123ef128ea5ccc01a4b1ac212ef5567f21e9c13d3d240609780beeb3200c49aa",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/scripts/generate_report.py": {
           "hash": "13df7118a3c50c83c4c3250a606d5f2b20b25a3d44cbc392b3d669ec75281453",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/scripts/improve_description.py": {
           "hash": "0dc43232db7ac6361775c894f4a1dbac958cb510c51a1230ff9e7fb30a74a7e8",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/scripts/package_skill.py": {
           "hash": "1a33059b0db1ef73375d46d513e5ea81369d2e8838c970597b0d52ddef8d1c0f",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/scripts/quick_validate.py": {
           "hash": "67cf5703402013936c8fb75ad6a1afecd8841d45cc5e606b634eb05825fde365",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/scripts/run_eval.py": {
           "hash": "43e3b8f80dbf69c343967ba77e268fae991d9fa3ed68b32a0ff02532cd48657f",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/scripts/run_loop.py": {
           "hash": "bafdb8e25c740813c735c54bf0489b9e87146da4cf697265927513c5430112d7",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/scripts/utils.py": {
           "hash": "3af8ae62c40c73ab712207436a0d9a981e845f25c5a7040229eb189cc8e45bb1",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "skill-creator/SKILL.md": {
           "hash": "ba8bebb2c085444120743af8dc859dd7c2592d6290e93aa5e1c08403109bdce7",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "specialists-creator/scripts/audit-spec-uniformity.mjs": {
           "hash": "0ada06784cfd5c3adfa9c9908a9cd23380e8278fb57329fc616a83140a47fb33",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "specialists-creator/scripts/scaffold-specialist.ts": {
           "hash": "c1bfa3693d644072e6d387d2519e131624d99c5b85521ae638680d7485267403",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "specialists-creator/scripts/validate-specialist.ts": {
           "hash": "3a5f5a3a77c50e98ecf9188634ff2882f8143b19d0f28a53aff5c42e1bd09dfa",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "specialists-creator/SKILL.md": {
           "hash": "223ab14dbd1c2443f147600691819408faed9f13524d485c0b99394fa84e0981",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sre-triage/scripts/alert_history.py": {
           "hash": "b33d60299ad2995a213c0147cfab375ec3bce5a86ad8a8c2e6f4ee2a5670b43c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sre-triage/scripts/alert_investigator.py": {
           "hash": "24b79c241cb629bd1ee964db9e5d5762cc1e12dca97e31204d4a3de864501695",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sre-triage/SKILL.md": {
           "hash": "b0d2b3c662064845d4810bff0720ae60f7cf9fc194662d5791e207af5692f608",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sync-docs/references/doc-structure.md": {
           "hash": "bd30ca7777262b582c95d72a9507ad307aad21b806594ee98d855449763a6247",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sync-docs/references/schema.md": {
           "hash": "7429a43169df08d97706833119543eda6e10bd943b3a52b399c24b7561c7b75a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sync-docs/scripts/changelog/add_entry.py": {
           "hash": "c9d2c3d637acbfcb193f05a13a4d67704881f786e4c0291787f6b010abfdfcd7",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sync-docs/scripts/context_gatherer.py": {
           "hash": "52a709949eece660ffd34fe809014b7114dffa986207d9097abb0ffaaee647fd",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sync-docs/scripts/doc_structure_analyzer.py": {
           "hash": "313c99ae326909892aa64213b7720a8bd5337bb1b02b6badc8ea53b3cea29cca",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sync-docs/scripts/drift_detector.py": {
           "hash": "967ec2320810e07388338bd59cd3a0066dd5f238275a38a01734ca86d4ef6d06",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sync-docs/scripts/pre-context.sh": {
           "hash": "b1c3ca39b1a05429b9436a287a55c06cb026e44a063783d6e449b56c617a79f4",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sync-docs/scripts/validate_doc.py": {
           "hash": "f46d547103964f1b462272bdfd462e68167cf71ac0a374fe4d0c3dcceba1ca75",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sync-docs/scripts/validate_metadata.py": {
           "hash": "8f85d3de0d78541a056a32400b0a0c753c277e73c6462492aa44f1723ff62fa2",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "sync-docs/SKILL.md": {
           "hash": "ebcdfe1f4d8e752e1a594ac32fcac2cf7d7817f65202b90fe4d58b266cf8fd33",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "test-planning/SKILL.md": {
           "hash": "6b2d56e6e8daa277632798877ddeeb659053c3d6ffbadc9f580a51fc3fb86205",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "update-specialists/SKILL.md": {
           "hash": "fdf8c680cf3e5dce80c9426f52b56c953f4f7f663c23a33a3378b2b6e4bab5a9",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "update-xt/SKILL.md": {
           "hash": "ef48ca32b8d9add09aaaed14ca5704e967d2e9a86f5d9a4310bf609f1db89754",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "updating-dependencies/schemas/dependency_update_case.schema.json": {
           "hash": "2f29b206593219548c7b8481c3d1d041861bc943a383e6ef15dab1cd8cbb2827",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "updating-dependencies/schemas/upgrade_dossier.schema.json": {
           "hash": "19486d8b0c9563fa63d389e66b2b7df2876e7a0113b9302bd44bdb8ac649de12",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "updating-dependencies/SKILL.md": {
           "hash": "0121ffef95ea24ef4dc3edad69d3e8d5b42d2e53b9928bbee6c54d3cc101b4f8",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "updating-dependencies/templates/post-deploy-watch-spec.md": {
           "hash": "692e1f6bb929888ca89284a14d2536f133edade463c9a773f16b68d9bf2f50e6",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "updating-dependencies/templates/pr-comment.md": {
           "hash": "bd87a587dba75c7fb231fb931f51270720680af5a2de29b83f08b3593dceaf61",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "updating-dependencies/templates/research-matrix.md": {
           "hash": "967b63ac9f436528babf2216d64e3cfa075f6c2f2126b4561f345d5bdf81855a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "updating-dependencies/templates/upgrade-dossier.md": {
           "hash": "425edebf079810d359e72643ba8820a62beaf7bfd0051e4216e1dd5c56354815",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "using-kpi/SKILL.md": {
           "hash": "dc22c51783b5bfb787c5bb10f46d3585151a33a3486e76ae38e3f43fb09f03bb",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "using-nodes/SKILL.md": {
           "hash": "742e9d2ad512a05c86855b88ae65f9065370876d9e7c1b10db2b68958248bc7b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "using-quality-gates/SKILL.md": {
           "hash": "4445e363a2930b8d233d79028eff3759dd90eed031a68f1ef6295fc5167fda93",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "using-script-specialists/SKILL.md": {
           "hash": "e87511d685eb7bc95c374641056194931a9da79434b624fdfb2805bd9dbac7b6",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "using-specialists-auto/SKILL.md": {
           "hash": "932f4248cd4a8bcece747bcc08c6e0dc775126cbb83aab5318e1ea82dde09686",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "using-specialists/SKILL.md": {
           "hash": "b1172e9405f6c6d2c9e8fdf2f9b53404d73467b83e4fabd64403baf981fd60a3",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "using-tdd/SKILL.md": {
           "hash": "e584b6fbd0f46fc0bdbf03daafbed874cd4fb02dd585402086bbc3b043bfc1e5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "using-xtrm/SKILL.md": {
           "hash": "9c70a5bb517d534011c7a0f79be81809b428a30e342847160dadeecf0ef9e8ff",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "vaultctl/SKILL.md": {
           "hash": "fe4e5287982be10acc2439727b4b8add7052b037a7c67fb48e7bcf214cc54214",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-debugging/SKILL.md": {
           "hash": "c9ad86ebe685530c92775f28cdab360936617e7dcefba21e054c7a9f0a9ec9aa",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-end/SKILL.md": {
           "hash": "d0b6c9269c04e8c07b5c10417f0927cfcb80cd64e8c39d45b35c056591d8f768",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-merge/SKILL.md": {
           "hash": "4e99071c17bc5a408025328592e3d06a9e4cd1d816a27ef8237eff24cb26473b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         }
       }
     },
@@ -1102,283 +1102,283 @@
       "files": {
         "architecture-design/architecture-patterns/references/advanced-patterns.md": {
           "hash": "e1cb31c83b532e579991de277836a1ea5e3d88b2ca30fc8ac16f6047ceca439e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/architecture-patterns/SKILL.md": {
           "hash": "c53973f453ec828c4761921952acadaa933f3d8dd01eace6102f8c5316cf643f",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/PACK.json": {
           "hash": "bac39ce1b4d51e3debf29337bcfdf9ab76466f6e9bf8459960df6c0d0c61b7ba",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/prompt-engineering-patterns/assets/few-shot-examples.json": {
           "hash": "8e1ade9727b0bb1fb5540a781192b67e2692fbb5908ffe9eac3ec7cc2fbc6216",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/prompt-engineering-patterns/assets/prompt-template-library.md": {
           "hash": "c5756b6f9c5558d8ca82d845fd50492b53f1f4d6d02cf27585f411440a4723c2",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/prompt-engineering-patterns/references/chain-of-thought.md": {
           "hash": "41242eb267f1892430bb0001e1361c862cc98f1eafc958280d485cbee7c13e6d",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/prompt-engineering-patterns/references/few-shot-learning.md": {
           "hash": "d8784634f7beb4c60c51add45203ef2d9d0e4e3accbb81ba3295f87d893dba10",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/prompt-engineering-patterns/references/prompt-optimization.md": {
           "hash": "5c25ad9b49045ef35c55b531bd227f04628b0018080b0d4f05cb20b01b44ee41",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/prompt-engineering-patterns/references/prompt-templates.md": {
           "hash": "18db56a32be1639072631f0f7256b153acd678fe6092edad23b2a4a44016e3da",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/prompt-engineering-patterns/references/system-prompts.md": {
           "hash": "88aa10639dad981b07f3bba05539c4eefcc5fba5ed255c60eab0df238778e000",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/prompt-engineering-patterns/scripts/optimize-prompt.py": {
           "hash": "e2bd63207f0b6ed40944d8bb49311e0c97babb40d0fae974580c2dd3be99a671",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/prompt-engineering-patterns/SKILL.md": {
           "hash": "c455dde62511e04c420824be5dd5e516ab34d07842019dd7be2c9b41ca1e46bc",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/subagent-driven-development/code-quality-reviewer-prompt.md": {
           "hash": "06d1e7c2287e5a00bd1809bf39038abd5f413b4cf917c37d30f00c48f6293421",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/subagent-driven-development/implementer-prompt.md": {
           "hash": "a416193f881e5a712c988fffabfe1d5a97bffcd091eb95577c84fe2136588617",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/subagent-driven-development/SKILL.md": {
           "hash": "081ad3869e55c80bf8f890b4768a90c0e8057daf94b1b6fadebfc85ea5b8304a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "architecture-design/subagent-driven-development/spec-reviewer-prompt.md": {
           "hash": "631980e472eec5394de8b89b69d432e54fd3f7f523ecf9afa7eb4cda0c9b2baf",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "code-quality/code-review-excellence/SKILL.md": {
           "hash": "014fff1c8db75807106484d5b16451607f0dde266ae50182a2753d68ad3449ed",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "code-quality/multi-reviewer-patterns/SKILL.md": {
           "hash": "30a8e067af085d6ddbf4f3775b212b0b24137ecc431a3e8570e3d6a09823a62a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "code-quality/PACK.json": {
           "hash": "88fdbfb573fd394ac9d391be98a7c6bae176a7cf6fe8681ac85a0341361acbf0",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "code-quality/systematic-debugging/SKILL.md": {
           "hash": "4999cb851360485eca5074e727bbdd62ef20549c5d5b01216fcbf5831badb473",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "code-quality/verification-before-completion/SKILL.md": {
           "hash": "ea52d15aabaf72bc6b558efe2c126f161b53961090ddcd712000273bfe8c7b6c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "data-engineering/data-analyst/SKILL.md": {
           "hash": "144e82457e8861ae540138f9d0168e1eb7c56761bc8db541733d448cb7cb3e1e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "data-engineering/PACK.json": {
           "hash": "ace1268e5c066b494112cb2ffbb976df7857526a294b4b56d5ca86182a44d938",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "README.txt": {
           "hash": "4eb5182b790a60a7826d625348b69203156df899cd0776cc0b8fed3e95fbd513",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/academic-researcher/SKILL.md": {
           "hash": "93334b34a735942fcfd66a4ddb02df13eea639864c579b47b356c9ad5d67d4d3",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/brainstorming/scripts/frame-template.html": {
           "hash": "fb22ba9d47f3b83b56e0a95d52a3c2727db03b0d4365078d92c850293a62457b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/brainstorming/scripts/helper.js": {
           "hash": "e763d82f32b4ebb320be2f0d08449d3e5a0585778edf5c407c1fdab3f39976a5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/brainstorming/scripts/server.cjs": {
           "hash": "ea81185f581897c67d4b417eeb9bc7a158c50e0932c73047054fe53efc2683ef",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/brainstorming/scripts/start-server.sh": {
           "hash": "3442a54b5ee5511637d27bf696e092b72f94c2324f40b5ba4410da4dd0c23bc8",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/brainstorming/scripts/stop-server.sh": {
           "hash": "f65b7634a27343eab2086bdb6c59ba78695685f471b5a577b08a8817f7c50600",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/brainstorming/SKILL.md": {
           "hash": "bba47904a7f6bbee3bf8a107ebbe84e65d392be683bbb898ded736b29e415f90",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/brainstorming/spec-document-reviewer-prompt.md": {
           "hash": "12cb5ed58aef41b8da6fbb505547c71ca3f5658c83b66ca6e556c936308b3189",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/brainstorming/visual-companion.md": {
           "hash": "a2bc6fc47d0df1df981d02f707a16225b147f462e7059175ad2bc5e6dd29fcae",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/deep-research/SKILL.md": {
           "hash": "5637feab59dcc091d307fb0881907d9dfae74d3eccdf51b9bc8acf879c28c682",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/fact-checker/SKILL.md": {
           "hash": "2a93fc43762d7f626379287f9c4aab02c4a4a6d1d04ca63f9444e6932ca0dade",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "research-methods/PACK.json": {
           "hash": "330d22a58d14685167f0f5490ac01eebd78ed6575ac1168cc1a47ddbb2f72206",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-ops/PACK.json": {
           "hash": "2925caefbbfc65d926d52338a84c29d9bd1b39707f95e7f6ab1413541fe4796e",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "security-ops/security-auditor/SKILL.md": {
           "hash": "794fa5153e7e5fc432783816167055283cc42252feb7ec6a930241554828f532",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/docker-expert/SKILL.md": {
           "hash": "e33b08feeaa8e110c08dddd030970547356514d42aa484e52f51e2fd2d4f451b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/obsidian-cli/SKILL.md": {
           "hash": "b54257cdc0e5d04488b35b0c797bfe427b24359f0848d3c73924dcacf8da6358",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/PACK.json": {
           "hash": "d824669b877a9421c7ed1f5a1a4e7ed5533d4808ad180e982379a0c492c2b4e4",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/python-testing/SKILL.md": {
           "hash": "98ce1865de021c57f416bb41c9630a9d0ee85c790e8d512d4a8c9f2ebc63b501",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-backend/references/api_design_patterns.md": {
           "hash": "5bef532218c1a4f994eef546fd102d124d6052eef4f472ef490079d747d1ccc7",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-backend/references/backend_security_practices.md": {
           "hash": "c565222bd5ce1452614e62f1af0dc3e1b17e140ff261e92238d626b5d821a454",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-backend/references/database_optimization_guide.md": {
           "hash": "e399dfdcf755186f54c34bdb37efda089e359932abb543adac2d5c398252243a",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-backend/scripts/api_load_tester.py": {
           "hash": "dca9b04f0a8e643c720561e1549411064be77c3d85879e93edc5d49633a0f0cf",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-backend/scripts/api_scaffolder.py": {
           "hash": "34c43d83d0f6aacfdba2b82576b2613b398fb0b69c7aaa78c8815d3cd76c0681",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-backend/scripts/database_migration_tool.py": {
           "hash": "37ee8a932c440abf9b400f9b9f5ba046068c64e1e4d268bea49dc80a6dd4ea0d",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-backend/SKILL.md": {
           "hash": "de1c35674ab09c38b0895ab29eddfaf501ceff19ecf4db39617d7fb1cbf8762d",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-data-scientist/references/experiment_design_frameworks.md": {
           "hash": "4bb669406f3a3e2482bfc775e328643bda472a334dea7cdcb41c1b0bb87b4673",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-data-scientist/references/feature_engineering_patterns.md": {
           "hash": "6657db3b24fc5fc721f4a29ce6be0ff0a6da1dae92aca67d56945ecc74858cd0",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-data-scientist/references/statistical_methods_advanced.md": {
           "hash": "2ad183277b8e57a307085ca7265258d31a08761bc5d3f5844a33dbc79a40a48b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-data-scientist/scripts/experiment_designer.py": {
           "hash": "e086c9d66a67910d114c0831e16d6a658c712f11d5356b82f28687ba43de30fb",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-data-scientist/scripts/feature_engineering_pipeline.py": {
           "hash": "706602f103fa3403196ceb0d110e91b56b039c0f21fc0302ebfc7856c1874168",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-data-scientist/scripts/model_evaluation_suite.py": {
           "hash": "e7ce48ead1011fcf20f1cbed140061914ddc76b9ecf022101630bbec816fcc39",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-data-scientist/SKILL.md": {
           "hash": "1e6974ea60451055b3b11ff8b12d6bbb8ef90ab2bf973830718271c8ed53de06",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-devops/references/cicd_pipeline_guide.md": {
           "hash": "1a9081fd856eaad7643ddbb1b704b1e7dcf66f0e531e42e8740b21dd09439ddc",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-devops/references/deployment_strategies.md": {
           "hash": "63d164425e4d097a60d947f2fe515e4e8e60966cba97b418858a6ee5b144660f",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-devops/references/infrastructure_as_code.md": {
           "hash": "82f85a94d900384b7f57b13d4519af5c6f4b47a0d2a53129f0b4452f11945374",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-devops/scripts/deployment_manager.py": {
           "hash": "11644f32cacc37d6340c805f698e96f8b3692a79352c16f500f96ccc7dde30f9",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-devops/scripts/pipeline_generator.py": {
           "hash": "716dccacc6edd012e3295880138e28a573eba5185ed843f883f56866b50e387b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-devops/scripts/terraform_scaffolder.py": {
           "hash": "f5c3a34fa93cc91635a957163525cbb0324489451cb869225dccb38f927c6794",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-devops/SKILL.md": {
           "hash": "478aed6e0ef1a629cd1e7b8d3805935ab154a15ed83a9fd928c1114d16abcaad",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-security/references/cryptography_implementation.md": {
           "hash": "d4d994d22c107903fe29c6f6bde732f92e7a5eb26eaa9b200f10a3d4ddbe4adb",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-security/references/penetration_testing_guide.md": {
           "hash": "06aaca9578eb2b91664f0ef964c03621b80c47469260b2982764615aaacdc512",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-security/references/security_architecture_patterns.md": {
           "hash": "86619c5fb1ae5432b2d0be75b897144161f260afaa2ded33fae0988f5da50b1d",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-security/scripts/pentest_automator.py": {
           "hash": "8b2280d6ee02a852b9fe92dc400fae1787998c4ad1d1d3bfbb19d06c05f40b30",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-security/scripts/security_auditor.py": {
           "hash": "ce767c5773cbdd5d99601819061670839b521b6b9d13a4de6f10bd189caa2fe9",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-security/scripts/threat_modeler.py": {
           "hash": "2a62f3043d9d402b15a5e749b3eecc657c0c390e8ddb8d36d9900f57c55ed2a5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "xt-optional/senior-security/SKILL.md": {
           "hash": "d7e26f159d81a9e5ca9a7bc9ff3af116876068349d727b894c6b50020efbd7a7",
-          "version": "0.10.2"
+          "version": "0.10.3"
         }
       }
     },
@@ -1389,59 +1389,59 @@
       "files": {
         ".env.example": {
           "hash": "70e6af83cb0faf13a74676a5a3b79551ac60997cccd226e14c8dbc5887c047d5",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "claude.mcp.json": {
           "hash": "20b811ccc82395f9f3cd9a45ef36b776c3382d553924ef34662dd817a0a1c197",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "claude.mcp.optional.json": {
           "hash": "6cf39ec4a4cf6096a8108c883456c80bd45f0d37430f9403ea44aea1590f4d5c",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "hooks.json": {
           "hash": "c32a0758fc3bbc7398e9b533e2b23d34e7cd0235c5d9c8df3908911896773688",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "instructions/agents-top.md": {
-          "hash": "dfacc5c4df5d3db1426b90d4a3a54a018442567aa190805e9af3fb99c421f0b4",
-          "version": "0.10.2"
+          "hash": "fbf67a96bf240cef77e63665dbc016d8c20ef8b47c2fe73dc48cd76b6c64e2a1",
+          "version": "0.10.3"
         },
         "instructions/claude-top.md": {
-          "hash": "ce474443c408a29c537f6ee9a2fb98a723af349a4c9ef375c5519ec7d5bd7dd1",
-          "version": "0.10.2"
+          "hash": "2a3c2054c1b9c832b31bc002bac3493a9211f6a7f29f0a56dfc3b65fefb5cbaf",
+          "version": "0.10.3"
         },
         "pi.mcp.json": {
           "hash": "fb7f018e15e0d04b46ca473994ea275b46ebb21d741ff59c90188e26be8fb2d2",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "pi/auth.json.template": {
           "hash": "3d608dfc7574015abbf8c0c395845ecd2a2c8d166a25ca1cfda6398a82ee723b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "pi/install-schema.json": {
           "hash": "44d91fd7b9ca6eb7198f1e4cd0f5f849a42dcb3df119b741746211218acf0c2b",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "pi/models.json.template": {
           "hash": "b3c0ba93f087eef9645edbe8790307c44d075a8cbba1806e621ef983db92c4fa",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "pi/pi-worktrees-settings.json": {
           "hash": "7ebd4bed1a3a88dd8d423e8a557d487df009a06c2871658be7da1661e9651891",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "pi/settings.json.template": {
           "hash": "3acfbfd2a13b1319dd228ba2f9ae5f16ab203a2f0290f74b21cb763697ec2713",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "README.md": {
           "hash": "45a8977e6aaf3ce8cf349bc4382ab00e66329e5e240421fa25b04a71073d8aa9",
-          "version": "0.10.2"
+          "version": "0.10.3"
         },
         "settings.json": {
           "hash": "ec83b2db614a707fe2406d6b5907e848f6680bc36f85fc82ffd5e2d6283755ec",
-          "version": "0.10.2"
+          "version": "0.10.3"
         }
       }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### `xtrm-tools` — Unreleased
+## [v0.10.3] — 2026-07-13
+
+Two multiplexing-runtime and coordination-UX landings that had been queued in `[Unreleased]` since v0.10.2, plus the bd v1.1.0 instruction refresh that shipped alongside them.
+
+### `xtrm-tools` v0.10.3 — 2026-07-13
 
 #### Added
 
 - **`multiplexing` / `multiplexing-team` — V2 SQLite runtime default-on (xtmux-3xs).** Picker delegates message/monitor/audit primitives to a SQLite-backed runtime by default; CLI surface unchanged (`message-send`/`message-list`/`unread-count`/`monitor-list`/`log-emit`); storage moved from JSONL to `${XDG_STATE_HOME}/xtmux/observability.db`. New behaviors: `message-send --bead <id>` implicitly sets `--expects-reply=true`; pane-scoped inbox via `unread-count --for <sid> --pane %N`; auto-monitor coordination hooks in `.claude/settings.json` (PostToolUse + Stop enforce Monitor wake on peer transition); auto-wake on pi side via `pi-inbox-reply` + `pi-auto-monitor` extensions. Env override: `XTMUX_OBS_V2=on|shadow|off`. Companion cross-refs added to `code-review`, `deploy-monitor`, `pr-reviewer` skill guides.
 - **Shared repo-scoped beads-status cache (xtrm-77t9q).** New `.xtrm/hooks/beads-status-cache.mjs` module coalesces N agents in the same repo (Claude statusline + Pi custom-footer, main + linked worktrees) to one `bd` refresh per TTL. Schema v1 cache at `<mainRoot>/.xtrm/cache/beads-status.json` (atomic rename, 0o600, single-flight lease at `.lock`, 5s TTL compact / 30s TTL descendants). `resolveMainRoot` is pure-fs (reads `.git/worktrees/<n>/gitdir` directly, no subprocess). `fetchCompact` walks nested parents up to 8 levels to find the owning epic. `formatCompact` renders the shared one-line spec (`12 open · 2 in progress · epic k2ufi (1/3 done)`) — Pi and Claude statusline get parity by construction. Fail-soft `stale: true` marker + `stale Xm` age tag past 10×TTL. `.xtrm/hooks/statusline.mjs` refactored to consume the module; `runFast(250ms)` for git / `runBd(2000ms)` for bd fixes the pre-existing 250ms-timeout bug that made statusline fall back to `no open issues`. `packages/pi-extensions/extensions/custom-footer/index.ts` consumes the same cache for compact rendering plus an on-demand Ctrl+O expanded epic tree (indent-2 per level, N=50 cap, `+M more` overflow) with skeleton-then-repaint refresh.
+
+#### Changed
+
+- **Instruction routing files caught up to bd v1.1.0 (xtrm-3kccz).** Verified the installed `bd` binary against v1.1.0's documented CLI surface (`bd --help`, `bd ready --help`, `bd create --help`) and added the two genuinely new, stable commands that `bd prime` itself doesn't teach: `bd ready --claim`/`--explain` and `bd create --graph`/`--waits-for`/`--spec-id`/`--skills`, to the `Essential command surface` section of both `.xtrm/config/instructions/agents-top.md` and `claude-top.md`. Deliberately excluded `bd ready --mol`/`--gated` (no formulas/molecules currently in use in this repo) and all `main`-only/unreleased bd features (claim TTL/heartbeat/reclaim, `bd formula schema`, `bd history --events`). Also evaluated and reverted a `bd setup claude`-injected block in `CLAUDE.md` (xtrm-h4cwy): its content duplicated `bd prime`'s live output and contradicted this repo's requirement to use Claude-local task planning (TaskCreate/TodoWrite-style) alongside beads.
 
 ## [v0.10.2] — 2026-07-13
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xtrm-cli",
   "private": true,
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "main": "./dist/index.js",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xtrm-tools",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtrm-tools",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "workspaces": [
         "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtrm-tools",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "license": "MIT",
   "type": "module",

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Cuts v0.10.3 as a single release bundle that folds three tracked-but-not-yet-released workstreams:

- **xtrm-77t9q** — shared repo-scoped beads-status cache (`.xtrm/hooks/beads-status-cache.mjs`) + Claude statusline refactor + Pi custom-footer parity + Ctrl+O expanded epic tree. Landed content-wise in #404 (6e723843). Fixes the 250ms subprocess-timeout bug that made statusline fall back to "no open issues".
- **xtmux-3xs** — `multiplexing` / `multiplexing-team` V2 SQLite runtime default-on, pane-scoped inbox, auto-monitor coordination hooks. Shipped alongside xtrm-77t9q in #404.
- **xtrm-3kccz** — instruction routing files (`agents-top.md` + `claude-top.md`) caught up to `bd` v1.1.0 CLI surface (`bd ready --claim`/`--explain`, `bd create --graph`/`--waits-for`/`--spec-id`/`--skills`). Reapplied here from local pane 3 work that missed #404.

## Diff

- 8 files changed, +381/-364
- `CHANGELOG.md` — promote `[Unreleased]` → `[v0.10.3] — 2026-07-13`
- `package.json` / `cli/package.json` / `packages/pi-extensions/package.json` / `package-lock.json` — 0.10.2 → 0.10.3 via `sync:cli-version`
- `.xtrm/registry.json` — regenerated (gitnexus/ untracked sidecar'd for parity)
- `.xtrm/config/instructions/{agents,claude}-top.md` — bd v1.1.0 command additions

## Gates verified locally

- `npm run check:registry-pack-parity` → 354/354 match
- `npm run check:specialists-vendor` → OK
- `npm run check:payload-hygiene` → 444 packed, no forbidden paths, no absolute-path leaks

## Post-merge plan

Per repo release convention (squash-merge orphans feature-branch tags):
1. Merge this PR (squash) → new merge commit on `main`
2. Operator tags `v0.10.3` on the merge commit
3. `gh release create v0.10.3 --generate-notes` fires `publish.yml`
4. Both npm packages published (`xtrm-tools@0.10.3` + `@jaggerxtrm/pi-extensions@0.10.3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)