### PR TITLE
Fix /beads expansion for multiple standalone in-progress issues

### DIFF
--- a/cli/test/extensions/custom-footer-parity.test.ts
+++ b/cli/test/extensions/custom-footer-parity.test.ts
@@ -128,6 +128,27 @@ describe("custom-footer shared beads cache", () => {
 		expect(SubprocessRunner.run).not.toHaveBeenCalled();
 	});
 
+	it("expands cached in-progress issues without an epic on Alt+B", async () => {
+		beadsCache.writeCache(cacheRoot, {
+			counts: { open: 2, in_progress: 3, blocked: 0 },
+			activeIssues: [
+				{ id: "xtrm-one", title: "First claim", status: "in_progress" },
+				{ id: "xtrm-two", title: "Second claim", status: "in_progress" },
+				{ id: "xtrm-three", title: "Third claim", status: "in_progress" },
+			],
+			activeEpic: null,
+		});
+		await start();
+		expect(shortcuts["ctrl+b"]).toBeUndefined();
+		expect(shortcuts["alt+b"]).toBeDefined();
+		await shortcuts["alt+b"].handler(ctx);
+		const text = footerRenderer.render(120).join("\n");
+		expect(text).toContain("in progress (3)");
+		expect(text).toContain("◐ one  First claim");
+		expect(text).toContain("◐ two  Second claim");
+		expect(text).toContain("◐ three  Third claim");
+	});
+
 	it("keeps Ctrl+O tool expansion independent from the beads tree", async () => {
 		beadsCache.writeCache(cacheRoot, {
 			counts: { open: 2, in_progress: 1, blocked: 0 },
@@ -145,7 +166,7 @@ describe("custom-footer shared beads cache", () => {
 		toolsExpanded = true;
 		await start();
 		expect(footerRenderer.render(120).join("\n")).not.toContain("First child");
-		await shortcuts["ctrl+b"].handler(ctx);
+		await commands.beads.handler("", ctx);
 		const text = footerRenderer.render(120).join("\n");
 		expect(text).toContain("epic epic (1/3 done) — Compact footer");
 		expect(text).toContain("  ◐ .1  in progress  First child");
@@ -184,7 +205,7 @@ describe("custom-footer shared beads cache", () => {
 			return { code: 1, stdout: "", stderr: "" };
 		});
 		await start();
-		await shortcuts["ctrl+b"].handler(ctx);
+		await commands.beads.handler("", ctx);
 		expect(footerRenderer.render(120).join("\n")).toContain("loading epic tree…");
 		await vi.runOnlyPendingTimersAsync();
 		await Promise.resolve();

--- a/packages/pi-extensions/extensions/custom-footer/index.ts
+++ b/packages/pi-extensions/extensions/custom-footer/index.ts
@@ -142,6 +142,17 @@ function renderEpicTree(cache: BeadsCache, width: number, theme: any): string[] 
 	return lines;
 }
 
+function renderActiveIssues(cache: BeadsCache, width: number, theme: any): string[] {
+	const lines = [theme.fg("muted", `in progress (${cache.counts.in_progress})`)];
+	for (const issue of cache.activeIssues) {
+		const shortId = issue.id.split("-").pop() ?? issue.id;
+		lines.push(truncateToWidth(theme.fg("accent", `  ${STATUS.in_progress.icon} ${shortId}  ${issue.title ?? ""}`), width));
+	}
+	const overflow = cache.counts.in_progress - cache.activeIssues.length;
+	if (overflow > 0) lines.push(theme.fg("dim", `  +${overflow} more`));
+	return lines;
+}
+
 export default function registerCustomFooter(pi: ExtensionAPI): void {
 	let capturedCtx: any = null;
 	let cacheModule: CacheModule | null = null;
@@ -350,12 +361,16 @@ export default function registerCustomFooter(pi: ExtensionAPI): void {
 
 					const compact = cacheModule?.formatCompact(beadsCache, { cols: width }) ?? "beads unavailable";
 					lines.push(truncateToWidth(compact, width));
-					if (beadsExpanded && beadsCache?.activeEpic) {
-						const descendants = beadsCache.descendants;
-						if (!descendants || descendants.epicId !== beadsCache.activeEpic.id || Date.now() - descendants.ts >= (cacheModule?.TTL_DESCENDANTS_MS ?? 30_000)) {
-							scheduleDescendants();
+					if (beadsExpanded && beadsCache) {
+						if (beadsCache.activeEpic) {
+							const descendants = beadsCache.descendants;
+							if (!descendants || descendants.epicId !== beadsCache.activeEpic.id || Date.now() - descendants.ts >= (cacheModule?.TTL_DESCENDANTS_MS ?? 30_000)) {
+								scheduleDescendants();
+							}
+							lines.push(...renderEpicTree(beadsCache, width, theme));
+						} else {
+							lines.push(...renderActiveIssues(beadsCache, width, theme));
 						}
-						lines.push(...renderEpicTree(beadsCache, width, theme));
 					}
 					return lines;
 				},
@@ -380,16 +395,16 @@ export default function registerCustomFooter(pi: ExtensionAPI): void {
 
 	const toggleBeads = (): void => {
 		beadsExpanded = !beadsExpanded;
-		if (beadsExpanded) scheduleDescendants();
+		if (beadsExpanded && beadsCache?.activeEpic) scheduleDescendants();
 		requestRender?.();
 	};
 
 	pi.registerCommand("beads", {
-		description: "Toggle the active epic tree",
+		description: "Toggle active beads details",
 		handler: async () => toggleBeads(),
 	});
-	pi.registerShortcut("ctrl+b", {
-		description: "Toggle the active epic tree",
+	pi.registerShortcut("alt+b", {
+		description: "Toggle active beads details",
 		handler: async () => toggleBeads(),
 	});
 


### PR DESCRIPTION
## What
- **xtrm-wnajv**: Fix /beads expansion for multiple standalone in-progress issues
  Regression in v0.10.3 custom footer: /beads toggles beadsExpanded but renders rows only when activeEpic exists. Reproduce with three repository-wide in-progress issues whose parent chains contain no epic: compact cache has activeEpic:null, so /beads appears to do nothing. Remove the conflicting hardcoded Ctrl+B shortcut and render the cached in-progress issues as the fallback expansion. Add regression coverage.

## Why
- xtrm-wnajv: Fixed: /beads now expands standalone in-progress issues and the shortcut moved from Ctrl+B to Alt+B.

## Changes
- 73ebaea8 fix: expand standalone active beads (xtrm-wnajv)

## Files changed
```
cli/test/extensions/custom-footer-parity.test.ts   | 25 ++++++++++++++--
 .../extensions/custom-footer/index.ts              | 33 ++++++++++++++++------
 2 files changed, 47 insertions(+), 11 deletions(-)
```

Closes: xtrm-wnajv