### PR TITLE
fix(pi): stabilize startup and expanded beads context

### DIFF
--- a/.xtrm/hooks/beads-status-cache.mjs
+++ b/.xtrm/hooks/beads-status-cache.mjs
@@ -145,7 +145,10 @@ export function fetchCompact(cwd) {
   const blockedList = bdJson(cwd, 'bd list --status=blocked --json') ?? [];
   const counts = { open: openList.length, in_progress: progressList.length, blocked: blockedList.length };
   const activeIssues = progressList.slice(0, 3).map(i => ({
-    id: i.id, title: i.title ?? null, status: 'in_progress',
+    id: i.id,
+    title: i.title ?? null,
+    status: 'in_progress',
+    parent: typeof i.parent === 'string' ? i.parent : typeof i.parent_id === 'string' ? i.parent_id : undefined,
   }));
 
   let activeEpic = null;

--- a/.xtrm/hooks/beads-status-cache.test.mjs
+++ b/.xtrm/hooks/beads-status-cache.test.mjs
@@ -104,6 +104,7 @@ esac
   assert.equal(compact.activeEpic.id, 'xtrm-epic');
   assert.equal(compact.activeEpic.closed, 1);
   assert.equal(compact.activeEpic.total, 2);
+  assert.equal(compact.activeIssues.find(issue => issue.id === 'xtrm-epic.1.1').parent, 'xtrm-epic.1');
 });
 
 test('formatCompact: zero-issue', () => {

--- a/cli/test/extensions/custom-footer-parity.test.ts
+++ b/cli/test/extensions/custom-footer-parity.test.ts
@@ -128,7 +128,7 @@ describe("custom-footer shared beads cache", () => {
 		expect(SubprocessRunner.run).not.toHaveBeenCalled();
 	});
 
-	it("expands cached in-progress issues without an epic on Alt+B", async () => {
+	it("expands cached in-progress issues without an epic on Alt+G", async () => {
 		beadsCache.writeCache(cacheRoot, {
 			counts: { open: 2, in_progress: 3, blocked: 0 },
 			activeIssues: [
@@ -140,8 +140,9 @@ describe("custom-footer shared beads cache", () => {
 		});
 		await start();
 		expect(shortcuts["ctrl+b"]).toBeUndefined();
-		expect(shortcuts["alt+b"]).toBeDefined();
-		await shortcuts["alt+b"].handler(ctx);
+		expect(shortcuts["alt+b"]).toBeUndefined();
+		expect(shortcuts["alt+g"]).toBeDefined();
+		await shortcuts["alt+g"].handler(ctx);
 		const text = footerRenderer.render(120).join("\n");
 		expect(text).toContain("in progress (3)");
 		expect(text).toContain("◐ one  First claim");

--- a/cli/test/extensions/custom-footer-parity.test.ts
+++ b/cli/test/extensions/custom-footer-parity.test.ts
@@ -214,4 +214,111 @@ describe("custom-footer shared beads cache", () => {
 		expect(footerRenderer.render(120).join("\n")).toContain("Fetched child");
 		expect(requestRenderSpy).toHaveBeenCalled();
 	});
+
+	it("renders a non-epic parent-child group with closed siblings", async () => {
+		beadsCache.writeCache(cacheRoot, {
+			counts: { open: 1, in_progress: 1, blocked: 0 },
+			activeIssues: [{ id: "xtrm-parent.2", parent: "xtrm-parent", title: "Active child", status: "in_progress" }],
+			activeEpic: null,
+		});
+		(SubprocessRunner.run as any).mockImplementation(async (command: string, args: string[]) => {
+			if (command !== "bd") return { code: 1, stdout: "", stderr: "" };
+			if (args[0] === "show" && args[1] === "xtrm-parent") {
+				return { code: 0, stdout: JSON.stringify([{ id: "xtrm-parent", title: "Ordinary parent", status: "closed" }]), stderr: "" };
+			}
+			if (args[0] === "children" && args[1] === "xtrm-parent") {
+				return { code: 0, stdout: JSON.stringify([
+					{ id: "xtrm-parent.1", parent: "xtrm-parent", title: "Closed sibling", status: "closed" },
+					{ id: "xtrm-parent.2", parent: "xtrm-parent", title: "Active child", status: "in_progress" },
+				]), stderr: "" };
+			}
+			return { code: 1, stdout: "", stderr: "" };
+		});
+		await start();
+		await commands.beads.handler("", ctx);
+		expect(footerRenderer.render(120).join("\n")).toContain("loading parent-child group…");
+		await vi.runOnlyPendingTimersAsync();
+		await Promise.resolve();
+		const text = footerRenderer.render(120).join("\n");
+		expect(text).toContain("parent parent (1/2 done) — Ordinary parent");
+		expect(text).toContain("✓ .1  closed  Closed sibling");
+		expect(text).toContain("◐ .2  in progress  Active child");
+	});
+
+	it("falls back to the active issue's structural parent when the cache predates parent ids", async () => {
+		beadsCache.writeCache(cacheRoot, {
+			counts: { open: 1, in_progress: 1, blocked: 0 },
+			activeIssues: [{ id: "xtrm-parent.2", title: "Active child", status: "in_progress" }],
+			activeEpic: null,
+		});
+		(SubprocessRunner.run as any).mockImplementation(async (command: string, args: string[]) => {
+			if (command !== "bd") return { code: 1, stdout: "", stderr: "" };
+			if (args[0] === "show" && args[1] === "xtrm-parent.2") {
+				return { code: 0, stdout: JSON.stringify([{ id: "xtrm-parent.2", parent: "xtrm-parent" }]), stderr: "" };
+			}
+			if (args[0] === "show" && args[1] === "xtrm-parent") {
+				return { code: 0, stdout: JSON.stringify([{ id: "xtrm-parent", title: "Ordinary parent", status: "open" }]), stderr: "" };
+			}
+			if (args[0] === "children" && args[1] === "xtrm-parent") {
+				return { code: 0, stdout: JSON.stringify([{ id: "xtrm-parent.2", title: "Active child", status: "in_progress" }]), stderr: "" };
+			}
+			return { code: 1, stdout: "", stderr: "" };
+		});
+		await start();
+		await commands.beads.handler("", ctx);
+		await vi.runOnlyPendingTimersAsync();
+		await Promise.resolve();
+		expect(footerRenderer.render(120).join("\n")).toContain("parent parent (0/1 done) — Ordinary parent");
+		expect((SubprocessRunner.run as any).mock.calls.filter((call: any[]) => call[0] === "bd")).toHaveLength(3);
+	});
+
+	it("loads only the first active parent-child group", async () => {
+		beadsCache.writeCache(cacheRoot, {
+			counts: { open: 2, in_progress: 2, blocked: 0 },
+			activeIssues: [
+				{ id: "xtrm-first.1", parent: "xtrm-first", title: "First child", status: "in_progress" },
+				{ id: "xtrm-second.1", parent: "xtrm-second", title: "Second child", status: "in_progress" },
+			],
+			activeEpic: null,
+		});
+		(SubprocessRunner.run as any).mockImplementation(async (command: string, args: string[]) => {
+			if (command !== "bd" || args[1] !== "xtrm-first") return { code: 1, stdout: "", stderr: "" };
+			if (args[0] === "show") return { code: 0, stdout: JSON.stringify([{ id: "xtrm-first", title: "First parent", status: "open" }]), stderr: "" };
+			return { code: 0, stdout: JSON.stringify([{ id: "xtrm-first.1", title: "First child", status: "in_progress" }]), stderr: "" };
+		});
+		await start();
+		await commands.beads.handler("", ctx);
+		await vi.runOnlyPendingTimersAsync();
+		await Promise.resolve();
+		const text = footerRenderer.render(120).join("\n");
+		expect(text).toContain("First parent");
+		expect(text).not.toContain("Second child");
+		expect((SubprocessRunner.run as any).mock.calls.filter((call: any[]) => call[0] === "bd")).toHaveLength(2);
+	});
+
+	it("does not create a group from non-parent dependency metadata", async () => {
+		beadsCache.writeCache(cacheRoot, {
+			counts: { open: 1, in_progress: 1, blocked: 0 },
+			activeIssues: [{
+				id: "xtrm-standalone",
+				title: "Standalone",
+				status: "in_progress",
+				dependencies: [{ id: "xtrm-origin", dependency_type: "discovered-from" }],
+			}],
+			activeEpic: null,
+		});
+		(SubprocessRunner.run as any).mockImplementation(async (command: string, args: string[]) => {
+			if (command === "bd" && args[0] === "show" && args[1] === "xtrm-standalone") {
+				return { code: 0, stdout: JSON.stringify([{ id: "xtrm-standalone", dependencies: [{ id: "xtrm-origin", dependency_type: "discovered-from" }] }]), stderr: "" };
+			}
+			return { code: 1, stdout: "", stderr: "" };
+		});
+		await start();
+		await commands.beads.handler("", ctx);
+		await vi.runOnlyPendingTimersAsync();
+		expect(footerRenderer.render(120).join("\n")).not.toContain("parent ");
+		const bdCalls = (SubprocessRunner.run as any).mock.calls.filter((call: any[]) => call[0] === "bd");
+		expect(bdCalls).toHaveLength(1);
+		expect(bdCalls[0][1]).toEqual(["show", "xtrm-standalone", "--json"]);
+	});
 });

--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -132,22 +132,9 @@ describe("xtrm-ui commands", () => {
     expect(Object.keys(commands).sort()).toEqual(supportedCommands);
   });
 
-  it("discovers only XTRM-named themes", async () => {
+  it("leaves theme ownership to the global Pi runtime sync", () => {
     const { handlers } = loadExtension();
-    const resources = await handlers.resources_discover[0]();
-    const themeDir = resources.themePaths[0];
-    const files = readdirSync(themeDir).filter((file) => file.endsWith(".json")).sort();
-
-    expect(files).toEqual([
-      "xtrm-dark-flattools.json",
-      "xtrm-dark.json",
-      "xtrm-light-flattools.json",
-      "xtrm-light.json",
-    ]);
-    for (const file of files) {
-      const theme = JSON.parse(readFileSync(join(themeDir, file), "utf8"));
-      expect(theme.name).toBe(file.replace(/\.json$/u, ""));
-    }
+    expect(handlers.resources_discover).toBeUndefined();
   });
 
   it("reports only active preferences and rejects subcommands", async () => {
@@ -341,7 +328,7 @@ describe("xtrm-ui external tool rendering", () => {
     );
 
     expect(rendered[0]).toContain("\x1b[48;2;82;210;255m[Serena]");
-    expect(rendered[0]).toContain("\x1b[49m find_symbol");
+    expect(rendered[0]).toContain("\x1b[49m \x1b[1mfind_symbol\x1b[22m");
     expect(rendered.length).toBeGreaterThan(2);
     expect(rendered.join("\n")).toContain('"name_path": "highlightExternalToolBadge"');
   });
@@ -355,7 +342,7 @@ describe("xtrm-ui external tool rendering", () => {
       "mcp_custom_tool",
     );
 
-    expect(rendered[0]).toContain("[mcp custom_tool]");
+    expect(rendered[0]).toContain("› \x1b[38;2;3;8;12m\x1b[48;2;178;190;210m[mcp]\x1b[39m\x1b[49m \x1b[1mcustom_tool\x1b[22m");
   });
 
   it("keeps a colored provider badge and action for raw GitNexus output", () => {
@@ -368,7 +355,28 @@ describe("xtrm-ui external tool rendering", () => {
     );
 
     expect(rendered[0]).toContain("\x1b[48;2;178;154;255m[GitNexus]");
-    expect(rendered[0]).toContain("\x1b[49m query");
+    expect(rendered[0]).toContain("\x1b[49m \x1b[1mquery\x1b[22m");
+  });
+
+  it("keeps the provider header and bold action stable across lifecycle states", () => {
+    const stripAnsi = (value: string) => value.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "");
+    const states = [
+      ["› [Serena] execute_shell_command", "running"],
+      ["[Serena] execute_shell_command", "success"],
+      ["[Serena] execute_shell_command", "failure"],
+    ] as const;
+
+    for (const [header] of states) {
+      const rendered = renderExternalToolBackgroundLines(
+        [header, "result"],
+        200,
+        "serena",
+        false,
+        "execute_shell_command",
+      );
+      expect(stripAnsi(rendered[0] ?? "")).toBe("› [Serena] execute_shell_command");
+      expect(rendered[0]).toContain("\x1b[1mexecute_shell_command\x1b[22m");
+    }
   });
 
   it("keeps collapsed structured output multiline and bounded", () => {

--- a/cli/test/pi-runtime.test.ts
+++ b/cli/test/pi-runtime.test.ts
@@ -18,7 +18,7 @@ async function makeExtension(baseDir: string, name: string, extraFiles: Record<s
 }
 
 describe('syncManagedPiThemes', () => {
-    it('symlinks every XTRM theme before Pi settings are read', async () => {
+    it('symlinks every XTRM theme and replaces copied assets', async () => {
         const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-theme-source-'));
         const targetDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-theme-target-'));
         const themes = ['xtrm-dark.json', 'xtrm-dark-flattools.json', 'xtrm-light.json', 'xtrm-light-flattools.json'];
@@ -26,10 +26,12 @@ describe('syncManagedPiThemes', () => {
         try {
             await Promise.all(themes.map((name) => fs.writeFile(path.join(sourceDir, name), `{"name":"${name}"}`)));
             await fs.writeFile(path.join(sourceDir, 'ignored.json'), '{}');
+            await Promise.all(themes.map((name) => fs.writeFile(path.join(targetDir, name), `{"name":"legacy-${name}"}`)));
+            await fs.writeFile(path.join(targetDir, 'custom.json'), '{}');
 
             await syncManagedPiThemes(sourceDir, false, undefined, targetDir);
 
-            expect((await fs.readdir(targetDir)).sort()).toEqual(themes.sort());
+            expect((await fs.readdir(targetDir)).sort()).toEqual([...themes, 'custom.json'].sort());
             for (const name of themes) {
                 expect((await fs.lstat(path.join(targetDir, name))).isSymbolicLink()).toBe(true);
                 expect(await fs.readFile(path.join(targetDir, name), 'utf8')).toContain(name);

--- a/packages/pi-extensions/extensions/custom-footer/index.ts
+++ b/packages/pi-extensions/extensions/custom-footer/index.ts
@@ -11,6 +11,7 @@ type RefreshKind = "runtime" | "compact";
 
 type CacheIssue = { id: string; title: string | null; status: string; parent?: string };
 type Descendants = { epicId: string; ts: number; items: CacheIssue[]; overflow: number };
+type ParentGroup = { parent: CacheIssue; ts: number; items: CacheIssue[]; overflow: number };
 type BeadsCache = {
 	v: number;
 	ts: number;
@@ -153,6 +154,30 @@ function renderActiveIssues(cache: BeadsCache, width: number, theme: any): strin
 	return lines;
 }
 
+function activeParentId(cache: BeadsCache): string | null {
+	return cache.activeIssues.find((issue) => issue.parent)?.parent ?? null;
+}
+
+function hasFreshParentGroup(parentId: string, group: ParentGroup | null): boolean {
+	return group?.parent.id === parentId && Date.now() - group.ts < 30_000;
+}
+
+function renderParentGroup(parentId: string, group: ParentGroup | null, width: number, theme: any): string[] {
+	if (!hasFreshParentGroup(parentId, group)) return [theme.fg("dim", "  loading parent-child group…")];
+	const closed = group.items.filter((item) => item.status === "closed").length;
+	const shortParent = group.parent.id.split("-").pop() ?? group.parent.id;
+	const title = group.parent.title ? ` — ${group.parent.title}` : "";
+	const lines = [truncateToWidth(theme.fg("muted", `parent ${shortParent} (${closed}/${group.items.length} done)${title}`), width)];
+	for (const item of group.items) {
+		const status = STATUS[item.status] ?? STATUS.open;
+		const relativeId = item.id.startsWith(`${group.parent.id}.`) ? item.id.slice(group.parent.id.length) : item.id;
+		const row = `  ${status.icon} ${relativeId}  ${status.label}  ${item.title ?? ""}`;
+		lines.push(truncateToWidth(theme.fg(status.color, row), width));
+	}
+	if (group.overflow > 0) lines.push(theme.fg("dim", `  +${group.overflow} more (bd show ${group.parent.id})`));
+	return lines;
+}
+
 export default function registerCustomFooter(pi: ExtensionAPI): void {
 	let capturedCtx: any = null;
 	let cacheModule: CacheModule | null = null;
@@ -164,12 +189,15 @@ export default function registerCustomFooter(pi: ExtensionAPI): void {
 	let footerReapplyTimer: ReturnType<typeof setTimeout> | null = null;
 	let scheduledRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 	let descendantRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+	let parentGroupRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 	let cacheSyncTimer: ReturnType<typeof setInterval> | null = null;
 	let scheduledRefreshKinds = new Set<RefreshKind>();
 	let runningRefreshPromise: Promise<void> | null = null;
 	let refreshingRuntime = false;
 	let refreshingCompact = false;
 	let refreshingDescendants = false;
+	let refreshingParentGroup = false;
+	let parentGroup: ParentGroup | null = null;
 	let beadsExpanded = false;
 	let runtimeState = { branch: null as string | null, gitStatus: "", lastFetch: 0 };
 
@@ -288,12 +316,72 @@ export default function registerCustomFooter(pi: ExtensionAPI): void {
 		}
 	};
 
+	const refreshParentGroup = async (): Promise<void> => {
+		if (refreshingParentGroup || !cacheModule || !beadsCache || beadsCache.activeEpic) return;
+		refreshingParentGroup = true;
+		try {
+			if (!cacheModule.isFresh(beadsCache)) await refreshCompact();
+			if (!beadsCache || beadsCache.activeEpic) return;
+			const activeIssue = beadsCache.activeIssues.find((issue) => issue.parent) ?? beadsCache.activeIssues[0];
+			let parentId = activeIssue?.parent ?? null;
+			if (!parentId && activeIssue) {
+				const activeResult = await run("bd", ["show", activeIssue.id, "--json"], DESCENDANT_REFRESH_TIMEOUT_MS);
+				const active = activeResult.code === 0 ? (JSON.parse(activeResult.stdout) as Array<Record<string, unknown>>)[0] : null;
+				parentId = typeof active?.parent === "string" ? active.parent : typeof active?.parent_id === "string" ? active.parent_id : null;
+				if (parentId) activeIssue.parent = parentId;
+			}
+			if (!parentId || hasFreshParentGroup(parentId, parentGroup)) return;
+			const [parentResult, childrenResult] = await Promise.all([
+				run("bd", ["show", parentId, "--json"], DESCENDANT_REFRESH_TIMEOUT_MS),
+				run("bd", ["children", parentId, "--json"], DESCENDANT_REFRESH_TIMEOUT_MS),
+			]);
+			if (parentResult.code !== 0 || childrenResult.code !== 0) return;
+			const parent = (JSON.parse(parentResult.stdout) as Array<Record<string, unknown>>)[0];
+			const children = JSON.parse(childrenResult.stdout) as Array<Record<string, unknown>>;
+			if (!parent || !Array.isArray(children)) return;
+			const items = children.map((item) => ({
+				id: String(item.id ?? ""),
+				title: typeof item.title === "string" ? item.title.slice(0, 80) : null,
+				status: String(item.status ?? "open"),
+				parent: parentId,
+			})).filter((item) => item.id).sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
+			parentGroup = {
+				parent: {
+					id: String(parent.id ?? parentId),
+					title: typeof parent.title === "string" ? parent.title.slice(0, 80) : null,
+					status: String(parent.status ?? "open"),
+				},
+				ts: Date.now(),
+				items: items.slice(0, MAX_DESCENDANTS),
+				overflow: Math.max(0, items.length - MAX_DESCENDANTS),
+			};
+			requestRender?.();
+		} catch {
+			// Keep the previous parent-child context on failures.
+		} finally {
+			refreshingParentGroup = false;
+		}
+	};
+
 	const scheduleDescendants = (): void => {
 		if (descendantRefreshTimer || refreshingDescendants) return;
 		descendantRefreshTimer = setTimeout(() => {
 			descendantRefreshTimer = null;
 			void refreshDescendants();
 		}, 0);
+	};
+
+	const scheduleParentGroup = (): void => {
+		if (parentGroupRefreshTimer || refreshingParentGroup) return;
+		parentGroupRefreshTimer = setTimeout(() => {
+			parentGroupRefreshTimer = null;
+			void refreshParentGroup();
+		}, 0);
+	};
+
+	const scheduleExpandedTree = (): void => {
+		if (beadsCache?.activeEpic) scheduleDescendants();
+		else scheduleParentGroup();
 	};
 
 	const runRefreshes = async (kinds: ReadonlySet<RefreshKind>): Promise<void> => {
@@ -369,7 +457,13 @@ export default function registerCustomFooter(pi: ExtensionAPI): void {
 							}
 							lines.push(...renderEpicTree(beadsCache, width, theme));
 						} else {
-							lines.push(...renderActiveIssues(beadsCache, width, theme));
+							const parentId = activeParentId(beadsCache);
+							if (parentId) {
+								if (!hasFreshParentGroup(parentId, parentGroup)) scheduleParentGroup();
+								lines.push(...renderParentGroup(parentId, parentGroup, width, theme));
+							} else {
+								lines.push(...renderActiveIssues(beadsCache, width, theme));
+							}
 						}
 					}
 					return lines;
@@ -391,11 +485,12 @@ export default function registerCustomFooter(pi: ExtensionAPI): void {
 		beadsCache = null;
 		cacheModule = null;
 		mainRoot = "";
+		parentGroup = null;
 	};
 
 	const toggleBeads = (): void => {
 		beadsExpanded = !beadsExpanded;
-		if (beadsExpanded && beadsCache?.activeEpic) scheduleDescendants();
+		if (beadsExpanded) scheduleExpandedTree();
 		requestRender?.();
 	};
 
@@ -445,9 +540,9 @@ export default function registerCustomFooter(pi: ExtensionAPI): void {
 		return undefined;
 	});
 	pi.on("session_shutdown", async () => {
-		for (const timer of [footerReapplyTimer, scheduledRefreshTimer, descendantRefreshTimer]) if (timer) clearTimeout(timer);
+		for (const timer of [footerReapplyTimer, scheduledRefreshTimer, descendantRefreshTimer, parentGroupRefreshTimer]) if (timer) clearTimeout(timer);
 		if (cacheSyncTimer) clearInterval(cacheSyncTimer);
-		footerReapplyTimer = scheduledRefreshTimer = descendantRefreshTimer = null;
+		footerReapplyTimer = scheduledRefreshTimer = descendantRefreshTimer = parentGroupRefreshTimer = null;
 		cacheSyncTimer = null;
 		scheduledRefreshKinds.clear();
 		branchChangeUnsub?.();

--- a/packages/pi-extensions/extensions/custom-footer/index.ts
+++ b/packages/pi-extensions/extensions/custom-footer/index.ts
@@ -403,7 +403,7 @@ export default function registerCustomFooter(pi: ExtensionAPI): void {
 		description: "Toggle active beads details",
 		handler: async () => toggleBeads(),
 	});
-	pi.registerShortcut("alt+b", {
+	pi.registerShortcut("alt+g", {
 		description: "Toggle active beads details",
 		handler: async () => toggleBeads(),
 	});

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -229,7 +229,7 @@ type PatchableToolExecutionComponent = {
 type ExternalToolFrameKind = "serena" | "gitnexus" | "structured" | "process" | "external";
 
 const PATCHED_EXTERNAL_TOOL_FRAME = "__xtrmUiExternalToolFrame";
-const EXTERNAL_TOOL_FRAME_PATCH_VERSION = 17;
+const EXTERNAL_TOOL_FRAME_PATCH_VERSION = 18;
 const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
 
 function stripAnsi(text: string): string {
@@ -302,7 +302,21 @@ function externalToolBadgeColor(kind: ExternalToolFrameKind, text: string): stri
   return `\x1b[38;2;3;8;12m\x1b[48;2;${badgeR};${badgeG};${badgeB}m${text}\x1b[39m\x1b[49m`;
 }
 
+function boldExternalToolAction(action: string): string {
+  return `\x1b[1m${action}\x1b[22m`;
+}
+
 export function highlightExternalToolBadge(kind: ExternalToolFrameKind, line: string): string {
+  const markedHeader = line.match(/^([•›]\s+)(\[[A-Za-z][A-Za-z0-9 _-]{0,31}\])(\s+)(\S+)(.*)$/u);
+  if (markedHeader?.[1] && markedHeader[2] && markedHeader[3] && markedHeader[4]) {
+    return `${markedHeader[1]}${externalToolBadgeColor(kind, markedHeader[2])}${markedHeader[3]}${boldExternalToolAction(markedHeader[4])}${markedHeader[5] ?? ""}`;
+  }
+
+  const providerHeader = line.match(/^(\[[A-Za-z][A-Za-z0-9 _-]{0,31}\])(\s+)(\S+)(.*)$/u);
+  if (providerHeader?.[1] && providerHeader[2] && providerHeader[3]) {
+    return `${externalToolBadgeColor(kind, providerHeader[1])}${providerHeader[2]}${boldExternalToolAction(providerHeader[3])}${providerHeader[4] ?? ""}`;
+  }
+
   const marked = line.match(/^([•›]\s+)(\S+)/u);
   if (marked?.[1] && marked[2]) {
     return marked[1] + externalToolBadgeColor(kind, marked[2]) + line.slice(marked[1].length + marked[2].length);
@@ -318,6 +332,38 @@ export function collapsedExternalToolLines(contentLines: string[], expanded: boo
     ...contentLines.slice(0, 6),
     `... (${contentLines.length - 6} more lines, ctrl+o to expand)`,
   ];
+}
+
+function externalToolProvider(kind: ExternalToolFrameKind, toolName?: string): string {
+  if (kind === "serena") return "Serena";
+  if (kind === "gitnexus") return "GitNexus";
+  if (kind === "structured") return "structured_return";
+  if (kind === "process") return "process";
+
+  const separator = toolName?.indexOf("_") ?? -1;
+  return separator > 0 ? toolName?.slice(0, separator) ?? "external" : normalizeToolLabel(toolName ?? "external");
+}
+
+function externalToolAction(kind: ExternalToolFrameKind, toolName?: string): string | undefined {
+  if (!toolName || kind === "structured" || kind === "process") return undefined;
+  if (kind === "gitnexus" && toolName.startsWith("gitnexus_")) return toolName.slice("gitnexus_".length);
+  if (kind === "serena") return toolName;
+
+  const separator = toolName.indexOf("_");
+  return separator > 0 ? toolName.slice(separator + 1).replace(/^_+/u, "") : undefined;
+}
+
+function externalToolHeader(
+  kind: ExternalToolFrameKind,
+  toolName: string | undefined,
+  firstLine: string,
+): { provider: string; action?: string } {
+  const bracketHeader = firstLine.match(/^(?:[•›]\s+)?\[([A-Za-z][A-Za-z0-9 _-]{0,31})\](?:\s+(\S+))?/u);
+  const markerHeader = firstLine.match(/^[•›]\s+(\S+)(?:\s+(\S+))?/u);
+  return {
+    provider: bracketHeader?.[1] ?? externalToolProvider(kind, toolName),
+    action: externalToolAction(kind, toolName) ?? bracketHeader?.[2] ?? markerHeader?.[2],
+  };
 }
 
 export function renderExternalToolBackgroundLines(
@@ -339,27 +385,16 @@ export function renderExternalToolBackgroundLines(
   }
 
   const firstLine = displayLines[0] ?? "";
-  const action = kind === "gitnexus" && toolName?.startsWith("gitnexus_")
-    ? toolName.slice("gitnexus_".length)
-    : kind === "serena" ? toolName : undefined;
-  const providerHeader = /^\[[A-Za-z][A-Za-z0-9 _-]{0,31}\]/u.test(firstLine);
+  const hasHeader = /^(?:[•›]\s+)?\[[A-Za-z][A-Za-z0-9 _-]{0,31}\]/u.test(firstLine)
+    || /^[•›]\s+\S+/u.test(firstLine);
+  const header = externalToolHeader(kind, toolName, firstLine);
+  const payloadLines = hasHeader ? displayLines.slice(1) : displayLines;
+  displayLines = [
+    `${TOOL_ROW_MARKER} [${header.provider}]${header.action ? ` ${header.action}` : ""}`,
+    ...payloadLines,
+  ];
 
-  if (providerHeader && action && !firstLine.endsWith(` ${action}`)) {
-    displayLines = [`${firstLine} ${action}`, ...displayLines.slice(1)];
-  } else if (!/^(?:[•›]\s+|\[[A-Za-z][A-Za-z0-9 _-]{0,31}\])/u.test(firstLine)) {
-    const labels: Record<ExternalToolFrameKind, string> = {
-      serena: "Serena",
-      gitnexus: "GitNexus",
-      structured: "structured_return",
-      process: "process",
-      external: "external",
-    };
-    const label = kind === "external" && toolName ? normalizeToolLabel(toolName) : labels[kind];
-    displayLines = [`[${label}]${action ? ` ${action}` : ""}`, ...displayLines];
-  }
-
-  const header = displayLines[0] ?? "";
-  const payloadLines = displayLines.slice(1);
+  const renderedHeader = displayLines[0] ?? "";
   const visiblePayload = expanded ? payloadLines : payloadLines.slice(0, 6);
   const shown = visiblePayload.length;
   const total = payloadLines.length;
@@ -372,10 +407,10 @@ export function renderExternalToolBackgroundLines(
     formatPayloadSize(contentLines.join("\n")),
   ]);
   const renderWidth = Math.max(8, width);
-  const body = [header, ...visiblePayload].map((rawLine) => {
-    const line = truncateToWidth(rawLine, renderWidth);
-    return highlightExternalToolBadge(kind, line);
-  });
+  const body = [
+    highlightExternalToolBadge(kind, truncateToWidth(renderedHeader, renderWidth)),
+    ...visiblePayload.map((rawLine) => truncateToWidth(rawLine, renderWidth)),
+  ];
   return footerMeta
     ? [...body, `\x1b[2m${truncateToWidth(`└─ ${footerMeta}`, renderWidth)}\x1b[22m`]
     : body;
@@ -1275,8 +1310,6 @@ export default function xtrmUiExtension(pi: ExtensionAPI): void {
   void installExternalToolFramePatch().catch(() => undefined);
 
   let prefs: XtrmUiPrefs = { ...DEFAULT_PREFS };
-  const extensionThemeDir = join(__dirname, "../../themes/xtrm-ui");
-
   const getPrefs = () => prefs;
   const setPrefs = (nextPrefs: XtrmUiPrefs) => {
     prefs = nextPrefs;
@@ -1290,10 +1323,6 @@ export default function xtrmUiExtension(pi: ExtensionAPI): void {
     applyXtrmChrome(ctx, prefs, getThinkingLevel);
     applyThinkingChrome(ctx);
   };
-
-  pi.on("resources_discover", async () => ({
-    themePaths: [extensionThemeDir],
-  }));
 
   pi.on("session_start", async (_event, ctx) => {
     setPrefs(loadPrefs(ctx.sessionManager.getEntries() as Array<MaybeCustomEntry>));

--- a/packages/pi-extensions/extensions/xtrm-ui/package.json
+++ b/packages/pi-extensions/extensions/xtrm-ui/package.json
@@ -13,9 +13,6 @@
   "pi": {
     "extensions": [
       "./index.ts"
-    ],
-    "themes": [
-      "../../themes/xtrm-ui"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- move the beads shortcut to Alt+G and remove duplicate package theme discovery
- normalize external-tool provider/action headers and bold only the action
- show one structural parent-child group in expanded beads context, retaining closed siblings

## Validation
- `npm test --workspace cli -- custom-footer-parity.test.ts xtrm-ui.test.ts pi-runtime.test.ts`
- `node --test .xtrm/hooks/beads-status-cache.test.mjs`
- `npm run typecheck --workspace cli`
- `npm run verify:runtime --workspace packages/pi-extensions`
- fresh real-Pi Alt+G smoke: no shortcut/theme conflicts; parent-child group rendered

## Known baseline
- full `npm test --workspace cli`: 11 unrelated existing failures in install/registry/init suites (774 passed, 98 skipped).

Closes xtrm-58rt0
Closes xtrm-36hgk
Closes xtrm-6uc5c
