### PR TITLE
feat(skills): add verified-audit skill

### DIFF
--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -125,6 +125,14 @@
       "install_mode": "copy",
       "install_scope": "global",
       "files": {
+        "README.txt": {
+          "hash": "d28484cda62e8712fecbaf0fa8871d4f72fb7188557e5bc362caca79ef72cd45",
+          "version": "0.10.4"
+        },
+        "agent-docs-maintainer/SKILL.md": {
+          "hash": "a80ff7960f24889f49e3a213cc7f5a191319aa04fbecca2fd1681c8323c09f63",
+          "version": "0.10.4"
+        },
         "agent-docs-maintainer/references/agents-template.md": {
           "hash": "1c1f9b93ad13c2c76245fb13ff9f2663043bc6cc5fb0448dc16ab11cb4001e01",
           "version": "0.10.4"
@@ -145,10 +153,6 @@
           "hash": "ffd6ebd0ac2ed3b447672641088fc8d2115d43fcd1b48677d55cdf0d1ef8a5e2",
           "version": "0.10.4"
         },
-        "agent-docs-maintainer/SKILL.md": {
-          "hash": "a80ff7960f24889f49e3a213cc7f5a191319aa04fbecca2fd1681c8323c09f63",
-          "version": "0.10.4"
-        },
         "clean-code/SKILL.md": {
           "hash": "1b212a0a59f8162587a681b16e20af5bd793e4f6c7fb7c7af2d32a7deef553fb",
           "version": "0.10.4"
@@ -161,6 +165,10 @@
           "hash": "cd0dadf31266cdf2ecbe9c129357133f105078d93e9c714d929378feaf3c4e63",
           "version": "0.10.4"
         },
+        "delegating/SKILL.md": {
+          "hash": "bb1c8ed316735afb98d1d5b8f32e07f869091f8a56d079c9a1ac359f8ee67a9b",
+          "version": "0.10.4"
+        },
         "delegating/config.yaml": {
           "hash": "74ab621ffdb27c2c4dbf897220117c14dc30536d342c40df37143f0a7727ecd4",
           "version": "0.10.4"
@@ -169,16 +177,20 @@
           "hash": "010165d814d660116d72e4860ed0bf5aba68945202112de4a31747c1416cd571",
           "version": "0.10.4"
         },
-        "delegating/SKILL.md": {
-          "hash": "bb1c8ed316735afb98d1d5b8f32e07f869091f8a56d079c9a1ac359f8ee67a9b",
-          "version": "0.10.4"
-        },
         "deploy-monitor/SKILL.md": {
           "hash": "cb0f523edb1d4b6394ab991b6ce8aa88cf0687656bc6a3f85b65dadf66cf1e78",
           "version": "0.10.4"
         },
         "documenting/CHANGELOG.md": {
           "hash": "a3990e4ae7d5b509d8da9ca0dc08c2837e10db63f04711cb53159817ecf0ed00",
+          "version": "0.10.4"
+        },
+        "documenting/README.md": {
+          "hash": "780e6a9770377f5a654c178b02ff13c72687aaa517e86d6bbc600cb5fb6dcd10",
+          "version": "0.10.4"
+        },
+        "documenting/SKILL.md": {
+          "hash": "39e342ff2edc75f74c5905b0aa6aaa9477285c1d31619821ae0e3e9ad0661b07",
           "version": "0.10.4"
         },
         "documenting/examples/example_pattern.md": {
@@ -195,10 +207,6 @@
         },
         "documenting/examples/example_workflow.md": {
           "hash": "8bcd40bceee97b1ffeb917dc408a9fd39d19853796fc36d3f18f3003c4de3459",
-          "version": "0.10.4"
-        },
-        "documenting/README.md": {
-          "hash": "780e6a9770377f5a654c178b02ff13c72687aaa517e86d6bbc600cb5fb6dcd10",
           "version": "0.10.4"
         },
         "documenting/references/changelog-format.md": {
@@ -261,10 +269,6 @@
           "hash": "f694803e069bda7064d67d8fc02002420c205c9126ae7a22b2c9abeff101b6b0",
           "version": "0.10.4"
         },
-        "documenting/SKILL.md": {
-          "hash": "39e342ff2edc75f74c5905b0aa6aaa9477285c1d31619821ae0e3e9ad0661b07",
-          "version": "0.10.4"
-        },
         "documenting/templates/CHANGELOG.md.template": {
           "hash": "148a1e54e5b646a6909bd40dcb5ab0a8f0825a35a68fd2449bca51b5f476abb4",
           "version": "0.10.4"
@@ -309,6 +313,10 @@
           "hash": "6aab994ee0266063245245483ee3280645aca66c0c5e56730ffad3f32ecbbc5c",
           "version": "0.10.4"
         },
+        "hook-development/SKILL.md": {
+          "hash": "5d2c2d85e7bbe091ba394817f4a1b200570e259af765131440f80f270b7fe0ee",
+          "version": "0.10.4"
+        },
         "hook-development/examples/load-context.sh": {
           "hash": "0d614599e711c087b381a4ac7ee3c40758af1022669fc998649d199b9dfe15ed",
           "version": "0.10.4"
@@ -337,12 +345,12 @@
           "hash": "d5dc513af7756dff436bcf5fe09ee4d9a87dfb7d410b83029c64492c90da377c",
           "version": "0.10.4"
         },
-        "hook-development/scripts/hook-linter.sh": {
-          "hash": "85a7d55488f8f38f9b98350b5cb597fb306432d5e61eaa3444e7226ca9309e0b",
-          "version": "0.10.4"
-        },
         "hook-development/scripts/README.md": {
           "hash": "08a28b12ffa9fcb16f257ea685c70a920f4f835978b9ffbbac055137c6f6aca0",
+          "version": "0.10.4"
+        },
+        "hook-development/scripts/hook-linter.sh": {
+          "hash": "85a7d55488f8f38f9b98350b5cb597fb306432d5e61eaa3444e7226ca9309e0b",
           "version": "0.10.4"
         },
         "hook-development/scripts/test-hook.sh": {
@@ -353,10 +361,6 @@
           "hash": "e7785d6c61d368f5ea5270c979753aea02f776f5b6aa220137ec4585abd720c2",
           "version": "0.10.4"
         },
-        "hook-development/SKILL.md": {
-          "hash": "5d2c2d85e7bbe091ba394817f4a1b200570e259af765131440f80f270b7fe0ee",
-          "version": "0.10.4"
-        },
         "init-session/SKILL.md": {
           "hash": "861e5134c41aba3504374cbb522d225b8bdbf065e352009fea11a89593e0040e",
           "version": "0.10.4"
@@ -365,16 +369,20 @@
           "hash": "73e69f9611bd5b4cc11c68a27de0cf5c37f49ed769c3d0ad32ed3fa6aa6299da",
           "version": "0.10.4"
         },
+        "last30days/SKILL.md": {
+          "hash": "a437a67e7ae741b2ceaee35740a535a65e8f8aadf14d479d378616c7ccc46232",
+          "version": "0.10.4"
+        },
         "last30days/scripts/briefing.py": {
           "hash": "58c895621b028f3d265dd4a98d2ab8169d2256c468bd73e6dd3adf765dca2e67",
           "version": "0.10.4"
         },
-        "last30days/scripts/evaluate_search_quality.py": {
-          "hash": "8f33a48768936091df02aa4d3746576cd3c3e935d93d109607404ea801b8152a",
-          "version": "0.10.4"
-        },
         "last30days/scripts/evaluate-synthesis.py": {
           "hash": "59ee7918109b96dc2668412ddc02e9308ebb94b522bbaa5a2b81b3e3849bf7a4",
+          "version": "0.10.4"
+        },
+        "last30days/scripts/evaluate_search_quality.py": {
+          "hash": "8f33a48768936091df02aa4d3746576cd3c3e935d93d109607404ea801b8152a",
           "version": "0.10.4"
         },
         "last30days/scripts/generate-synthesis-inputs.py": {
@@ -473,12 +481,16 @@
           "hash": "b3865cbb343d64fcc89965af93f41f8015ee6df87759ee14118e2c8392ec6bcd",
           "version": "0.10.4"
         },
+        "last30days/scripts/lib/query.py": {
+          "hash": "6bc2e0649034cdb28471346a66e2448ba58762cb7774c4fce45c055ab160912a",
+          "version": "0.10.4"
+        },
         "last30days/scripts/lib/query_type.py": {
           "hash": "021073dc45df000ff3f6412aea82a6a3c33de2f732bf1b0b7b23390db02c6b9e",
           "version": "0.10.4"
         },
-        "last30days/scripts/lib/query.py": {
-          "hash": "6bc2e0649034cdb28471346a66e2448ba58762cb7774c4fce45c055ab160912a",
+        "last30days/scripts/lib/reddit.py": {
+          "hash": "aa22eb72e74753f352f4b638e032d8a737f1696f1bd0e6875ab2b4b9886059cb",
           "version": "0.10.4"
         },
         "last30days/scripts/lib/reddit_enrich.py": {
@@ -487,10 +499,6 @@
         },
         "last30days/scripts/lib/reddit_public.py": {
           "hash": "8c18f9a7896b167377e86f0125247dd823cd904512808d570e0da48ccd4b80ce",
-          "version": "0.10.4"
-        },
-        "last30days/scripts/lib/reddit.py": {
-          "hash": "aa22eb72e74753f352f4b638e032d8a737f1696f1bd0e6875ab2b4b9886059cb",
           "version": "0.10.4"
         },
         "last30days/scripts/lib/relevance.py": {
@@ -531,6 +539,10 @@
         },
         "last30days/scripts/lib/ui.py": {
           "hash": "a1267ec37871f33125c5c83d52de645167158044785178f9f87bf6464404b4c3",
+          "version": "0.10.4"
+        },
+        "last30days/scripts/lib/vendor/bird-search/LICENSE": {
+          "hash": "62316704df7426e5a79d2827ff8aca36e9abb3a73b8e68557030749ebefec667",
           "version": "0.10.4"
         },
         "last30days/scripts/lib/vendor/bird-search/bird-search.mjs": {
@@ -585,10 +597,6 @@
           "hash": "b230db5583760ccd0b5b5fb1592f449a7d0bc92f6184808e8ffb6f8968df20e9",
           "version": "0.10.4"
         },
-        "last30days/scripts/lib/vendor/bird-search/LICENSE": {
-          "hash": "62316704df7426e5a79d2827ff8aca36e9abb3a73b8e68557030749ebefec667",
-          "version": "0.10.4"
-        },
         "last30days/scripts/lib/vendor/bird-search/package.json": {
           "hash": "96b65305969a179ee7a7735f1b475599d6035f32fda1fd030ea57ee09380cdb5",
           "version": "0.10.4"
@@ -625,20 +633,16 @@
           "hash": "2c03ac8e72e07a917bdaa413080bda3c8a3eaeadbf9f55980b9048b76a4c19cd",
           "version": "0.10.4"
         },
-        "last30days/SKILL.md": {
-          "hash": "a437a67e7ae741b2ceaee35740a535a65e8f8aadf14d479d378616c7ccc46232",
-          "version": "0.10.4"
-        },
         "multiplexing-team/SKILL.md": {
           "hash": "efe2c3a9bbff08f408d9577cee3d9ae2151ac8a6c9ab4ab0bf9ea6b47c3824c5",
           "version": "0.10.4"
         },
-        "multiplexing/scripts/verify-deploy-applied.sh": {
-          "hash": "a7ed4ebeafb4c87c9c6870e39ba5de0db737bb85b2261eb76480d96b70902f06",
-          "version": "0.10.4"
-        },
         "multiplexing/SKILL.md": {
           "hash": "55bdcb01d3431803ef293592cc95b6f531cc9fcefc735aa761879ee1ca28fe5b",
+          "version": "0.10.4"
+        },
+        "multiplexing/scripts/verify-deploy-applied.sh": {
+          "hash": "a7ed4ebeafb4c87c9c6870e39ba5de0db737bb85b2261eb76480d96b70902f06",
           "version": "0.10.4"
         },
         "planning/SKILL.md": {
@@ -655,6 +659,10 @@
         },
         "prompt-improving/README.md": {
           "hash": "3eaf7f7249096c4892b4cdadf0c67fb978d65efc92572376fe30fcbe34f3a467",
+          "version": "0.10.4"
+        },
+        "prompt-improving/SKILL.md": {
+          "hash": "3eb21391e4512e6dfa47051159cb6f68d130bba068dbe5b6b4744c422ed18387",
           "version": "0.10.4"
         },
         "prompt-improving/references/analysis_commands.md": {
@@ -675,10 +683,6 @@
         },
         "prompt-improving/references/xml_core.md": {
           "hash": "d4c8115983056d595da2afdeceeb3839c688087ed2ddc05b1516a70fe97284fe",
-          "version": "0.10.4"
-        },
-        "prompt-improving/SKILL.md": {
-          "hash": "3eb21391e4512e6dfa47051159cb6f68d130bba068dbe5b6b4744c422ed18387",
           "version": "0.10.4"
         },
         "quality-gates/.claude/hooks/hook-config.json": {
@@ -705,24 +709,20 @@
           "hash": "f161db6c1c6b6cea904057bb89dba559d8518d8e1bdbba7838a343162c4e6cf5",
           "version": "0.10.4"
         },
-        "README.txt": {
-          "hash": "d28484cda62e8712fecbaf0fa8871d4f72fb7188557e5bc362caca79ef72cd45",
+        "releasing/SKILL.md": {
+          "hash": "7a128078b5bbfaa12c1c2b2ed7d993e8264aa2431747a972cd50b5f680a5ff35",
           "version": "0.10.4"
         },
         "releasing/scripts/xt-reports.ts": {
           "hash": "34592dc1bdc2207330270919108b1b89f08c85736192d02d69171249a8898f5c",
           "version": "0.10.4"
         },
-        "releasing/SKILL.md": {
-          "hash": "7a128078b5bbfaa12c1c2b2ed7d993e8264aa2431747a972cd50b5f680a5ff35",
+        "security-pipeline/SKILL.md": {
+          "hash": "cfd328ce7a831270a393fcc12e0a0645d2dab101eb81cde0ac4c7d599e13c90f",
           "version": "0.10.4"
         },
         "security-pipeline/scripts/security-bootstrap.sh": {
           "hash": "344b9be1ae5d4d7d83eab1e07ac583f262d73badbbad1b534182bfe806c64619",
-          "version": "0.10.4"
-        },
-        "security-pipeline/SKILL.md": {
-          "hash": "cfd328ce7a831270a393fcc12e0a0645d2dab101eb81cde0ac4c7d599e13c90f",
           "version": "0.10.4"
         },
         "security-pipeline/templates/.githooks/pre-push.template": {
@@ -759,6 +759,10 @@
         },
         "security-pipeline/templates/scripts/semgrep-diff.sh": {
           "hash": "e4efc20d218e6f6689725a4a9aca37958384216ba080bf89ba2307cd529d6dc2",
+          "version": "0.10.4"
+        },
+        "service-skills/SKILL.md": {
+          "hash": "ca9d1e2ce74b69f2cda6d71995674bcd5f0454e16fc1d6c20311a419fd6e5d30",
           "version": "0.10.4"
         },
         "service-skills/install/git-hooks/doc_reminder.py": {
@@ -857,12 +861,16 @@
           "hash": "842890132fbb5f69c33bf2f5b5f51291ca8f931afce034426724959b15ad71fd",
           "version": "0.10.4"
         },
-        "service-skills/SKILL.md": {
-          "hash": "ca9d1e2ce74b69f2cda6d71995674bcd5f0454e16fc1d6c20311a419fd6e5d30",
-          "version": "0.10.4"
-        },
         "session-close-report/SKILL.md": {
           "hash": "98c170dded2b9ec88e2f38da6cb99d07b40cda7c0df5cd9b8e176747231e9d2c",
+          "version": "0.10.4"
+        },
+        "skill-creator/LICENSE.txt": {
+          "hash": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
+          "version": "0.10.4"
+        },
+        "skill-creator/SKILL.md": {
+          "hash": "ba8bebb2c085444120743af8dc859dd7c2592d6290e93aa5e1c08403109bdce7",
           "version": "0.10.4"
         },
         "skill-creator/agents/analyzer.md": {
@@ -887,10 +895,6 @@
         },
         "skill-creator/eval-viewer/viewer.html": {
           "hash": "a53213426ee1100441d701a3a0d49cda7a842f992d2c36463f4d3cc0258575fa",
-          "version": "0.10.4"
-        },
-        "skill-creator/LICENSE.txt": {
-          "hash": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
           "version": "0.10.4"
         },
         "skill-creator/references/schemas.md": {
@@ -933,8 +937,8 @@
           "hash": "3af8ae62c40c73ab712207436a0d9a981e845f25c5a7040229eb189cc8e45bb1",
           "version": "0.10.4"
         },
-        "skill-creator/SKILL.md": {
-          "hash": "ba8bebb2c085444120743af8dc859dd7c2592d6290e93aa5e1c08403109bdce7",
+        "specialists-creator/SKILL.md": {
+          "hash": "223ab14dbd1c2443f147600691819408faed9f13524d485c0b99394fa84e0981",
           "version": "0.10.4"
         },
         "specialists-creator/scripts/audit-spec-uniformity.mjs": {
@@ -949,8 +953,8 @@
           "hash": "3a5f5a3a77c50e98ecf9188634ff2882f8143b19d0f28a53aff5c42e1bd09dfa",
           "version": "0.10.4"
         },
-        "specialists-creator/SKILL.md": {
-          "hash": "223ab14dbd1c2443f147600691819408faed9f13524d485c0b99394fa84e0981",
+        "sre-triage/SKILL.md": {
+          "hash": "b0d2b3c662064845d4810bff0720ae60f7cf9fc194662d5791e207af5692f608",
           "version": "0.10.4"
         },
         "sre-triage/scripts/alert_history.py": {
@@ -961,8 +965,8 @@
           "hash": "24b79c241cb629bd1ee964db9e5d5762cc1e12dca97e31204d4a3de864501695",
           "version": "0.10.4"
         },
-        "sre-triage/SKILL.md": {
-          "hash": "b0d2b3c662064845d4810bff0720ae60f7cf9fc194662d5791e207af5692f608",
+        "sync-docs/SKILL.md": {
+          "hash": "ebcdfe1f4d8e752e1a594ac32fcac2cf7d7817f65202b90fe4d58b266cf8fd33",
           "version": "0.10.4"
         },
         "sync-docs/references/doc-structure.md": {
@@ -1001,10 +1005,6 @@
           "hash": "8f85d3de0d78541a056a32400b0a0c753c277e73c6462492aa44f1723ff62fa2",
           "version": "0.10.4"
         },
-        "sync-docs/SKILL.md": {
-          "hash": "ebcdfe1f4d8e752e1a594ac32fcac2cf7d7817f65202b90fe4d58b266cf8fd33",
-          "version": "0.10.4"
-        },
         "test-planning/SKILL.md": {
           "hash": "6b2d56e6e8daa277632798877ddeeb659053c3d6ffbadc9f580a51fc3fb86205",
           "version": "0.10.4"
@@ -1017,16 +1017,16 @@
           "hash": "93e3fa59acb53fff32502b12a39f41dc23882aa10061c9e14ba6cded4ae1ecd4",
           "version": "0.10.4"
         },
+        "updating-dependencies/SKILL.md": {
+          "hash": "0121ffef95ea24ef4dc3edad69d3e8d5b42d2e53b9928bbee6c54d3cc101b4f8",
+          "version": "0.10.4"
+        },
         "updating-dependencies/schemas/dependency_update_case.schema.json": {
           "hash": "2f29b206593219548c7b8481c3d1d041861bc943a383e6ef15dab1cd8cbb2827",
           "version": "0.10.4"
         },
         "updating-dependencies/schemas/upgrade_dossier.schema.json": {
           "hash": "19486d8b0c9563fa63d389e66b2b7df2876e7a0113b9302bd44bdb8ac649de12",
-          "version": "0.10.4"
-        },
-        "updating-dependencies/SKILL.md": {
-          "hash": "0121ffef95ea24ef4dc3edad69d3e8d5b42d2e53b9928bbee6c54d3cc101b4f8",
           "version": "0.10.4"
         },
         "updating-dependencies/templates/post-deploy-watch-spec.md": {
@@ -1079,6 +1079,10 @@
         },
         "vaultctl/SKILL.md": {
           "hash": "fe4e5287982be10acc2439727b4b8add7052b037a7c67fb48e7bcf214cc54214",
+          "version": "0.10.4"
+        },
+        "verified-audit/SKILL.md": {
+          "hash": "ca2b4e79dec1c2f139fa21b30d906fb985fbfe825ba2bbe023fb27efc59f75a7",
           "version": "0.10.4"
         },
         "xt-debugging/SKILL.md": {

--- a/.xtrm/skills/default/verified-audit/SKILL.md
+++ b/.xtrm/skills/default/verified-audit/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: verified-audit
+description: "Audit a file, subsystem, or repo for over-engineering and inefficiency, and verify every candidate cut with call-graph impact analysis before proposing it. Use whenever the user says \"audit this\", \"what can I delete\", \"find slop\", \"find bloat\", \"is this over-engineered\", \"sweep for waste\", \"reduce complexity\", \"hunt for redundant code\", \"find performance slop\", \"latency review\", \"find hot-path waste\", or asks for a whole-file / cross-file / repo-wide review of code quality. Two orthogonal axes are covered: line-count slop (dead code, one-line wrappers, reinvented stdlib, duplicated helpers, dead enum branches) and efficiency slop (sync fork in hot path, unmemoized deterministic computation, redundant I/O, N+1, regex-per-call, object alloc in loops, sequential-independent awaits). Every finding carries verified blast-radius receipts — never propose a cut without them. Diff-scope review is out of scope (use reviewer/seconder for that); this skill is for whole-file audits and repo sweeps."
+---
+
+# Verified Audit
+
+A senior-engineer audit lens for over-engineering and inefficiency, paired with call-graph verification so no proposed cut ships without receipts.
+
+## When to use
+
+Whole-file audits, cross-file sweeps, repo-wide reviews. Trigger phrases:
+
+- "audit this file / subsystem / repo"
+- "what can we delete"
+- "find over-engineering" / "find bloat" / "find slop"
+- "sweep for waste"
+- "latency review" / "hot-path review" / "find performance slop"
+- "is this over-engineered"
+- "reduce complexity"
+
+## When NOT to use
+
+- Small diffs on one branch → that's what `reviewer` and `seconder` are for. They already run a bounded post-writer gate on the writer's diff with the same vocabulary. This skill is broader (whole-file, cross-file) and heavier (efficiency lens + subagent sweeps).
+- Correctness bugs → use `/code-review` or the reviewer specialist.
+- Security findings → use `security-review` or `security-auditor`.
+
+## Why bother
+
+Two failure modes this skill is designed against:
+
+1. **Naive audit proposes cuts that are load-bearing.** "Looks like slop" without a call-graph check is guesswork. GitNexus turns it into "safe to cut, here is the blast radius."
+2. **Line-count review misses latency slop entirely.** Redundant I/O, sync fork in hot paths, unmemoized deterministic computation — zero line savings, huge user-visible cost. A pure line-count review will not catch these.
+
+The skill exists to separate "looks like slop" from "is slop" — and to run both axes at once.
+
+## Method: four legs
+
+Every audit runs four legs. Skip any leg and you either miss real slop or ship a cut that breaks something.
+
+### Leg 1 — The reduction lens (line-count)
+
+Read the target. For every candidate, stop at the first rule that holds:
+
+1. **Does it need to exist?** Speculative or dead code → mark for delete.
+2. **Already in this codebase?** A helper 3 files over already does this → reuse it.
+3. **Stdlib does it?** Use it. (Node examples: `setTimeout` from `node:timers/promises` for `sleep`, `randomUUID` from `node:crypto`, `structuredClone` for deep copy.)
+4. **Native platform feature covers it?** Language/runtime primitive over user-space code.
+5. **Already-installed dependency solves it?** Grep `package.json` before writing anything the deps handle (e.g. `zod` for schema validation, don't hand-roll a validator).
+6. **Can it be one line?** Chained `.replace()` × 3 → one regex. Named 4-line helper with one call site → inline expression.
+7. **Only then:** the minimum code that works.
+
+### Leg 2 — Call-graph verification (GitNexus impact)
+
+For every function/method/class candidate:
+
+```
+mcp__gitnexus__impact({target: "<symbolName>", direction: "upstream", repo: "<repo>"})
+```
+
+Record: `risk` (LOW/MEDIUM/HIGH/CRITICAL), `direct_callers`, `processes_affected`, `modules_affected`. Batch calls in parallel — one message with N tool uses.
+
+**Filter:** LOW = safe cut, MEDIUM = safe cut with a verify pass, HIGH = redesign or leave, CRITICAL = leave. Slop can live at all levels; only CRITICAL is a hard stop.
+
+### Leg 3 — Config / usage grep (for enum branches and dead data)
+
+GitNexus reasons about symbols, not enum values or dead switch cases. For candidates that look like:
+
+- A branch in a `switch (outputType) { case 'foo': ... }` and no config sets `outputType: 'foo'`.
+- A `Record<Enum, T>` entry whose key is never referenced by any consumer.
+- A deprecated code path (YAML fallback, legacy migration bridge) that no live spec exercises.
+
+Grep the config directories and the consumer files to prove/disprove reachable. Dead data does not appear in a call graph.
+
+### Leg 4 — Efficiency signals (the axis line-count misses)
+
+Scan for these independent of line-count:
+
+- **Sync fork in hot path**: `execSync`, `spawnSync`, `readFileSync`, `existsSync` inside per-spawn / per-turn / per-event code. Each blocks the event loop.
+- **Regex / schema / template constants inside functions** — recompiled per call. Hoist to module scope.
+- **Redundant instantiation** — `new X()` more than once per logical operation.
+- **Deterministic pure computations re-run per call** — same input, same output, recomputed every invocation. Memoize with `Map` / `WeakMap` / module-scope const.
+- **Sequential awaits / execSyncs of independent operations** — `Promise.all` / parallel batch candidates.
+- **N+1 patterns** — any loop containing a subprocess spawn, fs read, or SQLite query.
+- **Duplicate reads** — same file / bead / SQLite row read more than once per logical operation.
+- **JSON.parse of the same string more than once** — parse once, pass the value.
+- **String concatenation in loops** — accumulator `+=` on an unbounded input is O(n²). Use `parts: string[]` + `.join('')`.
+- **Object allocation in hot loops** — repeated 9-field object literals at each branch of a switch, when 7 of 9 fields are invariant across branches. Bind once, spread the deltas.
+- **Prompt / schema / skill-path assembly re-done for identical inputs** — memoize per-spec at load time.
+- **Wasted async** — `await` on something that could have been fired-and-parallelized.
+
+Rank each efficiency finding by **latency**:
+
+- **HIGH**: >100ms per event, or O(n²) at scale, or sync-blocking >50ms, or a network syscall in a per-spawn path.
+- **MEDIUM**: 10-100ms per event, per-turn cost, extra SQLite roundtrip per hot-path.
+- **LOW**: allocation-only, regex-hoist, one-pass merge, memoize-cheap-fn.
+
+Efficiency findings frequently save zero lines — that is fine. They are their own axis.
+
+## Methodology gotchas
+
+Real failures from prior sweeps. Read before running.
+
+### 1. Closures inside methods fool GitNexus
+
+A function defined as a closure inside another method (e.g. `const handler = () => { ... }` inside `run()`) has `direct_callers = 0` in the impact graph. GitNexus does not see the enclosing method's own body as a caller of its inner closures.
+
+**Workaround:** when impact reports `direct_callers=0` on something you know is called, grep-verify. Search the file for the closure name; caller lives in the enclosing method.
+
+### 2. Dead-data branches evade GitNexus
+
+Dead entries in a `Record<Enum, T>`, unused `case 'x':` in a switch, deprecated format handlers (YAML alongside JSON when no `.yaml` files exist) — none appear as "dead code" in the call graph. The function containing the switch is very much alive.
+
+**Workaround:** Leg 3 (config grep). List every value the discriminator can take; grep for actual producers.
+
+### 3. Dead files exist
+
+An entire module can be speculative infrastructure shipped ahead of demand, imported only by its own test. Whole-module gitnexus impact + `rg -n` on top-level exports across `src/` and `config/` catches these fast.
+
+**Workaround:** for any suspected dead file, `rg -n '<exportedName>|<exportedType>' src config`. If the only hits are the file itself + its test, it is deletable.
+
+### 4. File size ≠ slop density
+
+The scariest, biggest file often has the least line-count slop and the most efficiency slop. Do not rank sweep priority by line count. Rank by suspected hot-path density: which files are on the request path, the per-spawn path, the per-tick path.
+
+## Finding output format
+
+One section per finding. Rank by (lines_saved × ease) for line-count, by latency tier for efficiency.
+
+```
+### F<n> — <one-sentence summary>. LINE-IMPACT: <LOW|MEDIUM|HIGH|-> / LATENCY: <LOW|MEDIUM|HIGH|->
+- Where: `path:lineStart-lineEnd`
+- Cut rule: <1-7 from Leg 1, or "efficiency-only">
+- Signal: <which Leg-4 signal, or which Leg-1 rule caught it>
+- Impact receipts: `<symbol>` → risk=<X>, direct_callers=<N>, processes=<N>, modules=[<list>].
+- Callers: <list, or "internal to file only">
+- Cost estimate: <per-spawn / per-turn / per-tick / per-N ops — for efficiency findings>
+- Fix: <the lazier or faster version — one sentence or a short snippet>
+- Lines saved: <N or 0>
+- Verify notes: <for MEDIUM/HIGH — test / snapshot / benchmark that catches drift>
+```
+
+Always finish the report with:
+
+- **Total est. line savings** and **total efficiency wins by tier**.
+- **Methodology limits** — what this pass couldn't catch (things that need a human, a benchmark, or a different lens).
+- **Skipped-but-checked** — candidates that looked like slop but proved load-bearing. Every skip cites its evidence (test that pins the behavior, cross-module caller that gitnexus caught, config value that keeps the branch live). This section is high-signal — it stops the next reviewer from re-flagging the same thing.
+
+## Scaling: subagent sweep pattern
+
+For a repo-wide audit, do NOT do it in one context. Fan out one subagent per file, in parallel.
+
+Per-file subagent prompt template:
+
+- **Target**: one file path, plus known prior findings on it (so the subagent does not re-report).
+- **Legs**: all four required; explicit list of efficiency signals.
+- **Verification**: GitNexus impact for every function candidate; grep for enum-branch candidates; whole-file impact + `rg` for suspected dead files.
+- **Format**: the finding template above.
+- **Filter**: report LOW/MEDIUM/HIGH; skip CRITICAL. MEDIUM+ needs verify notes.
+- **Don't**: no edits, no invented findings, no proposed additions of abstractions. Subtractive only.
+
+After all subagents return, merge:
+
+1. Deduplicate cross-file findings (e.g. a `sleep` helper duplicated in two files surfaces from both — collapse to one finding with both locations).
+2. Rank by (lines_saved × ease) for line-count, latency tier for efficiency.
+3. Emit pure-delete inventory (zero verify needed) separately from structural findings (verify required) — the former ships as one commit, the latter goes bead-by-bead.
+
+## Applying cuts
+
+Sequence:
+
+1. **Pure deletes first.** Zero-caller functions, whole-file kills, dead-data branches with no live producer. One commit, brief message. No verify required beyond `tsc --noEmit` / linter / test suite passing.
+2. **LOW inlines next.** Single-caller helpers, chained `.replace()` → one regex. One commit per logical group.
+3. **MEDIUM structural cuts** each get their own commit and their own verify pass:
+   - Snapshot the user-facing surface before (test suite output, prompt blob, SQLite row schema, whatever the change touches).
+   - Apply the cut.
+   - Diff the surface. Behavior must be byte-identical unless the change is explicitly semantic.
+4. **HIGH cuts** get a plan reviewed before shipping. Do not batch with anything else.
+
+## What this skill will not do
+
+- Add abstractions to make future work easier. Subtractive only — that is the whole point.
+- Propose migrations (framework swap, dep swap). Slop reduction, not architecture change.
+- Judge style or naming for taste. Findings must have concrete evidence (line count, latency estimate, gitnexus receipts). "Looks messy" is not a finding.
+- Second-guess load-bearing code without evidence. The skipped-but-checked section is the discipline.
+
+## Reference
+
+Prior sweep on the specialists repo (7 core files, ~7500 lines) produced 61 findings, ~535 removable lines, and 38 verified efficiency wins. Top user-visible wins came from Leg 4: an SQLite N+1 in a per-status-write path, a `readFileSync + JSON.parse` per specialist during `sp list`, a 500ms–10s network syscall in a fallback branch. None would have surfaced from a line-count-only pass. Both axes are load-bearing.


### PR DESCRIPTION
## Summary

- Adds `verified-audit` skill to `.xtrm/skills/default/` — a four-leg audit methodology (line-count reduction lens, GitNexus impact verification, config/usage grep for enum branches, efficiency signals hunt) that produces cut proposals with mandatory blast-radius receipts.
- Registers the skill in `.xtrm/registry.json` (hash `ca2b4e79…`, version `0.10.4`).
- Registry file is re-sorted alphabetically as a side effect of jq's insert operation — same 243 skill entries + 28 hooks + 14 config + 70 skills_optional, ordering-only change on the rest.

## Why

Ponytail-style reviews miss latency slop (redundant I/O, sync fork in hot paths, unmemoized deterministic computation) — those are zero-line-savings but high-user-visible cost. GitNexus impact reviews miss dead-data branches and speculative infra. The four-leg method combines both axes and requires call-graph receipts before any proposed cut.

## Proven on

Specialists repo sweep of 7 core files (~7500 lines): 61 findings, ~535 removable lines, 38 verified efficiency wins including hot-path SQLite N+1s, `sp list` doing 25× redundant global-config parses, and a 500ms–10s network syscall in a `resolveDefaultBranch` fallback. None would surface from a line-count-only pass.

## Wiring

Reviewer specialist in the specialists repo is wired via a follow-up PR (xtrm-dev/specialists) that adds this skill to its `skills.paths`. That PR **must land after this one is installed on the host** — otherwise reviewer's pre-run validator hard-fails on the missing skill file.

## Test plan

- [ ] Merge this PR.
- [ ] Run `xt update` (or equivalent skills-reconcile) on the host to install into `~/.xtrm/skills/default/verified-audit/`.
- [ ] Merge the specialists follow-up PR.
- [ ] Trigger a reviewer run and verify the skill loads (spec validator + runtime skills.paths existence check).

Refs: unitAI-jfqpy, unitAI-jfqpy.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)