### PR TITLE
chore(security): baseline historical Qwen OAuth commit + ignore accounts/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,10 @@ hooks/tsconfig-cache.json
 # Beads / Dolt files (added by bd init)
 .beads/proxieddb/
 
+# Local provider OAuth credentials (never track account snapshots).
+accounts/oauth_creds_*.json
+accounts/
+
 # Local agent/runtime dotfile artifacts (generated per checkout, not source)
 .claude/settings.json
 .claude/service-registry.json

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,6 +6,10 @@ useDefault = true
 
 [allowlist]
 description = "xtrm-tools allowlist"
+# Historical Qwen OAuth credentials were revoked; keep this commit out of full-history scans.
+commits = [
+    '''dc019b8848a03ceedc3d388c9316110acb2c4b1d''',
+]
 stopwords = []
 regexes = [
     # Test fixture placeholders in cli/test/install-pi.test.ts.


### PR DESCRIPTION
Historical commit dc019b88 (2026-02-06) added 5 short-lived Qwen OAuth
tokens under accounts/oauth_creds_*.json. Tokens are revoked. Files no
longer tracked. Add commit to gitleaks allowlist to stop backstop scan
noise, and ignore accounts/ path so future snapshots don't slip in.

Fixes xtrm-e5d0c
