### PR TITLE
docs(multiplexing): document bare xt claude/pi --prompt launch mode

### DIFF
--- a/.xtrm/skills/default/multiplexing/SKILL.md
+++ b/.xtrm/skills/default/multiplexing/SKILL.md
@@ -163,6 +163,29 @@ Steps:
 5. On confirmation: use `xtmux safe-send-pointer --yes ...` when available; otherwise `tmux send-keys -t Y '<single-line pointer>' Enter`. **Claude Code panes consume the first Enter deterministically as paste-detection**; send a second Enter after 1-2s for Claude Code targets. Codex/pi panes submit on the first Enter.
 6. If polling is appropriate, set up a registered monitor or background polling loop (see Monitoring).
 
+### Pattern 2b — Bare launch of a general-purpose worker (post PR #433 / xtmux-r6g.6)
+
+When the delegate is a general-purpose worker rather than a specialist config, launch it in bare mode. **Do not reach for `tmux new-session -d claude`** — that skips the `--dangerously-skip-permissions` flag the `xt` wrapper adds automatically, and burns the operator with hundreds of approval prompts.
+
+```bash
+# Claude Code worker — adds --dangerously-skip-permissions automatically.
+xt claude <session-name> --no-attach --prompt 'leggi /tmp/<session>-<topic>.txt e seguilo'
+
+# Pi worker — same shape, no permission-bypass concept.
+xt pi <session-name> --no-attach --prompt 'leggi /tmp/<session>-<topic>.txt e seguilo'
+```
+
+Both print `session_name:pane_id` on stdout, honour the standard session-naming convention as `<runtime>-<slug>`, and export `XTMUX_AGENT_TASK` / `XTMUX_AGENT_PROMPT_FILE` into the child. `--prompt` and `--bead` are mutually exclusive — pick one. For trackable work, prefer `--bead <id>` so the worker reads the durable contract via `bd show <id>` and appends notes back to it; `--prompt` is right for one-shots and pointer-style handoffs.
+
+Slash-command syntax differs across runtimes — do not paste one into the wrong pane:
+
+| Runtime | Slash form | Example |
+|---|---|---|
+| Claude Code | `/<name>` | `/multiplexing`, `/using-specialists` |
+| Pi          | `/skill:<name>` | `/skill:multiplexing`, `/skill:using-specialists` |
+
+`--` passthrough and `--parent` / `--child` / `--reuse` require `--role`; they are rejected in bare mode. When you need those (or a persistent coordinator with specialist state), use Pattern 7 instead — bare and role modes are complementary, not competitors.
+
 ### Pattern 3 — Cleanup hygiene
 
 Trigger: operator says "clean orphans", "kill dead sessions", "what's leaking RAM"


### PR DESCRIPTION
## Summary
- Adds Pattern 2b to `.xtrm/skills/default/multiplexing/SKILL.md` covering bare launch mode enabled by PR #433.
- Documents `xt claude/pi <name> --no-attach --prompt "..."` (no `--role` needed), `--prompt` / `--bead` mutual exclusion, and the automatic `--dangerously-skip-permissions` for Claude Code panes.
- Adds slash-command syntax table (`/name` for Claude vs `/skill:<name>` for pi).
- Notes that `--` passthrough / `--parent` / `--child` / `--reuse` remain `--role`-only, and points at Pattern 7 for coordinator use cases.

## Why
Multiplexing skill still taught only the `--role` pattern from PR #391. Downstream orchestrators without a specialist config were reaching for `tmux new-session -d claude`, which drops the permission-bypass flag the `xt` wrapper adds — observed in the xtmux-r6g sprint as hundreds of manual approvals.

## Audit for PR #433
- ✅ CLI (`cli/src/commands/claude.ts`, `pi.ts`, `worktree-session.ts`) shipped bare mode with tests.
- ✅ `xt claude --help` / `xt pi --help` already document the new flags and show bare examples.
- ❌ (fixed here) Multiplexing SKILL.md missed it.
- Out of scope per bead NON_GOALS: delegating, using-specialists.

Closes xtrm-fk6i5.

## Test plan
- [x] `grep -n 'bare mode\|Pattern 2b\|/skill:' .xtrm/skills/default/multiplexing/SKILL.md` → matches
- [x] Reader lands on new pattern immediately after Pattern 2 (Assisted hand-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)