### PR TITLE
test(cli): fix update.test.ts stale expectations post-f42ns.8 (xtrm-f42ns.10)

### DIFF
--- a/cli/src/tests/update.test.ts
+++ b/cli/src/tests/update.test.ts
@@ -441,7 +441,7 @@ describe('xtrm update', () => {
     await runUpdateCli(['--apply', '--repo', repo]);
 
     expect(logBootstrapTriggerMock).toHaveBeenCalledWith({ command: 'update', cwd: tmpDir, pkgVersion: '1.2.3' });
-    expect(ensureGlobalSkillsBootstrappedMock).toHaveBeenCalledWith(packageRoot);
+    expect(ensureGlobalSkillsBootstrappedMock).toHaveBeenCalledWith(packageRoot, {});
     expect(logBootstrapTriggerMock.mock.invocationCallOrder[0]).toBeLessThan(checkDriftMock.mock.invocationCallOrder[0]);
     expect(ensureGlobalSkillsBootstrappedMock.mock.invocationCallOrder[0]).toBeLessThan(checkDriftMock.mock.invocationCallOrder[0]);
   });
@@ -484,8 +484,7 @@ describe('xtrm update', () => {
   it('help mentions package freshness and refresh behavior', async () => {
     const command = createUpdateCommand();
     const help = await command.helpInformation();
-    expect(help).toContain('global xt Pi packages');
-    expect(help).toContain('missing or outdated packages');
+    expect(help).toContain('Routine refresh and repair for xtrm-managed files, runtimes, hooks, skills, and packages');
     expect(help).toContain('--all-repos');
   });
 });


### PR DESCRIPTION
## Summary

Test-only fix. Two tests in \`cli/src/tests/update.test.ts\` pinned pre-consolidation behavior and started failing after #446 (xtrm-f42ns.8, UX consolidation) landed:

- Bootstrap mock signature (stale call ordering)
- Help text (\`'global xt Pi packages'\` — replaced in .8)

No production behavior modified. Restores CI 'test (22.x, 3.11)' to green on main.

## Why this exists

PR #446 landed with CI test failing because 'test (22.x, 3.11)' is NOT in main's required-checks list (only Gitleaks/Semgrep/OSV scan are required). Bad state on main ~1h.

## Follow-up (separate track)

Branch protection on main should include 'test (22.x, 3.11)' as a required check to prevent recurrence. Not in this bead's scope.

## Closes

xtrm-f42ns.10 (follow-up to xtrm-f42ns.8)