### PR TITLE
test(cli): harden HOME leak guard + strip env leaks + exclude worktrees from root vitest (xtrm-on2mk)

### DIFF
--- a/cli/src/tests/claude-runtime-sync-global-guard.test.ts
+++ b/cli/src/tests/claude-runtime-sync-global-guard.test.ts
@@ -3,6 +3,14 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// xtrm-on2mk: force the pre-global-hooks branch this file was written to
+// exercise. Without this mock, operators with XTRM_GLOBAL_HOOKS=1 exported
+// in their shell drop into reconcileGlobalClaudeHooks — which reads
+// <tmpHome>/.xtrm/config/hooks.json that this test never seeds.
+vi.mock('../core/global-hooks-flag.js', () => ({
+  shouldUseGlobalHooks: () => false,
+}));
+
 import { runClaudeRuntimeSyncPhase } from '../core/claude-runtime-sync.js';
 
 // xtrm-il7ov: runClaudeRuntimeSyncPhase must NOT overwrite the hooks section of

--- a/cli/test/setup.ts
+++ b/cli/test/setup.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+import fsSync from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -8,50 +10,63 @@ const runnerCwd = path.resolve(process.cwd());
 const tmpGitPath = path.join(tempRoot, '.git');
 const runnerStartsOutsideTmp = runnerCwd !== tempRoot && !runnerCwd.startsWith(`${tempRoot}${path.sep}`);
 
-// HOME LEAK DETECTOR (xtrm-8zsi1).
-// A prior full-suite run wiped the operator's real ~/.xtrm/skills/default and
-// ~/.xtrm/hooks/ payload because tests that trigger init/install/bootstrap
-// paths did not sandbox HOME. A universal HOME override was too aggressive
-// (pi-runtime tests fall back to `npm view` when their PI_AGENT_DIR is
-// package-empty, adding 5s network timeouts per managed package). Instead:
-//
-//   * Each leaky test file (init-phases, prune-retired-managed-skills, etc.)
-//     sandboxes HOME in its own beforeEach/afterEach.
-//   * This setup DETECTS regressions: if the guarded state.json files under
-//     the real user's ~/.xtrm/{hooks,skills}/ ever change mtime during the
-//     test process, throw immediately in afterEach so the offender is named.
+// xtrm-on2mk: TREE-HASH LEAK GUARD.
+// The prior mtime-only detector could not catch a wipe that leaves
+// state.json alone. When an operator ran vitest from a repo root whose glob
+// reached older worktree copies of init-phases (pre-xtrm-8zsi1), those
+// tests wiped ~/.xtrm/{hooks/*,skills/default/*} because they resolved
+// os.homedir() live and state.json's mtime did not change in the same
+// process. Hash the whole ~/.xtrm/{hooks,skills/default} tree at module
+// load and again in afterEach; throw and name the offender if it drifted.
 const realHome = process.env.HOME ?? os.homedir();
-const guardedPaths = [
-  path.join(realHome, '.xtrm', 'hooks', 'state.json'),
-  path.join(realHome, '.xtrm', 'skills', 'state.json'),
+const guardedTrees = [
+  path.join(realHome, '.xtrm', 'hooks'),
+  path.join(realHome, '.xtrm', 'skills', 'default'),
 ];
 
-async function currentMtime(p: string): Promise<number> {
-  try { return (await fs.stat(p)).mtimeMs; } catch { return -1; }
+async function treeHash(dir: string): Promise<string> {
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const parts: string[] = [];
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const full = path.join(dir, entry.name);
+      // eslint-disable-next-line no-await-in-loop
+      const stat = await fs.stat(full).catch(() => null);
+      if (!stat) continue;
+      if (stat.isDirectory()) {
+        // eslint-disable-next-line no-await-in-loop
+        parts.push(`${entry.name}/${await treeHash(full)}`);
+      } else {
+        parts.push(`${entry.name}:${stat.size}:${stat.mtimeMs}`);
+      }
+    }
+    return crypto.createHash('sha256').update(parts.join('\n')).digest('hex');
+  } catch {
+    return 'missing';
+  }
 }
 
-const initialMtimes = new Map<string, number>();
-for (const p of guardedPaths) {
+const initialTreeHashes = new Map<string, string>();
+for (const tree of guardedTrees) {
   // eslint-disable-next-line no-await-in-loop
-  initialMtimes.set(p, await currentMtime(p));
+  initialTreeHashes.set(tree, await treeHash(tree));
 }
 
 async function assertRealHomeUntouched(): Promise<void> {
-  for (const p of guardedPaths) {
+  for (const tree of guardedTrees) {
     // eslint-disable-next-line no-await-in-loop
-    const now = await currentMtime(p);
-    const initial = initialMtimes.get(p) ?? -1;
+    const now = await treeHash(tree);
+    const initial = initialTreeHashes.get(tree) ?? 'missing';
     if (now !== initial) {
-      // Update baseline so subsequent tests aren't spammed with the same
-      // failure — but throw once loudly so the responsible test is named.
-      initialMtimes.set(p, now);
+      initialTreeHashes.set(tree, now);
       throw new Error(
-        `test setup: real user's ${p} was touched during a test `
-        + `(mtime ${initial} -> ${now}). This is the class of leak that wiped `
-        + `~/.xtrm/skills/default and ~/.xtrm/hooks/ in xtrm-8zsi1. `
+        `test setup: real user's ${tree} tree was modified during a test `
+        + `(hash ${initial.slice(0, 12)} -> ${now.slice(0, 12)}). This is the class of `
+        + `leak that wiped ~/.xtrm/{hooks,skills/default} during xtrm-on2mk. `
         + `Sandbox HOME in this test's beforeEach: `
         + `previousHome = process.env.HOME; process.env.HOME = fs.mkdtempSync(...); `
-        + `and restore in afterEach.`,
+        + `and restore in afterEach. If your code path uses os.homedir(), also `
+        + `vi.spyOn(os, 'homedir').mockReturnValue(sandboxHome).`,
       );
     }
   }
@@ -65,7 +80,21 @@ async function removeTmpGitPollution(): Promise<void> {
 
 await removeTmpGitPollution();
 
-beforeEach(removeTmpGitPollution);
+// xtrm-on2mk: operators using the global migration export
+// XTRM_GLOBAL_HOOKS=1 and XTRM_GLOBAL_SKILLS=1 in their shell. Vitest
+// inherits the parent env, which forces tests that assume the pre-global
+// branches (registry-scaffold, prune-retired-managed-skills, update,
+// claude-runtime-sync-global-guard, ...) down code paths they never seed.
+// Tests that want the global branches set the env var explicitly inside
+// their own beforeEach.
+delete process.env.XTRM_GLOBAL_HOOKS;
+delete process.env.XTRM_GLOBAL_SKILLS;
+
+beforeEach(() => {
+  delete process.env.XTRM_GLOBAL_HOOKS;
+  delete process.env.XTRM_GLOBAL_SKILLS;
+  return removeTmpGitPollution();
+});
 afterEach(async () => {
   await removeTmpGitPollution();
   await assertRealHomeUntouched();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+// xtrm-on2mk: repo-root config exists solely to prevent `npx vitest run`
+// (invoked from repo root by mistake) from globbing test files across every
+// .xtrm/worktrees/*/cli/src/tests/ tree — which would otherwise multiply
+// any failure by the number of worktrees present. The canonical entry point
+// is `npm test --workspace cli` (see CLAUDE.md); this is a safety net.
+export default defineConfig({
+  test: {
+    include: ['cli/src/**/*.test.ts', 'cli/test/**/*.test.ts'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '.xtrm/worktrees/**',
+      '.git/**',
+    ],
+  },
+});


### PR DESCRIPTION
## What happened
Investigating "70 failing tests" on \`main\` uncovered a chain of test-isolation failures that had actually **wiped my real \`~/.xtrm/{hooks,skills/default}\` payload** during a naive \`npx vitest run\` from the repo root. Full incident writeup in xtrm-on2mk. This PR is the test-hygiene half of the fix.

## Three defects converged
1. **Root-directory vitest glob crossed worktrees.** No repo-root \`vitest.config.*\` → vitest defaults globbed \`**/*.test.ts\` — including all \`.xtrm/worktrees/*/cli/src/tests/\` (34 worktrees present). Each failing test ran once per worktree → 70+ failures.
2. **Pre-xtrm-8zsi1 worktree copies of \`init-phases.test.ts\` had no HOME sandbox.** When globbed by (1) they resolved \`os.homedir()\` live and wrote directly into real \`~/.xtrm/{hooks,skills/default}\`, wiping the payload.
3. **The setup.ts leak detector only watched \`state.json\` mtime.** It couldn't catch a wipe that leaves state.json alone. Even when triggered, it throws in \`afterEach\` — after the damage.

Additionally, operators using the global-hooks migration export \`XTRM_GLOBAL_HOOKS=1\` and \`XTRM_GLOBAL_SKILLS=1\` in their shell. Vitest inherits them, forcing tests that assume the pre-global branch (registry-scaffold, prune-retired-managed-skills, update, doctor, install-integration, claude-runtime-sync-global-guard) down code paths they never seed.

## Summary of changes
- \`cli/test/setup.ts\`: replace state.json mtime detector with a full **tree-hash guard** over \`~/.xtrm/{hooks,skills/default}\` — catches file deletes/adds/changes.
- \`cli/test/setup.ts\`: delete \`XTRM_GLOBAL_HOOKS\` / \`XTRM_GLOBAL_SKILLS\` at module load and in every \`beforeEach\`.
- \`cli/src/tests/claude-runtime-sync-global-guard.test.ts\`: \`vi.mock('../core/global-hooks-flag.js')\` to lock the pre-global branch this file was written to test.
- \`vitest.config.ts\` (new, repo root): scope include to \`cli/src/**\` and \`cli/test/**\`, exclude \`.xtrm/worktrees/**\` and \`node_modules/**\`.

## Results
- Baseline on main (env cleared): **6 failures** across 4 files
- With this change:               **2 failures** — both pre-existing, unrelated to test isolation:
  - \`pi-runtime-safeguards.test.ts\`: hardcoded path expects \`/home/dawid/dev/packages/...\` missing "core"
  - \`registry.test.ts\`: calls \`scripts/gen-registry.mjs\` from wrong cwd
- These 2 will be filed as separate low-priority beads.

## Related
- **Discovered during this work**: xtrm-5ts3l (P1) — \`xt update --apply --force\` destroys the hooks section of \`.xtrm/registry.json\`. Filed separately; not addressed here.

## Test plan
- [x] \`env -u XTRM_GLOBAL_HOOKS -u XTRM_GLOBAL_SKILLS npx vitest run\` from \`cli/\` — 507/509 pass (2 pre-existing unrelated)
- [x] \`XTRM_GLOBAL_HOOKS=1 XTRM_GLOBAL_SKILLS=1 npx vitest run\` from \`cli/\` — env-delete in beforeEach observed to sanitize most tests
- [x] \`npx vitest run\` from repo root now scopes to cli/ only (no worktree globbing)
- [x] Tree-hash guard verified to detect a synthetic wipe

Closes xtrm-on2mk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)