### PR TITLE
docs(audit): publish contracts & runtime matrix (P1-01 + P1-06 + P1-08)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
     - name: Verify Pi extension manifest schema
       run: npm run check:pi-manifest
 
+    - name: Verify runtime-compatibility contract
+      run: npm run check:runtime-compat
+
     - name: Flat active skills layout guard
       run: npm run check:layout-guards
 

--- a/cli/src/types/interactive-role-envelope.ts
+++ b/cli/src/types/interactive-role-envelope.ts
@@ -1,0 +1,37 @@
+// Interactive-role envelope contract.
+//
+// Slim boundary between Core (interactive session launcher) and
+// Specialists (role definitions + background job supervision).
+//
+// Schema id: xtrm.interactive-role-envelope.v1
+// Docs:      docs/architecture/interactive-role-envelope.md
+// Audit:     ~/dev/11.md §P1-01
+//
+// Any Core code that consumes a role from Specialists SHOULD
+// type-check against this interface. Additive fields (new optional
+// properties) do not require a version bump; removing or renaming
+// fields does.
+
+export interface InteractiveRoleEnvelope {
+    /** Canonical role name (e.g. "chain-coordinator"). */
+    role: string;
+
+    /** Effective merged system prompt for the interactive persona. */
+    systemPrompt: string;
+
+    /** Absolute paths of skills the interactive session must load at turn 1. */
+    skillPaths: string[];
+
+    /** Surface-specific model override, if any. */
+    model?: string;
+
+    /** Thinking level where the surface supports it. */
+    thinkingLevel?: string;
+}
+
+/**
+ * Schema id constant. Prefer importing this over hard-coding the
+ * string so bumps show up as a single-file change plus every
+ * consumer's compile error.
+ */
+export const INTERACTIVE_ROLE_ENVELOPE_SCHEMA = 'xtrm.interactive-role-envelope.v1' as const;

--- a/docs/architecture/interactive-role-envelope.md
+++ b/docs/architecture/interactive-role-envelope.md
@@ -1,0 +1,85 @@
+# Interactive-role envelope (`xtrm.interactive-role-envelope.v1`)
+
+Audit reference: `~/dev/11.md` §P1-01.
+
+Core's integration with Specialists for **interactive role launch** is
+deliberately slim. This document declares the fields Core is
+allowed to consume and the fields it must not — establishing a
+narrow, versioned boundary that prevents drift between the two
+repos over time.
+
+The TypeScript interface is exported from
+`cli/src/types/interactive-role-envelope.ts` and any Core code
+that consumes a role from Specialists SHOULD type-check against it.
+
+## The envelope
+
+```ts
+interface InteractiveRoleEnvelope {
+  role: string;              // canonical role name (e.g. "chain-coordinator")
+  systemPrompt: string;      // effective merged system prompt for the interactive persona
+  skillPaths: string[];      // absolute paths of skills the interactive session must load
+  model?: string;            // surface-specific model override, if any
+  thinkingLevel?: string;    // thinking level where the surface supports it
+}
+```
+
+## Core owns
+
+- worktree creation
+- branch creation
+- runtime selection (claude / pi)
+- interactive role composition from the envelope
+- tmux placement (`@agent_*` pane metadata)
+- parent identity (`XTMUX_AGENT_*` env vars)
+- bead metadata
+- session launch
+
+## Specialists owns
+
+- background job execution
+- retry policy
+- stall detection
+- job permissions
+- specialist capabilities
+- job result persistence
+- job lineage
+
+## Rules
+
+Core **must not** consume, enforce, or persist any of the following
+fields even if they appear in a Specialist role definition:
+
+- `retries`
+- `stall_timeout`
+- `overall_job_timeout`
+- `permission_tier`
+- `external_command_capabilities`
+- `background_execution_policy`
+- `supervisor_restart_policy`
+
+Those fields describe **Specialists-supervised jobs** — background
+work that Specialists itself governs. If Core were to consume them,
+Core would become a second, competing job supervisor. That is
+explicitly forbidden.
+
+If a new interactive requirement appears (say, a role wanting to
+inject an initial bead), extend the envelope with the smallest
+additive field — do **not** grow it into a full launch-plan
+abstraction. Prefer adding one optional field to introducing a new
+schema version.
+
+## Versioning
+
+- Current version: `xtrm.interactive-role-envelope.v1`.
+- Additive fields (new optional properties) do NOT require a
+  version bump — they are backwards-compatible.
+- Removing or renaming a field, or changing the semantics of an
+  existing field, requires bumping to `v2` AND updating
+  `docs/runtime-compatibility.json` in the same PR.
+
+## Cross-references
+
+- Compatibility window: `docs/runtime-compatibility.json` (`contracts.interactive_role_envelope`).
+- Runtime matrix: `docs/runtime-matrix.yml`.
+- Envelope type: `cli/src/types/interactive-role-envelope.ts`.

--- a/docs/runtime-compatibility.json
+++ b/docs/runtime-compatibility.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "xtrm.runtime-compatibility.v1",
+  "notes": [
+    "Declares Core's compatibility window against Specialists / xtmux / node.",
+    "Consumed by scripts/check-runtime-compatibility.mjs (build-time gate).",
+    "NOT enforced at CLI startup — see NON_GOALS in xtrm-f2pey.2. A future preflight can consult this file but must not hard-fail without operator opt-in.",
+    "Bumping a minimum here should coincide with the release PR that requires it (see ~/dev/11.md P1-06 for the target flow)."
+  ],
+  "core": {
+    "package": "xtrm-tools",
+    "requires": {
+      "specialists": ">=3.21.0 <4",
+      "xtmux": ">=0.1.0 <0.2",
+      "node": ">=24.0.0"
+    }
+  },
+  "contracts": {
+    "runtime_origin": "xtrm.runtime-origin.v1",
+    "interactive_role_envelope": "xtrm.interactive-role-envelope.v1",
+    "specialist_role_envelope": "1",
+    "xtmux_bridge": "xtrm.xtmux.bridge.v1",
+    "pi_extension_manifest": "xtrm.pi-extension-manifest.v1",
+    "command_deprecations": "xtrm.command-deprecations.v1",
+    "runtime_matrix": "xtrm.runtime-matrix.v1",
+    "runtime_compatibility": "xtrm.runtime-compatibility.v1"
+  }
+}

--- a/docs/runtime-matrix.yml
+++ b/docs/runtime-matrix.yml
@@ -1,0 +1,69 @@
+# xtrm runtime matrix
+#
+# Single source of truth for the runtime minimums of every repo in
+# the xtrm-tools stack. Consulted by operators when provisioning
+# fresh machines and by CI when validating release readiness.
+#
+# Whenever you bump a minimum in a repo's package.json engines
+# (Core), engines (xtmux packaging), or bun-version pin
+# (specialists), update this file in the same PR.
+#
+# Referenced by:
+#   - ~/dev/11.md §P1-08 (audit)
+#   - .github/workflows/fresh-machine-smoke.yml
+#   - .github/workflows/publish.yml
+#   - docs/runtime-compatibility.json (compatibility contract)
+
+schema_version: "xtrm.runtime-matrix.v1"
+
+core:
+  # Node-only Commander CLI. Bun not required.
+  primary_runtime: node
+  minimum: ">=24.0.0"
+  node_usage:
+    - "CLI entrypoint (cli/dist/index.cjs)"
+    - "Scripts under scripts/"
+  bun_usage: []
+  notes: >
+    Pinned to Node 24 LTS in v0.11.0 (PR #448). Older Node versions
+    will exit early via engines guard.
+
+xtmux:
+  # Bun-first runtime; Node used for packaging + one-shot scripts.
+  primary_runtime: bun
+  bun_minimum: ">=1.0.0"
+  node_usage:
+    - "npm packaging"
+    - "install scripts"
+  node_minimum: ">=20.0.0"
+  notes: >
+    xtmux's own binaries run under Bun. Node is only used when the
+    package is installed via npm (postinstall build steps).
+
+specialists:
+  # Bun-first runtime.
+  primary_runtime: bun
+  bun_minimum: ">=1.0.0"
+  node_usage:
+    - "select scripts (vendoring helpers)"
+    - "package tooling"
+  node_minimum: null
+  notes: >
+    sp binary uses `#!/usr/bin/env bun`. No Node minimum enforced —
+    call-sites that need node use whatever the local install provides.
+
+# Consumed-by matrix — which downstream CI/workflow steps depend on
+# each runtime minimum. Update when adding a new workflow.
+consumers:
+  - workflow: .github/workflows/ci.yml
+    repo: core
+    runtime: node
+  - workflow: .github/workflows/publish.yml
+    repo: core
+    runtime: node
+  - workflow: .github/workflows/pre-publish-readiness.yml
+    repo: core
+    runtime: node
+  - workflow: .github/workflows/fresh-machine-smoke.yml
+    repo: core+specialists
+    runtime: node+bun

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "check:layout-guards": "node scripts/check-layout-guards.mjs",
     "check:gitnexus-no-counter": "node scripts/check-gitnexus-no-counter.mjs",
     "check:skills-symlinks": "node scripts/check-skills-symlinks.mjs",
-    "prepublishOnly": "npm run sync:cli-version && npm run check:package && npm run check:skills-ownership && npm run check:deprecations && npm run check:pi-manifest && node scripts/vendor-specialists-from-manifest.mjs && npm run gen-registry && npm run check:registry-pack-parity && npm run check:payload-hygiene && npm run check:specialists-vendor && npm run check:layout-guards && npm run check:gitnexus-no-counter && npm run check:skills-symlinks && npm run build",
+    "prepublishOnly": "npm run sync:cli-version && npm run check:package && npm run check:skills-ownership && npm run check:deprecations && npm run check:pi-manifest && npm run check:runtime-compat && node scripts/vendor-specialists-from-manifest.mjs && npm run gen-registry && npm run check:registry-pack-parity && npm run check:payload-hygiene && npm run check:specialists-vendor && npm run check:layout-guards && npm run check:gitnexus-no-counter && npm run check:skills-symlinks && npm run build",
     "release": "npm publish --tag latest",
     "release:pi-extensions": "npm publish --workspace @jaggerxtrm/pi-extensions --tag latest --access public",
     "release:all": "npm run release && npm run release:pi-extensions",
@@ -78,7 +78,8 @@
     "check:registry-pack-parity": "node scripts/check-registry-pack-parity.mjs",
     "check:payload-hygiene": "node scripts/check-payload-hygiene.mjs",
     "check:deprecations": "node scripts/check-command-deprecations.mjs",
-    "check:pi-manifest": "node scripts/check-pi-extension-manifest.mjs"
+    "check:pi-manifest": "node scripts/check-pi-extension-manifest.mjs",
+    "check:runtime-compat": "node scripts/check-runtime-compatibility.mjs"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/scripts/check-runtime-compatibility.mjs
+++ b/scripts/check-runtime-compatibility.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Validate docs/runtime-compatibility.json:
+//   - shape matches xtrm.runtime-compatibility.v1
+//   - core.requires.node matches root package.json engines.node
+//   - every referenced schema_version constant follows xtrm.<kebab>.v<int>
+//
+// Build-time gate. Not consulted at CLI startup.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const compatPath = path.join(repoRoot, 'docs', 'runtime-compatibility.json');
+const rootPkgPath = path.join(repoRoot, 'package.json');
+
+const EXPECTED_SCHEMA = 'xtrm.runtime-compatibility.v1';
+const REQUIRED_TOP = ['schema_version', 'core', 'contracts'];
+const REQUIRED_CORE_REQUIRES = ['specialists', 'xtmux', 'node'];
+// Allow multi-segment names: xtrm.xtmux.bridge.v1, xtrm.pi-extension-manifest.v1, …
+const SCHEMA_ID_RE = /^xtrm\.[a-z][\w.-]*\.v\d+$/;
+
+function main() {
+    if (!fs.existsSync(compatPath)) {
+        console.error(`Missing: ${path.relative(repoRoot, compatPath)}`);
+        process.exit(1);
+    }
+    const compat = JSON.parse(fs.readFileSync(compatPath, 'utf8'));
+    const errors = [];
+
+    for (const key of REQUIRED_TOP) {
+        if (!(key in compat)) errors.push(`missing top-level ${key}`);
+    }
+    if (compat.schema_version !== EXPECTED_SCHEMA) {
+        errors.push(`schema_version: expected ${EXPECTED_SCHEMA}, got ${compat.schema_version}`);
+    }
+
+    const core = compat.core ?? {};
+    if (!core.package) errors.push('core.package missing');
+    if (!core.requires) errors.push('core.requires missing');
+    else {
+        for (const dep of REQUIRED_CORE_REQUIRES) {
+            if (!core.requires[dep]) errors.push(`core.requires.${dep} missing`);
+        }
+    }
+
+    // Cross-check node minimum matches root package.json engines.node.
+    const rootPkg = JSON.parse(fs.readFileSync(rootPkgPath, 'utf8'));
+    const enginesNode = rootPkg.engines?.node;
+    const contractNode = core.requires?.node;
+    if (enginesNode && contractNode && enginesNode !== contractNode) {
+        errors.push(
+            `node range mismatch: package.json engines.node=${enginesNode} vs docs/runtime-compatibility.json core.requires.node=${contractNode}`
+        );
+    }
+
+    const contracts = compat.contracts ?? {};
+    if (typeof contracts !== 'object' || Array.isArray(contracts)) {
+        errors.push('contracts: expected object');
+    } else {
+        for (const [name, id] of Object.entries(contracts)) {
+            if (typeof id !== 'string' || (id !== '1' && !SCHEMA_ID_RE.test(id))) {
+                errors.push(`contracts.${name}: expected xtrm.<kebab>.v<int> (or literal "1"), got ${JSON.stringify(id)}`);
+            }
+        }
+    }
+
+    if (errors.length) {
+        console.error('runtime-compatibility validation failed:');
+        for (const err of errors) console.error(`  - ${err}`);
+        process.exit(1);
+    }
+    console.log(`Runtime compatibility ok: core requires specialists ${core.requires.specialists}, xtmux ${core.requires.xtmux}, node ${core.requires.node}.`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Docs + machine-readable contracts for three audit items from `~/dev/11.md`. No runtime behavior changes; no `worktree-session.ts` touch (still blocked by `xtrm-3xgs5`).

| Audit | Ships | Files |
|---|---|---|
| **P1-08** runtime matrix | `docs/runtime-matrix.yml` (`xtrm.runtime-matrix.v1`) — Node/Bun minima per repo + consumer map | `docs/` |
| **P1-06** compatibility contract | `docs/runtime-compatibility.json` (`xtrm.runtime-compatibility.v1`) declaring Core's version window against specialists/xtmux/node + contract schema ids. `scripts/check-runtime-compatibility.mjs` validator cross-checks against `package.json` engines. | `docs/`, `scripts/`, `package.json`, `ci.yml` |
| **P1-01** interactive-role envelope | `docs/architecture/interactive-role-envelope.md` (documents the slim Core↔Specialists boundary + 5 permitted fields + explicit forbidden list) + `cli/src/types/interactive-role-envelope.ts` type export | `docs/architecture/`, `cli/src/types/` |

## Verification

- Full CLI test suite: **915 pass / 98 skipped / 0 fail**.
- `npm run check:runtime-compat` green.
- tsc note: 6 tsc errors on main in `worktree-session-bare-slash.test.ts` (owned by `xtrm-3xgs5` WIP) are pre-existing; this branch adds zero. tsc is not currently a CI gate.

## Bd

Closes epic `xtrm-f2pey` + children `xtrm-f2pey.1..3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)