### PR TITLE
feat(contracts): @xtrm/contracts shared schema package (audit P2-02)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "xtrm-tools",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtrm-tools",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "workspaces": [
         "cli",
-        "packages/pi-extensions"
+        "packages/pi-extensions",
+        "packages/contracts"
       ],
       "dependencies": {
         "comment-json": "^4.2.3",
@@ -26,12 +27,12 @@
         "xtrm": "cli/dist/index.cjs"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=24.0.0"
       }
     },
     "cli": {
       "name": "xtrm-cli",
-      "version": "0.10.6",
+      "version": "0.11.1",
       "dependencies": {
         "boxen": "^8.0.1",
         "cli-table3": "^0.6.5",
@@ -68,7 +69,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=24.0.0"
       }
     },
     "cli/node_modules/@types/node": {
@@ -1602,6 +1603,10 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@xtrm/contracts": {
+      "resolved": "packages/contracts",
+      "link": true
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -4155,9 +4160,38 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "packages/contracts": {
+      "name": "@xtrm/contracts",
+      "version": "0.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.20.0"
+      },
+      "devDependencies": {
+        "tsup": "^8.5.1",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
+      }
+    },
+    "packages/contracts/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "packages/pi-extensions": {
       "name": "@jaggerxtrm/pi-extensions",
-      "version": "0.9.5",
+      "version": "0.11.1",
       "license": "MIT"
     },
     "packages/pi-extensions/extensions/core": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "workspaces": [
     "cli",
-    "packages/pi-extensions"
+    "packages/pi-extensions",
+    "packages/contracts"
   ],
   "bin": {
     "xtrm": "cli/dist/index.cjs",
@@ -60,6 +61,8 @@
     "start": "node cli/dist/index.cjs",
     "lint": "echo 'No linting configured'",
     "test": "npm test --workspace cli",
+    "test:contracts": "npm test --workspace @xtrm/contracts",
+    "build:contracts": "npm run build --workspace @xtrm/contracts",
     "check:package": "node scripts/assert-no-self-dependency.mjs",
     "changelog:update": "node scripts/changelog-update.mjs",
     "changelog:check": "node scripts/changelog-update.mjs --check",

--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,0 +1,60 @@
+# @xtrm/contracts
+
+Shared cross-runtime contracts for the xtrm ecosystem (Core ⇄ Specialists ⇄ xtmux).
+Publishes the wire/record schemas the three repos agree on, as **JSON Schemas**
+(source of truth) plus **TypeScript types**, **ajv runtime validators**, and
+**golden fixtures**. Audit item **P2-02**.
+
+## Layout
+
+| Path | What |
+|---|---|
+| `schemas/*.json` | JSON Schema (draft-07) per contract, `$id` = schema id. The source of truth. |
+| `src/validate.ts` | ajv registry: `validate`, `assertValid`, `getValidator`, `getSchema`, `SCHEMA_IDS`. |
+| `src/types.ts` | Hand-authored TS types mirroring the schemas + `SCHEMA_ID` constants + `ContractTypeMap`. |
+| `fixtures/golden.json` | One valid golden payload per schema. |
+| `fixtures/invalid.json` | One intentionally-invalid payload per schema (negative fixtures). |
+| `test/contracts.test.ts` | Proves every golden validates, every invalid is rejected, and id coverage. |
+
+## Usage
+
+```ts
+import { validate, assertValid, isValid, SCHEMA_ID } from '@xtrm/contracts';
+import type { RuntimeOriginV1 } from '@xtrm/contracts';
+
+const { valid, errors } = validate(SCHEMA_ID.runtimeOrigin, payload);
+assertValid('xtrm.branch.integration.v1', event); // throws with a readable message
+if (isValid(SCHEMA_ID.piExtensionManifest, data)) { /* data: PiExtensionManifestV1 */ }
+```
+
+Consumers who only want the raw schemas can read `@xtrm/contracts/schemas/<id>.json`.
+
+## Contracts
+
+Core: `xtrm.runtime-compatibility.v1`, `xtrm.interactive-role-envelope.v1`,
+`xtrm.pi-extension-manifest.v1`, `xtrm.command-deprecations.v1`, `xtrm.runtime-matrix.v1`.
+Lineage/observability: `xtrm.runtime-origin.v1`, `xtrm.branch.integration.v1`.
+xtmux runtime: `xtrm.xtmux.topology.v1`, `xtrm.xtmux.message.v1`, `xtrm.xtmux.obligation.v1`,
+`xtrm.xtmux.monitor.v1`, `xtrm.xtmux.wait.v1`, `xtrm.xtmux.bridge.v1`, `xtrm.agent-role-launched.v1`.
+Legacy specialists: `xtrm.specialist-role-envelope.v1` (registry version `"1"`).
+
+Each schema documents its authoritative source file in its `description`. The
+JSON Schema is the source of truth — the TS types mirror it and the fixture test
+guards their agreement.
+
+## Scripts
+
+```
+npm run build      # tsup → dist (esm + cjs + d.ts)
+npm run typecheck  # tsc --noEmit
+npm test           # vitest
+```
+
+## Notes
+
+- Un-versioned xtmux CLI responses (message/obligation/monitor/wait) carry no
+  `schema_version` on the wire; their schemas mirror the current CLI output shape.
+- `format` (e.g. `date-time`) is documentation only — not enforced (no ajv-formats dep).
+- This package does **not** yet feed the existing `scripts/check-*.mjs` gates or
+  `docs/runtime-compatibility.json`; wiring runtime code to consume these
+  validators is a separate follow-up (per the P2-02 brief).

--- a/packages/contracts/fixtures/golden.json
+++ b/packages/contracts/fixtures/golden.json
@@ -1,0 +1,230 @@
+{
+    "xtrm.runtime-compatibility.v1": {
+        "schema_version": "xtrm.runtime-compatibility.v1",
+        "notes": ["Declares Core's compatibility window against Specialists / xtmux / node."],
+        "core": {
+            "package": "xtrm-tools",
+            "requires": { "specialists": ">=3.21.0 <4", "xtmux": ">=0.1.0 <0.2", "node": ">=24.0.0" }
+        },
+        "contracts": {
+            "runtime_origin": "xtrm.runtime-origin.v1",
+            "runtime_compatibility": "xtrm.runtime-compatibility.v1",
+            "specialist_role_envelope": "1"
+        }
+    },
+    "xtrm.interactive-role-envelope.v1": {
+        "role": "chain-coordinator",
+        "systemPrompt": "You are the chain coordinator.",
+        "skillPaths": ["/home/u/.xtrm/skills/active/using-specialists/SKILL.md"],
+        "model": "claude-opus-4-8",
+        "thinkingLevel": "high"
+    },
+    "xtrm.pi-extension-manifest.v1": {
+        "schema_version": "xtrm.pi-extension-manifest.v1",
+        "active": [
+            { "id": "beads", "displayName": "beads", "required": true, "ownership": "xtrm" },
+            { "id": "lsp-bootstrap", "displayName": "lsp-bootstrap", "required": false }
+        ],
+        "disabled": { "gitnexus": "Retired; provided by the npm:pi-gitnexus package." }
+    },
+    "xtrm.command-deprecations.v1": {
+        "schema_version": "xtrm.command-deprecations.v1",
+        "notes": ["Source of truth for xt/xtrm command tokens marked deprecated or retired."],
+        "entries": [
+            {
+                "command": "xt bootstrap",
+                "deprecated_since": "0.11.0",
+                "remove_in": "0.13.0",
+                "replacement": "xt update --apply --force",
+                "behavior": "execute-with-warning",
+                "code_ref": "cli/src/commands/bootstrap.ts"
+            }
+        ]
+    },
+    "xtrm.runtime-matrix.v1": {
+        "schema_version": "xtrm.runtime-matrix.v1",
+        "core": { "primary_runtime": "node", "minimum": ">=24.0.0", "node_usage": ["CLI entrypoint"], "bun_usage": [], "notes": "Pinned to Node 24 LTS." },
+        "xtmux": { "primary_runtime": "bun", "bun_minimum": ">=1.0.0", "node_usage": ["npm packaging"], "node_minimum": ">=20.0.0", "notes": "xtmux binaries run under Bun." },
+        "specialists": { "primary_runtime": "bun", "bun_minimum": ">=1.0.0", "node_usage": ["vendoring helpers"], "node_minimum": null, "notes": "sp binary uses bun shebang." },
+        "consumers": [{ "workflow": ".github/workflows/ci.yml", "repo": "core", "runtime": "node" }]
+    },
+    "xtrm.runtime-origin.v1": {
+        "schema_version": "xtrm.runtime-origin.v1",
+        "kind": "xtmux.agent_instance",
+        "host_id": "host-01J2M8GQY8",
+        "tmux_session_id": "$3",
+        "tmux_window_id": "@7",
+        "tmux_pane_id": "%17",
+        "agent_instance_id": "7cc0b27f-41b0-4cae-b6e8-6929035bbb44",
+        "bead_id": "specialists-123",
+        "parent_session_id": "$1",
+        "captured_at_ms": 1783987200000,
+        "capture_source": "xtmux-context",
+        "verified": true
+    },
+    "xtrm.branch.integration.v1": {
+        "schema_version": "xtrm.branch.integration.v1",
+        "timestamp": "2023-11-14T22:13:20.000Z",
+        "t_unix_ms": 1700000000000,
+        "source": { "job_id": "job-abc123", "branch": "specialist/executor/xtrm-5ts3l", "worktree": "/home/dev/.specialists/jobs/job-abc123" },
+        "target": { "branch": "main", "worktree": "/home/dev/specialists" },
+        "status": "merged",
+        "commit": "76b888fa1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f"
+    },
+    "xtrm.xtmux.topology.v1": {
+        "schema_version": "xtrm.xtmux.topology.v1",
+        "generated_at_ms": 1783987200000,
+        "host": { "host_id": "host-01J2M8GQY8", "tmux_server_id": "tmux-6a89e1" },
+        "sessions": [
+            {
+                "session_id": "$3",
+                "name": "specialists-dev",
+                "created_at_ms": 1783980000000,
+                "activity_at_ms": 1783987190000,
+                "attached": true,
+                "active": true,
+                "windows": [
+                    {
+                        "window_id": "@7",
+                        "window_index": 1,
+                        "name": "agent",
+                        "active": true,
+                        "panes": [
+                            {
+                                "pane_id": "%17",
+                                "pane_index": 0,
+                                "active": true,
+                                "width": 160,
+                                "height": 48,
+                                "left": 0,
+                                "top": 0,
+                                "pid": 31415,
+                                "current_command": "pi",
+                                "current_path": "/srv/specialists",
+                                "agent": {
+                                    "instance_id": "7cc0b27f",
+                                    "state": "running",
+                                    "bead_id": "specialists-123",
+                                    "task": "review runtime bridge",
+                                    "prompt_file": "/tmp/review-runtime.md",
+                                    "parent_session_id": "$1",
+                                    "last_transition": "2026-07-14T02:39:50+02:00"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "xtrm.xtmux.message.v1": {
+        "messageKey": "msg-1783987200000-421337",
+        "senderId": "$3",
+        "senderPaneId": "%17",
+        "recipientId": "$1",
+        "targetPaneId": "%2",
+        "beadId": "xtmux-123",
+        "summary": "review runtime bridge",
+        "createdAtMs": 1783987200000,
+        "expectsReply": true,
+        "acked": true,
+        "ackedAtMs": 1783987205000,
+        "ackedBy": "$1",
+        "replyStatus": "fulfilled",
+        "fulfilledAtMs": 1783987260000,
+        "fulfilledByMessageKey": "reply-msg-1",
+        "correlatedReply": {
+            "messageKey": "reply-msg-1",
+            "senderId": "$1",
+            "senderPaneId": "%2",
+            "recipientId": "$3",
+            "targetPaneId": "%17",
+            "summary": "done",
+            "createdAtMs": 1783987260000
+        }
+    },
+    "xtrm.xtmux.obligation.v1": {
+        "messageKey": "msg-1783987200000-421337",
+        "messageId": 42,
+        "senderId": "$3",
+        "senderPaneId": "%17",
+        "recipientId": "$1",
+        "targetPaneId": "%2",
+        "summary": "review runtime bridge",
+        "createdAtMs": 1783987200000,
+        "acked": false,
+        "ackedAtMs": null,
+        "replyStatus": "pending"
+    },
+    "xtrm.xtmux.monitor.v1": {
+        "monitorId": "monitor-1783987200000-123456",
+        "waitId": "wait-1783987200000-123456",
+        "target": "reviewer",
+        "requesterSessionId": "$1",
+        "requesterPaneId": "%2",
+        "sessionId": "$3",
+        "paneId": "%17",
+        "state": "running",
+        "startedAtMs": 1783987200000,
+        "updatedAtMs": 1783987205000,
+        "timeoutMs": 600000,
+        "intervalMs": 5000,
+        "terminalStatus": null,
+        "terminalAtMs": null,
+        "wakeDelivered": false,
+        "wakeConsumed": false,
+        "orphan": false
+    },
+    "xtrm.xtmux.wait.v1": {
+        "waitId": "wait-1783987200000-123456",
+        "target": "reviewer",
+        "requesterSessionId": "$1",
+        "requesterPaneId": "%2",
+        "targetSessionId": "$3",
+        "targetPaneId": "%17",
+        "state": "terminal",
+        "monitorId": "monitor-1783987200000-123456",
+        "terminalStatus": "done",
+        "wakeDelivered": true,
+        "wakeConsumed": false,
+        "replayed": false,
+        "startedAtMs": 1783987200000,
+        "completedAtMs": 1783987260000,
+        "timeoutMs": 600000,
+        "intervalMs": null
+    },
+    "xtrm.xtmux.bridge.v1": {
+        "id": 1,
+        "method": "pane.capture",
+        "params": { "pane_id": "%17", "lines": 200 }
+    },
+    "xtrm.agent-role-launched.v1": {
+        "instance_id": "7cc0b27f",
+        "session": "$3",
+        "session_name": "specialists-dev",
+        "pane": "%17",
+        "runtime": "pi",
+        "role": "reviewer",
+        "bead": "xtmux-123",
+        "task": "review runtime bridge",
+        "prompt_file": "/tmp/review-runtime.md",
+        "parent": "$1"
+    },
+    "xtrm.specialist-role-envelope.v1": {
+        "specialist": {
+            "metadata": { "name": "smoke-echo", "version": "1.0.0", "description": "Minimal script-class specialist.", "category": "test" },
+            "execution": {
+                "mode": "auto",
+                "model": "nano-gpt/moonshotai/kimi-k2.5",
+                "timeout_ms": 30000,
+                "interactive": false,
+                "response_format": "json",
+                "output_type": "custom",
+                "permission_required": "READ_ONLY",
+                "requires_worktree": false,
+                "max_retries": 0
+            },
+            "prompt": { "task_template": "Summarize the following text.\n\n$content", "output_schema": { "required": ["summary"] } }
+        }
+    }
+}

--- a/packages/contracts/fixtures/invalid.json
+++ b/packages/contracts/fixtures/invalid.json
@@ -1,0 +1,121 @@
+{
+    "xtrm.runtime-compatibility.v1": {
+        "schema_version": "xtrm.runtime-compatibility.v1",
+        "contracts": { "runtime_origin": "xtrm.runtime-origin.v1" }
+    },
+    "xtrm.interactive-role-envelope.v1": {
+        "role": "chain-coordinator",
+        "systemPrompt": "missing skillPaths"
+    },
+    "xtrm.pi-extension-manifest.v1": {
+        "schema_version": "xtrm.pi-extension-manifest.v1",
+        "active": [{ "id": "beads", "displayName": "beads", "required": "yes" }],
+        "disabled": {}
+    },
+    "xtrm.command-deprecations.v1": {
+        "schema_version": "xtrm.command-deprecations.v1",
+        "entries": [
+            {
+                "command": "xt bootstrap",
+                "deprecated_since": "0.11.0",
+                "remove_in": "0.13.0",
+                "replacement": "xt update --apply",
+                "behavior": "explode-loudly",
+                "code_ref": "cli/src/commands/bootstrap.ts"
+            }
+        ]
+    },
+    "xtrm.runtime-matrix.v1": {
+        "schema_version": "xtrm.runtime-matrix.v1",
+        "core": { "minimum": ">=24.0.0" },
+        "xtmux": { "primary_runtime": "bun" },
+        "specialists": { "primary_runtime": "bun" },
+        "consumers": []
+    },
+    "xtrm.runtime-origin.v1": {
+        "schema_version": "xtrm.runtime-origin.v1",
+        "kind": "xtmux.agent_instance",
+        "host_id": "host-01",
+        "tmux_session_id": "$3",
+        "tmux_window_id": "@7",
+        "captured_at_ms": 1783987200000,
+        "capture_source": "xtmux-context",
+        "verified": true
+    },
+    "xtrm.branch.integration.v1": {
+        "schema_version": "xtrm.branch.integration.v1",
+        "timestamp": "2023-11-14T22:13:20.000Z",
+        "t_unix_ms": 1700000000000,
+        "source": { "job_id": "job-abc", "branch": "sp/x", "worktree": "/w" },
+        "target": { "branch": "main", "worktree": "/repo" },
+        "status": "reverted",
+        "commit": "76b888fa1c2d3e4f"
+    },
+    "xtrm.xtmux.topology.v1": {
+        "schema_version": "xtrm.xtmux.topology.v1",
+        "generated_at_ms": 1783987200000,
+        "host": { "host_id": "host-01", "tmux_server_id": "tmux-1" },
+        "sessions": [
+            { "session_id": "$3", "name": "dev", "created_at_ms": 1, "activity_at_ms": 2, "attached": true, "active": true }
+        ]
+    },
+    "xtrm.xtmux.message.v1": {
+        "senderId": "$3",
+        "recipientId": "$1",
+        "summary": "missing messageKey"
+    },
+    "xtrm.xtmux.obligation.v1": {
+        "messageKey": "msg-1",
+        "messageId": 42,
+        "senderId": "$3",
+        "senderPaneId": "%17",
+        "recipientId": "$1",
+        "targetPaneId": "%2",
+        "summary": "review",
+        "createdAtMs": 1783987200000,
+        "acked": false,
+        "ackedAtMs": null,
+        "replyStatus": "fulfilled"
+    },
+    "xtrm.xtmux.monitor.v1": {
+        "monitorId": "monitor-1",
+        "target": "reviewer",
+        "sessionId": "$3",
+        "paneId": "%17",
+        "state": "running",
+        "startedAtMs": 1,
+        "updatedAtMs": 2,
+        "timeoutMs": 600000,
+        "intervalMs": 5000,
+        "wakeDelivered": false,
+        "wakeConsumed": false
+    },
+    "xtrm.xtmux.wait.v1": {
+        "waitId": "wait-1",
+        "target": "reviewer",
+        "requesterSessionId": "$1",
+        "requesterPaneId": "%2",
+        "targetSessionId": "$3",
+        "targetPaneId": "%17",
+        "state": "terminal",
+        "wakeDelivered": true,
+        "wakeConsumed": false,
+        "replayed": false,
+        "startedAtMs": 1,
+        "intervalMs": 5000
+    },
+    "xtrm.xtmux.bridge.v1": {
+        "id": 2,
+        "method": "message.send"
+    },
+    "xtrm.agent-role-launched.v1": {
+        "role": 123
+    },
+    "xtrm.specialist-role-envelope.v1": {
+        "specialist": {
+            "metadata": { "name": "smoke-echo", "version": "1.0.0", "description": "d", "category": "test" },
+            "execution": { "model": null },
+            "prompt": {}
+        }
+    }
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@xtrm/contracts",
+  "version": "0.11.1",
+  "description": "Shared xtrm cross-runtime contracts: JSON Schemas, TypeScript types, runtime validators and golden fixtures (audit P2-02)",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "xtrm",
+    "contracts",
+    "json-schema",
+    "runtime-compatibility"
+  ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./schemas/*": "./schemas/*"
+  },
+  "author": "xtrm",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/xtrm-dev/core.git",
+    "directory": "packages/contracts"
+  },
+  "homepage": "https://github.com/xtrm-dev/core/tree/main/packages/contracts",
+  "bugs": {
+    "url": "https://github.com/xtrm-dev/core/issues"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "ajv": "^8.20.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
+  },
+  "files": [
+    "dist",
+    "schemas",
+    "fixtures",
+    "README.md"
+  ]
+}

--- a/packages/contracts/schemas/xtrm.agent-role-launched.v1.json
+++ b/packages/contracts/schemas/xtrm.agent-role-launched.v1.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.agent-role-launched.v1",
+    "title": "xtmux agent.role.launched event fields",
+    "description": "The key=value field bag carried by `xtmux log emit agent.role.launched ...`, parsed into agent-instance open input. Source: xtmux src/cli-log.ts (case 'agent.role.launched') -> openInstance (src/domains/agents/instance.ts); persisted envelope type becomes 'agents.instance.open', idempotent on instance_id. Loose event: emitters pass free k=v pairs, so extra keys are tolerated. Canonical + alias keys are typed below; missing session/pane default to ''.",
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+        "instance_id": { "type": "string" },
+        "instance": { "type": "string" },
+        "session": { "type": "string" },
+        "session_id": { "type": "string" },
+        "session_name": { "type": "string" },
+        "pane": { "type": "string" },
+        "pane_id": { "type": "string" },
+        "runtime": { "type": "string" },
+        "role": { "type": "string" },
+        "bead": { "type": "string" },
+        "bead_id": { "type": "string" },
+        "task": { "type": "string" },
+        "prompt_file": { "type": "string" },
+        "parent": { "type": "string" },
+        "parent_session": { "type": "string" }
+    }
+}

--- a/packages/contracts/schemas/xtrm.branch.integration.v1.json
+++ b/packages/contracts/schemas/xtrm.branch.integration.v1.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.branch.integration.v1",
+    "title": "xtrm branch integration event",
+    "description": "Append-only RESULT record emitted by Specialists after a chain/specialist branch merges into a target (coordinator or main) branch. Source: specialists src/specialist/branch-integration-events.ts (createBranchIntegrationEvent). Persisted to Specialists' observability.db (table branch_integration_events); git remains the authority, this only observes. target.role is omitted (not null) when unset.",
+    "type": "object",
+    "required": ["schema_version", "timestamp", "t_unix_ms", "source", "target", "status", "commit"],
+    "additionalProperties": false,
+    "properties": {
+        "schema_version": { "const": "xtrm.branch.integration.v1" },
+        "timestamp": { "type": "string", "format": "date-time" },
+        "t_unix_ms": { "type": "integer", "minimum": 0 },
+        "source": {
+            "type": "object",
+            "required": ["job_id", "branch", "worktree"],
+            "additionalProperties": false,
+            "properties": {
+                "job_id": { "type": "string", "minLength": 1 },
+                "branch": { "type": "string", "minLength": 1 },
+                "worktree": { "type": "string", "minLength": 1 }
+            }
+        },
+        "target": {
+            "type": "object",
+            "required": ["branch", "worktree"],
+            "additionalProperties": false,
+            "properties": {
+                "branch": { "type": "string", "minLength": 1 },
+                "worktree": { "type": "string", "minLength": 1 },
+                "role": { "type": "string", "minLength": 1 }
+            }
+        },
+        "status": { "type": "string", "enum": ["merged"] },
+        "commit": { "type": "string", "minLength": 7 }
+    }
+}

--- a/packages/contracts/schemas/xtrm.command-deprecations.v1.json
+++ b/packages/contracts/schemas/xtrm.command-deprecations.v1.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.command-deprecations.v1",
+    "title": "xtrm command deprecations",
+    "description": "Source of truth for xt/xtrm command tokens marked deprecated or retired. Instance: docs/command-deprecations.json. Build-time gate: scripts/check-command-deprecations.mjs.",
+    "type": "object",
+    "required": ["schema_version", "entries"],
+    "additionalProperties": false,
+    "properties": {
+        "schema_version": { "const": "xtrm.command-deprecations.v1" },
+        "notes": {
+            "type": "array",
+            "items": { "type": "string" }
+        },
+        "entries": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["command", "deprecated_since", "remove_in", "replacement", "behavior", "code_ref"],
+                "additionalProperties": false,
+                "properties": {
+                    "command": { "type": "string", "minLength": 1 },
+                    "deprecated_since": { "type": "string", "minLength": 1 },
+                    "remove_in": { "type": "string", "minLength": 1 },
+                    "replacement": { "type": "string", "minLength": 1 },
+                    "behavior": {
+                        "type": "string",
+                        "enum": ["execute-with-warning", "fail-with-redirect"]
+                    },
+                    "code_ref": { "type": "string", "minLength": 1 },
+                    "notes": { "type": "string" }
+                }
+            }
+        }
+    }
+}

--- a/packages/contracts/schemas/xtrm.interactive-role-envelope.v1.json
+++ b/packages/contracts/schemas/xtrm.interactive-role-envelope.v1.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.interactive-role-envelope.v1",
+    "title": "xtrm interactive role envelope",
+    "description": "The slim Core->runtime handoff for an interactive role launch. Authoritative shape: cli/src/types/interactive-role-envelope.ts. Deliberately minimal: Core must NOT carry Specialist job-supervision metadata (retries, stall_timeout, permission_tier, ...). additionalProperties:false enforces the slim envelope; additive optional fields bump the schema, removal/rename bumps the major version.",
+    "type": "object",
+    "required": ["role", "systemPrompt", "skillPaths"],
+    "additionalProperties": false,
+    "properties": {
+        "role": { "type": "string", "minLength": 1 },
+        "systemPrompt": { "type": "string" },
+        "skillPaths": {
+            "type": "array",
+            "items": { "type": "string" }
+        },
+        "model": { "type": "string" },
+        "thinkingLevel": { "type": "string" }
+    }
+}

--- a/packages/contracts/schemas/xtrm.pi-extension-manifest.v1.json
+++ b/packages/contracts/schemas/xtrm.pi-extension-manifest.v1.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.pi-extension-manifest.v1",
+    "title": "xtrm pi extension manifest",
+    "description": "Declares which xtrm-managed Pi extensions are active and which are disabled (with a reason). Instance: packages/pi-extensions/src/manifest.json. Loader: cli/src/core/pi-runtime.ts (loadPiExtensionManifest). Note: the loader validates id/displayName/required and ignores ownership; ownership is kept here as an optional field.",
+    "type": "object",
+    "required": ["schema_version", "active", "disabled"],
+    "additionalProperties": false,
+    "properties": {
+        "schema_version": { "const": "xtrm.pi-extension-manifest.v1" },
+        "active": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["id", "displayName", "required"],
+                "additionalProperties": false,
+                "properties": {
+                    "id": { "type": "string", "minLength": 1 },
+                    "displayName": { "type": "string", "minLength": 1 },
+                    "required": { "type": "boolean" },
+                    "ownership": { "type": "string" }
+                }
+            }
+        },
+        "disabled": {
+            "type": "object",
+            "description": "extension-id -> non-empty reason string.",
+            "additionalProperties": { "type": "string", "minLength": 1 }
+        }
+    }
+}

--- a/packages/contracts/schemas/xtrm.runtime-compatibility.v1.json
+++ b/packages/contracts/schemas/xtrm.runtime-compatibility.v1.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.runtime-compatibility.v1",
+    "title": "xtrm runtime compatibility",
+    "description": "Core's declared compatibility window against Specialists / xtmux / node, plus the registry of known contract ids. Instance: docs/runtime-compatibility.json. Build-time gate: scripts/check-runtime-compatibility.mjs.",
+    "type": "object",
+    "required": ["schema_version", "core", "contracts"],
+    "additionalProperties": false,
+    "properties": {
+        "schema_version": { "const": "xtrm.runtime-compatibility.v1" },
+        "notes": {
+            "type": "array",
+            "items": { "type": "string" }
+        },
+        "core": {
+            "type": "object",
+            "required": ["package", "requires"],
+            "additionalProperties": false,
+            "properties": {
+                "package": { "type": "string", "minLength": 1 },
+                "requires": {
+                    "type": "object",
+                    "required": ["specialists", "xtmux", "node"],
+                    "additionalProperties": { "type": "string", "minLength": 1 },
+                    "properties": {
+                        "specialists": { "type": "string", "minLength": 1 },
+                        "xtmux": { "type": "string", "minLength": 1 },
+                        "node": { "type": "string", "minLength": 1 }
+                    }
+                }
+            }
+        },
+        "contracts": {
+            "type": "object",
+            "description": "contract-name -> schema id. Ids follow xtrm.<kebab>.v<int> or the legacy literal \"1\".",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "string",
+                "pattern": "^(xtrm\\.[a-z][\\w.-]*\\.v\\d+|1)$"
+            }
+        }
+    }
+}

--- a/packages/contracts/schemas/xtrm.runtime-matrix.v1.json
+++ b/packages/contracts/schemas/xtrm.runtime-matrix.v1.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.runtime-matrix.v1",
+    "title": "xtrm runtime matrix",
+    "description": "Per-repo runtime profile (node/bun) and cross-repo consumer workflows. Instance: docs/runtime-matrix.yml. Repo blocks are intentionally non-uniform (core uses minimum/bun_usage; xtmux/specialists use bun_minimum/node_minimum), so a repo block requires primary_runtime and allows the observed union of keys.",
+    "type": "object",
+    "required": ["schema_version", "core", "xtmux", "specialists", "consumers"],
+    "additionalProperties": false,
+    "properties": {
+        "schema_version": { "const": "xtrm.runtime-matrix.v1" },
+        "core": { "$ref": "#/definitions/repoBlock" },
+        "xtmux": { "$ref": "#/definitions/repoBlock" },
+        "specialists": { "$ref": "#/definitions/repoBlock" },
+        "consumers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["workflow", "repo", "runtime"],
+                "additionalProperties": false,
+                "properties": {
+                    "workflow": { "type": "string", "minLength": 1 },
+                    "repo": { "type": "string", "minLength": 1 },
+                    "runtime": { "type": "string", "minLength": 1 }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "repoBlock": {
+            "type": "object",
+            "required": ["primary_runtime"],
+            "additionalProperties": false,
+            "properties": {
+                "primary_runtime": { "type": "string", "enum": ["node", "bun"] },
+                "minimum": { "type": "string" },
+                "bun_minimum": { "type": "string" },
+                "node_minimum": { "type": ["string", "null"] },
+                "node_usage": { "type": "array", "items": { "type": "string" } },
+                "bun_usage": { "type": "array", "items": { "type": "string" } },
+                "notes": { "type": "string" }
+            }
+        }
+    }
+}

--- a/packages/contracts/schemas/xtrm.runtime-origin.v1.json
+++ b/packages/contracts/schemas/xtrm.runtime-origin.v1.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.runtime-origin.v1",
+    "title": "xtrm runtime origin",
+    "description": "Where a runtime physically launched: host + tmux session/window/pane + agent instance. Captured by `xtmux context --current --json`, validated by RuntimeOriginV1 (xtmux src/domains/identity/runtime-context.ts; specialists src/specialist/runtime-origin.ts) and propagated to child jobs via SPECIALISTS_RUNTIME_ORIGIN_V1. Strict allowlist: unknown keys are rejected. NOTE: worktree/branch/role/parent-job lineage is NOT here — it lives on SupervisorStatus (spawn_origin / root_runtime_origin).",
+    "type": "object",
+    "required": [
+        "schema_version",
+        "kind",
+        "host_id",
+        "tmux_session_id",
+        "tmux_window_id",
+        "tmux_pane_id",
+        "captured_at_ms",
+        "capture_source",
+        "verified"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "schema_version": { "const": "xtrm.runtime-origin.v1" },
+        "kind": { "const": "xtmux.agent_instance" },
+        "host_id": { "type": "string", "minLength": 1 },
+        "tmux_server_id": { "type": "string", "minLength": 1 },
+        "tmux_session_id": { "type": "string", "minLength": 1 },
+        "tmux_window_id": { "type": "string", "minLength": 1 },
+        "tmux_pane_id": { "type": "string", "minLength": 1 },
+        "agent_instance_id": { "type": "string", "minLength": 1 },
+        "bead_id": { "type": "string", "minLength": 1 },
+        "parent_session_id": { "type": "string", "minLength": 1 },
+        "captured_at_ms": { "type": "number", "minimum": 0 },
+        "capture_source": { "type": "string", "enum": ["xtmux-context", "propagated"] },
+        "verified": { "type": "boolean" }
+    }
+}

--- a/packages/contracts/schemas/xtrm.specialist-role-envelope.v1.json
+++ b/packages/contracts/schemas/xtrm.specialist-role-envelope.v1.json
@@ -1,0 +1,60 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.specialist-role-envelope.v1",
+    "title": "specialist role envelope (legacy)",
+    "description": "The legacy Specialists-owned role envelope: a .specialist.json document. Registered in docs/runtime-compatibility.json as specialist_role_envelope with the legacy version literal \"1\". Source of truth: specialists src/specialist/schema.ts (Zod SpecialistSchema). Every object is Zod .passthrough(), so this contract is intentionally OPEN (additionalProperties:true) — only the minimal required fields are enforced.",
+    "type": "object",
+    "required": ["specialist"],
+    "additionalProperties": true,
+    "properties": {
+        "specialist": {
+            "type": "object",
+            "required": ["metadata", "execution", "prompt"],
+            "additionalProperties": true,
+            "properties": {
+                "metadata": {
+                    "type": "object",
+                    "required": ["name", "version", "description", "category"],
+                    "additionalProperties": true,
+                    "properties": {
+                        "name": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+                        "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+$" },
+                        "description": { "type": "string" },
+                        "category": { "type": "string" },
+                        "updated": { "type": "string" },
+                        "tags": { "type": "array", "items": { "type": "string" } }
+                    }
+                },
+                "execution": {
+                    "type": "object",
+                    "required": ["model"],
+                    "additionalProperties": true,
+                    "properties": {
+                        "mode": { "type": "string", "enum": ["tool", "skill", "auto"] },
+                        "model": { "type": ["string", "null"] },
+                        "response_format": { "type": "string", "enum": ["text", "json", "markdown"] },
+                        "output_type": { "type": "string", "enum": ["codegen", "analysis", "review", "synthesis", "orchestration", "workflow", "research", "custom"] },
+                        "permission_required": { "type": "string", "enum": ["READ_ONLY", "LOW", "MEDIUM", "HIGH"] },
+                        "thinking_level": { "type": "string", "enum": ["off", "minimal", "low", "medium", "high", "xhigh"] },
+                        "auto_commit": { "type": "string", "enum": ["never", "checkpoint_on_waiting", "checkpoint_on_terminal"] },
+                        "interactive": { "type": "boolean" },
+                        "requires_worktree": { "type": "boolean" },
+                        "bare": { "type": "boolean" },
+                        "max_retries": { "type": "integer", "minimum": 0 },
+                        "timeout_ms": { "type": "number" }
+                    }
+                },
+                "prompt": {
+                    "type": "object",
+                    "required": ["task_template"],
+                    "additionalProperties": true,
+                    "properties": {
+                        "task_template": { "type": "string" },
+                        "system": { "type": "string" },
+                        "system_prompt_mode": { "type": "string", "enum": ["append", "replace"] }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/contracts/schemas/xtrm.xtmux.bridge.v1.json
+++ b/packages/contracts/schemas/xtrm.xtmux.bridge.v1.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.xtmux.bridge.v1",
+    "title": "xtmux read-only bridge frame",
+    "description": "One NDJSON frame of the read-only xtmux bridge protocol (BRIDGE_SCHEMA='xtrm.xtmux.bridge.v1'). Source: xtmux src/bridge/stdio.ts. A frame is exactly one of: a request (id + method [+ params]), a success reply (id + result), or an error reply (id + error). Invariant: every reply echoes the request id — exactly one reply per request id. snake_case on params/result/detail. Only READ_ONLY_METHODS are accepted; mutation methods return XTMUX_BRIDGE_READ_ONLY.",
+    "oneOf": [
+        {
+            "type": "object",
+            "required": ["id", "method"],
+            "additionalProperties": false,
+            "properties": {
+                "id": { "type": ["string", "number"] },
+                "method": {
+                    "type": "string",
+                    "enum": ["bridge.hello", "bridge.cancel", "topology.snapshot", "journal.query", "journal.follow", "pane.capture", "health.get"]
+                },
+                "params": { "type": "object" }
+            }
+        },
+        {
+            "type": "object",
+            "required": ["id", "result"],
+            "additionalProperties": false,
+            "properties": {
+                "id": { "type": ["string", "number", "null"] },
+                "result": { "type": "object" }
+            }
+        },
+        {
+            "type": "object",
+            "required": ["id", "error"],
+            "additionalProperties": false,
+            "properties": {
+                "id": { "type": ["string", "number", "null"] },
+                "error": {
+                    "type": "object",
+                    "required": ["code", "message"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "detail": { "type": "object" }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/packages/contracts/schemas/xtrm.xtmux.message.v1.json
+++ b/packages/contracts/schemas/xtrm.xtmux.message.v1.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.xtmux.message.v1",
+    "title": "xtmux message record",
+    "description": "A message record as emitted by the xtmux message CLI (message-send / message-list / message-status / message-reply, all --json). Source: xtmux src/cli-messages.ts + src/domains/messages/*. camelCase, no schema_version on the wire. One permissive record covering all message responses: messageKey/senderId/recipientId are the stable core; send-, list-, status- and reply-specific fields are optional. replyStatus is only present for reply-required messages.",
+    "type": "object",
+    "required": ["messageKey", "senderId", "recipientId"],
+    "additionalProperties": false,
+    "properties": {
+        "messageKey": { "type": "string", "minLength": 1 },
+        "messageId": { "type": "number" },
+        "duplicate": { "type": "boolean" },
+        "senderId": { "type": "string", "minLength": 1 },
+        "senderPaneId": { "type": ["string", "null"] },
+        "senderKind": { "type": "string" },
+        "recipientId": { "type": "string", "minLength": 1 },
+        "targetPaneId": { "type": ["string", "null"] },
+        "recipientKind": { "type": "string" },
+        "beadId": { "type": ["string", "null"] },
+        "summary": { "type": "string" },
+        "createdAtMs": { "type": ["number", "null"] },
+        "expectsReply": { "type": "boolean" },
+        "acked": { "type": "boolean" },
+        "ackedAtMs": { "type": ["number", "null"] },
+        "ackedBy": { "type": ["string", "null"] },
+        "replyStatus": { "type": ["string", "null"], "enum": ["pending", "fulfilled", "cancelled", null] },
+        "fulfilledAtMs": { "type": ["number", "null"] },
+        "fulfilledByMessageKey": { "type": ["string", "null"] },
+        "replyToMessageKey": { "type": "string" },
+        "fulfilledMessageKey": { "type": "string" },
+        "fulfilled": { "type": "boolean" },
+        "correlatedReply": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "required": ["messageKey", "senderId", "recipientId", "summary", "createdAtMs"],
+            "properties": {
+                "messageKey": { "type": "string", "minLength": 1 },
+                "senderId": { "type": "string" },
+                "senderPaneId": { "type": ["string", "null"] },
+                "recipientId": { "type": "string" },
+                "targetPaneId": { "type": ["string", "null"] },
+                "summary": { "type": "string" },
+                "createdAtMs": { "type": "number" }
+            }
+        }
+    }
+}

--- a/packages/contracts/schemas/xtrm.xtmux.monitor.v1.json
+++ b/packages/contracts/schemas/xtrm.xtmux.monitor.v1.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.xtmux.monitor.v1",
+    "title": "xtmux monitor projection",
+    "description": "One monitor row as emitted by `xtmux monitor-list --json` (a bare array of these). Source: xtmux src/cli-monitors.ts (monitorProjection). camelCase. No schema_version on the wire. waitId is present only when a live wait is joined.",
+    "type": "object",
+    "required": ["monitorId", "target", "sessionId", "paneId", "state", "startedAtMs", "updatedAtMs", "timeoutMs", "intervalMs", "wakeDelivered", "wakeConsumed", "orphan"],
+    "additionalProperties": false,
+    "properties": {
+        "monitorId": { "type": "string", "minLength": 1 },
+        "waitId": { "type": "string", "minLength": 1 },
+        "target": { "type": "string" },
+        "requesterSessionId": { "type": ["string", "null"] },
+        "requesterPaneId": { "type": ["string", "null"] },
+        "sessionId": { "type": "string" },
+        "paneId": { "type": "string" },
+        "state": { "type": "string" },
+        "startedAtMs": { "type": "number" },
+        "updatedAtMs": { "type": "number" },
+        "timeoutMs": { "type": "number" },
+        "intervalMs": { "type": "number" },
+        "terminalStatus": { "type": ["string", "null"] },
+        "terminalAtMs": { "type": ["number", "null"] },
+        "wakeDelivered": { "type": "boolean" },
+        "wakeConsumed": { "type": "boolean" },
+        "orphan": { "type": "boolean" }
+    }
+}

--- a/packages/contracts/schemas/xtrm.xtmux.obligation.v1.json
+++ b/packages/contracts/schemas/xtrm.xtmux.obligation.v1.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.xtmux.obligation.v1",
+    "title": "xtmux pending obligation",
+    "description": "One reply-obligation row as emitted by `xtmux obligations list --json` (a bare array of these). Source: xtmux src/domains/messages/obligations.ts (PendingObligation). camelCase. No schema_version on the wire; replyStatus is always the literal 'pending'.",
+    "type": "object",
+    "required": ["messageKey", "messageId", "senderId", "senderPaneId", "recipientId", "targetPaneId", "summary", "createdAtMs", "acked", "ackedAtMs", "replyStatus"],
+    "additionalProperties": false,
+    "properties": {
+        "messageKey": { "type": "string", "minLength": 1 },
+        "messageId": { "type": "number" },
+        "senderId": { "type": "string", "minLength": 1 },
+        "senderPaneId": { "type": ["string", "null"] },
+        "recipientId": { "type": "string", "minLength": 1 },
+        "targetPaneId": { "type": ["string", "null"] },
+        "summary": { "type": "string" },
+        "createdAtMs": { "type": "number" },
+        "acked": { "type": "boolean" },
+        "ackedAtMs": { "type": ["number", "null"] },
+        "replyStatus": { "const": "pending" }
+    }
+}

--- a/packages/contracts/schemas/xtrm.xtmux.topology.v1.json
+++ b/packages/contracts/schemas/xtrm.xtmux.topology.v1.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.xtmux.topology.v1",
+    "title": "xtmux topology projection",
+    "description": "Aggregated tmux topology projection produced by the xtmux bash picker ($XTMUX_PICKER topology --json) and relayed verbatim by the read-only bridge (topology.snapshot). snake_case, deliberate cross-repo contract. Canonical shape: xtmux docs/xtmux-gaps.md §5.3.",
+    "type": "object",
+    "required": ["schema_version", "generated_at_ms", "host", "sessions"],
+    "additionalProperties": false,
+    "properties": {
+        "schema_version": { "const": "xtrm.xtmux.topology.v1" },
+        "generated_at_ms": { "type": "number", "minimum": 0 },
+        "host": {
+            "type": "object",
+            "required": ["host_id", "tmux_server_id"],
+            "additionalProperties": false,
+            "properties": {
+                "host_id": { "type": "string", "minLength": 1 },
+                "tmux_server_id": { "type": "string", "minLength": 1 }
+            }
+        },
+        "sessions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["session_id", "name", "created_at_ms", "activity_at_ms", "attached", "active", "windows"],
+                "additionalProperties": false,
+                "properties": {
+                    "session_id": { "type": "string", "minLength": 1 },
+                    "name": { "type": "string" },
+                    "created_at_ms": { "type": "number", "minimum": 0 },
+                    "activity_at_ms": { "type": "number", "minimum": 0 },
+                    "attached": { "type": "boolean" },
+                    "active": { "type": "boolean" },
+                    "windows": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["window_id", "window_index", "name", "active", "panes"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "window_id": { "type": "string", "minLength": 1 },
+                                "window_index": { "type": "number" },
+                                "name": { "type": "string" },
+                                "active": { "type": "boolean" },
+                                "panes": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "required": ["pane_id", "pane_index", "active", "width", "height", "left", "top", "pid", "current_command", "current_path"],
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "pane_id": { "type": "string", "minLength": 1 },
+                                            "pane_index": { "type": "number" },
+                                            "active": { "type": "boolean" },
+                                            "width": { "type": "number" },
+                                            "height": { "type": "number" },
+                                            "left": { "type": "number" },
+                                            "top": { "type": "number" },
+                                            "pid": { "type": "number" },
+                                            "current_command": { "type": "string" },
+                                            "current_path": { "type": "string" },
+                                            "agent": {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "instance_id": { "type": "string" },
+                                                    "state": { "type": "string" },
+                                                    "bead_id": { "type": "string" },
+                                                    "task": { "type": "string" },
+                                                    "prompt_file": { "type": "string" },
+                                                    "parent_session_id": { "type": "string" },
+                                                    "last_transition": { "type": "string" }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/contracts/schemas/xtrm.xtmux.wait.v1.json
+++ b/packages/contracts/schemas/xtrm.xtmux.wait.v1.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.xtmux.wait.v1",
+    "title": "xtmux wait projection",
+    "description": "The single object emitted by `xtmux wait-agent --json`. Source: xtmux src/cli-monitors.ts (waitProjection). camelCase. No schema_version on the wire. intervalMs is always null in the wait projection.",
+    "type": "object",
+    "required": ["waitId", "target", "requesterSessionId", "requesterPaneId", "targetSessionId", "targetPaneId", "state", "wakeDelivered", "wakeConsumed", "replayed", "startedAtMs"],
+    "additionalProperties": false,
+    "properties": {
+        "waitId": { "type": "string", "minLength": 1 },
+        "target": { "type": "string" },
+        "requesterSessionId": { "type": "string" },
+        "requesterPaneId": { "type": "string" },
+        "targetSessionId": { "type": "string" },
+        "targetPaneId": { "type": "string" },
+        "state": { "type": "string" },
+        "monitorId": { "type": ["string", "null"] },
+        "terminalStatus": { "type": ["string", "null"] },
+        "wakeDelivered": { "type": "boolean" },
+        "wakeConsumed": { "type": "boolean" },
+        "replayed": { "type": "boolean" },
+        "startedAtMs": { "type": "number" },
+        "completedAtMs": { "type": ["number", "null"] },
+        "timeoutMs": { "type": ["number", "null"] },
+        "intervalMs": { "type": "null" }
+    }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,29 @@
+// @xtrm/contracts — shared cross-runtime contracts for the xtrm ecosystem.
+// Ships JSON Schemas (../schemas), TypeScript types and ajv-backed runtime
+// validators. The JSON Schema files are the single source of truth.
+
+export * from './types.js';
+export {
+    SCHEMA_IDS,
+    getSchema,
+    getValidator,
+    validate,
+    assertValid,
+    type JsonSchema,
+    type ValidationResult,
+} from './validate.js';
+
+import { validate } from './validate.js';
+import type { ContractTypeMap } from './types.js';
+
+/**
+ * Typed validation guard: narrows `data` to the payload type for a known
+ * schema id when it validates. `validate()` is the untyped, error-returning
+ * form; this is the ergonomic guard for TypeScript consumers.
+ */
+export function isValid<K extends keyof ContractTypeMap>(
+    id: K,
+    data: unknown,
+): data is ContractTypeMap[K] {
+    return validate(id, data).valid;
+}

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -1,0 +1,332 @@
+// Hand-authored TypeScript types mirroring the JSON Schemas under ../schemas.
+// The JSON Schema files are the source of truth; these mirror them for
+// consumers who want compile-time shapes. Keep them in sync when a schema
+// changes (the fixture test guards the schema<->fixture agreement, not this).
+
+/** Canonical schema ids shipped by this package. */
+export const SCHEMA_ID = {
+    runtimeCompatibility: 'xtrm.runtime-compatibility.v1',
+    interactiveRoleEnvelope: 'xtrm.interactive-role-envelope.v1',
+    piExtensionManifest: 'xtrm.pi-extension-manifest.v1',
+    commandDeprecations: 'xtrm.command-deprecations.v1',
+    runtimeMatrix: 'xtrm.runtime-matrix.v1',
+    runtimeOrigin: 'xtrm.runtime-origin.v1',
+    branchIntegration: 'xtrm.branch.integration.v1',
+    xtmuxTopology: 'xtrm.xtmux.topology.v1',
+    xtmuxMessage: 'xtrm.xtmux.message.v1',
+    xtmuxObligation: 'xtrm.xtmux.obligation.v1',
+    xtmuxMonitor: 'xtrm.xtmux.monitor.v1',
+    xtmuxWait: 'xtrm.xtmux.wait.v1',
+    xtmuxBridge: 'xtrm.xtmux.bridge.v1',
+    agentRoleLaunched: 'xtrm.agent-role-launched.v1',
+    specialistRoleEnvelope: 'xtrm.specialist-role-envelope.v1',
+} as const;
+
+export type SchemaId = (typeof SCHEMA_ID)[keyof typeof SCHEMA_ID];
+
+// --- xtrm.runtime-compatibility.v1 ---
+export interface RuntimeCompatibilityV1 {
+    schema_version: 'xtrm.runtime-compatibility.v1';
+    notes?: string[];
+    core: {
+        package: string;
+        requires: { specialists: string; xtmux: string; node: string; [dep: string]: string };
+    };
+    contracts: Record<string, string>;
+}
+
+// --- xtrm.interactive-role-envelope.v1 ---
+export interface InteractiveRoleEnvelopeV1 {
+    role: string;
+    systemPrompt: string;
+    skillPaths: string[];
+    model?: string;
+    thinkingLevel?: string;
+}
+
+// --- xtrm.pi-extension-manifest.v1 ---
+export interface PiExtensionManifestV1 {
+    schema_version: 'xtrm.pi-extension-manifest.v1';
+    active: Array<{ id: string; displayName: string; required: boolean; ownership?: string }>;
+    disabled: Record<string, string>;
+}
+
+// --- xtrm.command-deprecations.v1 ---
+export interface CommandDeprecationEntry {
+    command: string;
+    deprecated_since: string;
+    remove_in: string;
+    replacement: string;
+    behavior: 'execute-with-warning' | 'fail-with-redirect';
+    code_ref: string;
+    notes?: string;
+}
+export interface CommandDeprecationsV1 {
+    schema_version: 'xtrm.command-deprecations.v1';
+    notes?: string[];
+    entries: CommandDeprecationEntry[];
+}
+
+// --- xtrm.runtime-matrix.v1 ---
+export interface RuntimeMatrixRepoBlock {
+    primary_runtime: 'node' | 'bun';
+    minimum?: string;
+    bun_minimum?: string;
+    node_minimum?: string | null;
+    node_usage?: string[];
+    bun_usage?: string[];
+    notes?: string;
+}
+export interface RuntimeMatrixV1 {
+    schema_version: 'xtrm.runtime-matrix.v1';
+    core: RuntimeMatrixRepoBlock;
+    xtmux: RuntimeMatrixRepoBlock;
+    specialists: RuntimeMatrixRepoBlock;
+    consumers: Array<{ workflow: string; repo: string; runtime: string }>;
+}
+
+// --- xtrm.runtime-origin.v1 ---
+export interface RuntimeOriginV1 {
+    schema_version: 'xtrm.runtime-origin.v1';
+    kind: 'xtmux.agent_instance';
+    host_id: string;
+    tmux_server_id?: string;
+    tmux_session_id: string;
+    tmux_window_id: string;
+    tmux_pane_id: string;
+    agent_instance_id?: string;
+    bead_id?: string;
+    parent_session_id?: string;
+    captured_at_ms: number;
+    capture_source: 'xtmux-context' | 'propagated';
+    verified: boolean;
+}
+
+// --- xtrm.branch.integration.v1 ---
+export interface BranchIntegrationV1 {
+    schema_version: 'xtrm.branch.integration.v1';
+    timestamp: string;
+    t_unix_ms: number;
+    source: { job_id: string; branch: string; worktree: string };
+    target: { branch: string; worktree: string; role?: string };
+    status: 'merged';
+    commit: string;
+}
+
+// --- xtrm.xtmux.topology.v1 ---
+export interface XtmuxTopologyAgent {
+    instance_id?: string;
+    state?: string;
+    bead_id?: string;
+    task?: string;
+    prompt_file?: string;
+    parent_session_id?: string;
+    last_transition?: string;
+}
+export interface XtmuxTopologyPane {
+    pane_id: string;
+    pane_index: number;
+    active: boolean;
+    width: number;
+    height: number;
+    left: number;
+    top: number;
+    pid: number;
+    current_command: string;
+    current_path: string;
+    agent?: XtmuxTopologyAgent;
+}
+export interface XtmuxTopologyWindow {
+    window_id: string;
+    window_index: number;
+    name: string;
+    active: boolean;
+    panes: XtmuxTopologyPane[];
+}
+export interface XtmuxTopologySession {
+    session_id: string;
+    name: string;
+    created_at_ms: number;
+    activity_at_ms: number;
+    attached: boolean;
+    active: boolean;
+    windows: XtmuxTopologyWindow[];
+}
+export interface XtmuxTopologyV1 {
+    schema_version: 'xtrm.xtmux.topology.v1';
+    generated_at_ms: number;
+    host: { host_id: string; tmux_server_id: string };
+    sessions: XtmuxTopologySession[];
+}
+
+// --- xtrm.xtmux.message.v1 ---
+export type XtmuxReplyStatus = 'pending' | 'fulfilled' | 'cancelled' | null;
+export interface XtmuxCorrelatedReply {
+    messageKey: string;
+    senderId: string;
+    senderPaneId?: string | null;
+    recipientId: string;
+    targetPaneId?: string | null;
+    summary: string;
+    createdAtMs: number;
+}
+export interface XtmuxMessageV1 {
+    messageKey: string;
+    senderId: string;
+    recipientId: string;
+    messageId?: number;
+    duplicate?: boolean;
+    senderPaneId?: string | null;
+    senderKind?: string;
+    targetPaneId?: string | null;
+    recipientKind?: string;
+    beadId?: string | null;
+    summary?: string;
+    createdAtMs?: number | null;
+    expectsReply?: boolean;
+    acked?: boolean;
+    ackedAtMs?: number | null;
+    ackedBy?: string | null;
+    replyStatus?: XtmuxReplyStatus;
+    fulfilledAtMs?: number | null;
+    fulfilledByMessageKey?: string | null;
+    replyToMessageKey?: string;
+    fulfilledMessageKey?: string;
+    fulfilled?: boolean;
+    correlatedReply?: XtmuxCorrelatedReply | null;
+}
+
+// --- xtrm.xtmux.obligation.v1 ---
+export interface XtmuxObligationV1 {
+    messageKey: string;
+    messageId: number;
+    senderId: string;
+    senderPaneId: string | null;
+    recipientId: string;
+    targetPaneId: string | null;
+    summary: string;
+    createdAtMs: number;
+    acked: boolean;
+    ackedAtMs: number | null;
+    replyStatus: 'pending';
+}
+
+// --- xtrm.xtmux.monitor.v1 ---
+export interface XtmuxMonitorV1 {
+    monitorId: string;
+    target: string;
+    sessionId: string;
+    paneId: string;
+    state: string;
+    startedAtMs: number;
+    updatedAtMs: number;
+    timeoutMs: number;
+    intervalMs: number;
+    wakeDelivered: boolean;
+    wakeConsumed: boolean;
+    orphan: boolean;
+    waitId?: string;
+    requesterSessionId?: string | null;
+    requesterPaneId?: string | null;
+    terminalStatus?: string | null;
+    terminalAtMs?: number | null;
+}
+
+// --- xtrm.xtmux.wait.v1 ---
+export interface XtmuxWaitV1 {
+    waitId: string;
+    target: string;
+    requesterSessionId: string;
+    requesterPaneId: string;
+    targetSessionId: string;
+    targetPaneId: string;
+    state: string;
+    wakeDelivered: boolean;
+    wakeConsumed: boolean;
+    replayed: boolean;
+    startedAtMs: number;
+    monitorId?: string | null;
+    terminalStatus?: string | null;
+    completedAtMs?: number | null;
+    timeoutMs?: number | null;
+    intervalMs?: null;
+}
+
+// --- xtrm.xtmux.bridge.v1 ---
+export interface XtmuxBridgeRequest {
+    id: string | number;
+    method:
+        | 'bridge.hello'
+        | 'bridge.cancel'
+        | 'topology.snapshot'
+        | 'journal.query'
+        | 'journal.follow'
+        | 'pane.capture'
+        | 'health.get';
+    params?: Record<string, unknown>;
+}
+export interface XtmuxBridgeSuccess {
+    id: string | number | null;
+    result: Record<string, unknown>;
+}
+export interface XtmuxBridgeError {
+    id: string | number | null;
+    error: { code: string; message: string; detail?: Record<string, unknown> };
+}
+export type XtmuxBridgeV1 = XtmuxBridgeRequest | XtmuxBridgeSuccess | XtmuxBridgeError;
+
+// --- xtrm.agent-role-launched.v1 (loose k=v field bag) ---
+export interface AgentRoleLaunchedV1 {
+    instance_id?: string;
+    instance?: string;
+    session?: string;
+    session_id?: string;
+    session_name?: string;
+    pane?: string;
+    pane_id?: string;
+    runtime?: string;
+    role?: string;
+    bead?: string;
+    bead_id?: string;
+    task?: string;
+    prompt_file?: string;
+    parent?: string;
+    parent_session?: string;
+    [key: string]: string | undefined;
+}
+
+// --- xtrm.specialist-role-envelope.v1 (legacy "1", passthrough/open) ---
+export interface SpecialistRoleEnvelopeV1 {
+    specialist: {
+        metadata: {
+            name: string;
+            version: string;
+            description: string;
+            category: string;
+            [key: string]: unknown;
+        };
+        execution: { model: string | null; [key: string]: unknown };
+        prompt: { task_template: string; [key: string]: unknown };
+        [key: string]: unknown;
+    };
+    [key: string]: unknown;
+}
+
+/** Map from schema id to its TypeScript payload type. */
+export interface ContractTypeMap {
+    'xtrm.runtime-compatibility.v1': RuntimeCompatibilityV1;
+    'xtrm.interactive-role-envelope.v1': InteractiveRoleEnvelopeV1;
+    'xtrm.pi-extension-manifest.v1': PiExtensionManifestV1;
+    'xtrm.command-deprecations.v1': CommandDeprecationsV1;
+    'xtrm.runtime-matrix.v1': RuntimeMatrixV1;
+    'xtrm.runtime-origin.v1': RuntimeOriginV1;
+    'xtrm.branch.integration.v1': BranchIntegrationV1;
+    'xtrm.xtmux.topology.v1': XtmuxTopologyV1;
+    'xtrm.xtmux.message.v1': XtmuxMessageV1;
+    'xtrm.xtmux.obligation.v1': XtmuxObligationV1;
+    'xtrm.xtmux.monitor.v1': XtmuxMonitorV1;
+    'xtrm.xtmux.wait.v1': XtmuxWaitV1;
+    'xtrm.xtmux.bridge.v1': XtmuxBridgeV1;
+    'xtrm.agent-role-launched.v1': AgentRoleLaunchedV1;
+    'xtrm.specialist-role-envelope.v1': SpecialistRoleEnvelopeV1;
+}

--- a/packages/contracts/src/validate.ts
+++ b/packages/contracts/src/validate.ts
@@ -1,0 +1,64 @@
+import { Ajv, type ValidateFunction, type ErrorObject } from 'ajv';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// Schemas ship as static JSON under ../schemas (sibling of both src/ and dist/,
+// so this resolves the same whether running from source or the packed build).
+const schemasDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'schemas');
+
+export type JsonSchema = Record<string, unknown> & { $id: string };
+
+function loadSchemas(): JsonSchema[] {
+    return readdirSync(schemasDir)
+        .filter((f) => f.endsWith('.json'))
+        .map((f) => JSON.parse(readFileSync(path.join(schemasDir, f), 'utf8')) as JsonSchema);
+}
+
+// strict:false — contract ids (e.g. "xtrm.runtime-origin.v1") are intentionally
+// not URIs, and we lean on draft-07 `const`; neither should be a strict-mode error.
+// validateFormats:false — `format` (e.g. date-time) is kept as documentation only;
+// enforcing it would need ajv-formats. Keeps output clean and dependency-light.
+// allErrors defaults to false (fail-fast): a validator that may see cross-repo
+// payloads shouldn't let a crafted input balloon the error array (DoS).
+const ajv = new Ajv({ strict: false, validateFormats: false });
+const schemas = loadSchemas();
+for (const schema of schemas) ajv.addSchema(schema);
+
+/** All contract schema ids shipped by this package, sorted. */
+export const SCHEMA_IDS: readonly string[] = schemas.map((s) => s.$id).sort();
+
+/** Return the raw JSON Schema object for a contract id, or undefined. */
+export function getSchema(id: string): JsonSchema | undefined {
+    return schemas.find((s) => s.$id === id);
+}
+
+/** Compiled ajv validator for a contract id. Throws on unknown id. */
+export function getValidator(id: string): ValidateFunction {
+    const validator = ajv.getSchema(id);
+    if (!validator) {
+        throw new Error(`Unknown contract schema id: ${id}. Known ids: ${SCHEMA_IDS.join(', ')}`);
+    }
+    return validator as ValidateFunction;
+}
+
+export interface ValidationResult {
+    valid: boolean;
+    errors: ErrorObject[];
+}
+
+/** Validate data against a contract schema. Never throws on invalid data. */
+export function validate(id: string, data: unknown): ValidationResult {
+    const validator = getValidator(id);
+    const valid = validator(data) as boolean;
+    return { valid, errors: valid ? [] : validator.errors ?? [] };
+}
+
+/** Validate and throw a readable error if invalid. */
+export function assertValid(id: string, data: unknown): void {
+    const { valid, errors } = validate(id, data);
+    if (!valid) {
+        const detail = errors.map((e) => `${e.instancePath || '/'} ${e.message}`).join('; ');
+        throw new Error(`Contract ${id} validation failed: ${detail}`);
+    }
+}

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { SCHEMA_IDS, SCHEMA_ID, validate, getSchema, isValid } from '../src/index.js';
+
+const fixturesDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'fixtures');
+const golden = JSON.parse(readFileSync(path.join(fixturesDir, 'golden.json'), 'utf8')) as Record<string, unknown>;
+const invalid = JSON.parse(readFileSync(path.join(fixturesDir, 'invalid.json'), 'utf8')) as Record<string, unknown>;
+
+describe('@xtrm/contracts registry', () => {
+    it('exposes every declared SCHEMA_ID as a loadable schema', () => {
+        for (const id of Object.values(SCHEMA_ID)) {
+            expect(SCHEMA_IDS, `SCHEMA_ID.${id} missing from loaded schemas`).toContain(id);
+            expect(getSchema(id), `schema ${id} not loadable`).toBeTruthy();
+        }
+    });
+
+    it('loaded schema set exactly matches the SCHEMA_ID constants (no orphans, no gaps)', () => {
+        expect([...SCHEMA_IDS].sort()).toEqual([...Object.values(SCHEMA_ID)].sort());
+    });
+
+    it('every schema ships a golden + invalid fixture', () => {
+        for (const id of SCHEMA_IDS) {
+            expect(golden, `golden fixture missing for ${id}`).toHaveProperty(id);
+            expect(invalid, `invalid fixture missing for ${id}`).toHaveProperty(id);
+        }
+    });
+});
+
+describe('golden fixtures validate', () => {
+    for (const id of SCHEMA_IDS) {
+        it(`accepts the golden payload for ${id}`, () => {
+            const result = validate(id, golden[id]);
+            expect(result.errors, `${id}: ${JSON.stringify(result.errors)}`).toEqual([]);
+            expect(result.valid).toBe(true);
+        });
+    }
+});
+
+describe('invalid fixtures are rejected', () => {
+    for (const id of SCHEMA_IDS) {
+        it(`rejects the fabricated invalid payload for ${id}`, () => {
+            expect(validate(id, invalid[id]).valid).toBe(false);
+        });
+    }
+});
+
+describe('validator behavior', () => {
+    it('rejects a fabricated invalid pi-extension manifest (audit acceptance criterion)', () => {
+        const fabricated = {
+            schema_version: 'xtrm.pi-extension-manifest.v1',
+            active: [{ id: 'evil', displayName: 'evil', required: 'not-a-boolean' }],
+            disabled: { foo: '' },
+        };
+        const { valid, errors } = validate(SCHEMA_ID.piExtensionManifest, fabricated);
+        expect(valid).toBe(false);
+        expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('isValid narrows a valid runtime-origin payload', () => {
+        expect(isValid(SCHEMA_ID.runtimeOrigin, golden[SCHEMA_ID.runtimeOrigin])).toBe(true);
+        expect(isValid(SCHEMA_ID.runtimeOrigin, { nope: true })).toBe(false);
+    });
+
+    it('throws on an unknown schema id', () => {
+        expect(() => validate('xtrm.not-a-real-schema.v1', {})).toThrow(/Unknown contract schema id/);
+    });
+});

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "declaration": true,
+        "sourceMap": true,
+        "resolveJsonModule": true
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist",
+        "test"
+    ]
+}

--- a/packages/contracts/tsup.config.ts
+++ b/packages/contracts/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+
+// Dual ESM+CJS build so both `import` and `require` consumers (e.g. the P2-01
+// integration suite running against a packed tarball) can load the validators.
+// Schemas are NOT bundled — they ship as static files under schemas/ and are
+// read at runtime relative to the module (../schemas), which resolves the same
+// from dist/ and from src/ since both sit one level under the package root.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    target: 'node24',
+    // Inject an import.meta.url shim into the CJS output so ../schemas resolves
+    // for require() consumers too (esbuild leaves import.meta unshimmed otherwise).
+    shims: true,
+});

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+// Own config so this package's tests are discovered independently of the repo
+// root config (which scopes to cli/** and excludes .xtrm/worktrees/**).
+export default defineConfig({
+    test: {
+        include: ['test/**/*.test.ts'],
+    },
+});


### PR DESCRIPTION
## Audit P2-02 — shared contract package (Wave-2 helper γ)

Adds `packages/contracts` (`@xtrm/contracts`): the cross-runtime contracts shared by **Core / Specialists / xtmux**, published as **JSON Schemas** (source of truth) + **TypeScript types** + **ajv runtime validators** + **golden fixtures**.

### What's in it
- **15 draft-07 JSON Schemas** (`schemas/*.json`, `$id` = schema id):
  - Core: `runtime-compatibility.v1`, `interactive-role-envelope.v1`, `pi-extension-manifest.v1`, `command-deprecations.v1`, `runtime-matrix.v1`
  - Lineage/observability: `runtime-origin.v1`, `branch.integration.v1`
  - xtmux runtime: `xtmux.{topology,message,obligation,monitor,wait,bridge}.v1`, `agent-role-launched.v1`
  - Legacy: `specialist-role-envelope.v1` (registry version `"1"`, open/passthrough)
- `src/` — ajv registry (`validate`, `assertValid`, `isValid`, `getValidator`, `getSchema`, `SCHEMA_IDS`) + hand-authored TS types + `SCHEMA_ID`/`ContractTypeMap`
- `fixtures/golden.json` + `fixtures/invalid.json` — one valid + one invalid payload per schema
- `test/contracts.test.ts` — **36 tests**: every golden validates, every invalid is rejected, id coverage, and the "reject a fabricated invalid manifest" acceptance case

### Verification
- `npm test --workspace @xtrm/contracts` → **36/36**
- `tsc --noEmit` clean; `tsup` dual **esm + cjs + d.ts** build; both `require()` and `import()` of built dist verified (schemas resolve via `../schemas`, same from `src/` and `dist/`)

### Key decisions
- **Packaging (a)**: inside core, mirrors `packages/pi-extensions`; wired into root `workspaces` + `test:contracts`/`build:contracts` scripts.
- **Validator = ajv** (already a cli devDep) rather than the bespoke `scripts/check-*.mjs` style — a contracts package shouldn't reinvent JSON-Schema validation. `allErrors` left at the fail-fast default (Semgrep DoS gate); `validateFormats:false` keeps `format` as annotation (no ajv-formats dep).
- xtmux / `branch.integration` / `runtime-origin` shapes reverse-engineered from `~/dev/xtmux` (master) and `~/dev/specialists` (PR #199 `76b888fa`).

### Scope discipline (untouched)
- `docs/runtime-compatibility.json` and `scripts/check-*.mjs` are **not** modified — wiring runtime code to consume these validators is a separate follow-up epic.
- `cli/src/utils/worktree-session.ts` (xtrm-3xgs5) and `packages/pi-extensions/**` untouched.
- `dist/` gitignored (prepublishOnly builds it for pack).

### Open question for operator
Publish scope: audit names `@xtrm/contracts`, but the existing published scope is `@jaggerxtrm` (pi-extensions). `@xtrm` may be unowned — decide at publish time (publishing is gated on operator anyway).

core-tracker: **xtrm-kvsrd.1** (epic **xtrm-kvsrd**, audit sprint wave 2). Helper δ (P2-01 integration suite) runs in parallel and can consume this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)