### PR TITLE
fix(hooks): migrate xtrm-logger from sqlite3 CLI to node:sqlite (xtrm-etmv4.1)

### DIFF
--- a/.xtrm/hooks/xtrm-logger.mjs
+++ b/.xtrm/hooks/xtrm-logger.mjs
@@ -9,15 +9,15 @@
 //   import { logEvent } from './xtrm-logger.mjs';
 //   logEvent({ cwd, sessionId, kind: 'gate.edit.allow', outcome: 'allow', toolName, issueId });
 
-import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 
 // ── Schema ────────────────────────────────────────────────────────────────────
 
 const INIT_SQL = `
-PRAGMA journal_mode=WAL;
 PRAGMA busy_timeout=5000;
+PRAGMA journal_mode=WAL;
 CREATE TABLE IF NOT EXISTS events (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   ts          INTEGER NOT NULL,
@@ -51,22 +51,11 @@ function findDbPath(cwd) {
   return null; // No beads project found — silently skip logging
 }
 
-function sqlExec(dbPath, sql) {
-  return spawnSync('sqlite3', [dbPath, sql], {
-    stdio: ['pipe', 'pipe', 'pipe'],
-    encoding: 'utf8',
-    timeout: 3000,
-  });
-}
-
-function ensureDb(dbPath) {
+function openDb(dbPath) {
   mkdirSync(dirname(dbPath), { recursive: true });
-  sqlExec(dbPath, INIT_SQL);
-}
-
-function sqlEsc(val) {
-  if (val === null || val === undefined) return 'NULL';
-  return `'${String(val).replace(/'/g, "''")}'`;
+  const db = new DatabaseSync(dbPath);
+  db.exec(INIT_SQL);
+  return db;
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -88,6 +77,7 @@ function sqlEsc(val) {
  * @param {object}  [params.extra]     Legacy: extra object (merged into data)
  */
 export function logEvent(params) {
+  let db;
   try {
     const { cwd, sessionId, kind } = params;
     if (!cwd || !sessionId || !kind) return;
@@ -109,15 +99,18 @@ export function logEvent(params) {
       if (Object.keys(merged).length > 0) dataStr = JSON.stringify(merged);
     }
 
-    const ts = Date.now();
-    const sql = `INSERT INTO events (ts,session_id,runtime,worktree,kind,tool_name,outcome,issue_id,duration_ms,data) VALUES (${ts},${sqlEsc(sessionId)},${sqlEsc(runtime)},${sqlEsc(worktree)},${sqlEsc(kind)},${sqlEsc(toolName ?? null)},${sqlEsc(outcome ?? null)},${sqlEsc(issueId ?? null)},${durationMs ?? 'NULL'},${sqlEsc(dataStr)})`;
-
-    let result = sqlExec(dbPath, sql);
-    if (result.status !== 0) {
-      ensureDb(dbPath);
-      result = sqlExec(dbPath, sql);
-    }
+    db = openDb(dbPath);
+    db.prepare(`
+      INSERT INTO events
+        (ts, session_id, runtime, worktree, kind, tool_name, outcome, issue_id, duration_ms, data)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      Date.now(), sessionId, runtime, worktree, kind, toolName ?? null,
+      outcome ?? null, issueId ?? null, durationMs ?? null, dataStr,
+    );
   } catch {
     // Silently swallow all errors — logging never affects hook behavior
+  } finally {
+    try { db?.close(); } catch { /* fail-open */ }
   }
 }

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -107,7 +107,7 @@
           "version": "0.11.1"
         },
         "xtrm-logger.mjs": {
-          "hash": "b39e9e7b48a5585782924b35365004a96c58e10012db6b91f3ca9101cc34f61a",
+          "hash": "865592b9490f47da087f09b872284b7d281a9333a4e2a51f40e0535cf6334854",
           "version": "0.11.1"
         },
         "xtrm-session-logger.mjs": {

--- a/cli/src/tests/xtrm-logger.test.ts
+++ b/cli/src/tests/xtrm-logger.test.ts
@@ -1,0 +1,65 @@
+import { DatabaseSync } from 'node:sqlite';
+import { mkdtemp, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const tempDirs: string[] = [];
+const loggerUrl = new URL('../../../.xtrm/hooks/xtrm-logger.mjs', import.meta.url);
+
+async function loadLogger(): Promise<{ logEvent: (params: Record<string, unknown>) => void }> {
+  return import(`${loggerUrl.href}?test=${Date.now()}`);
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('xtrm hook logger', () => {
+  it('persists events without an sqlite3 executable on PATH', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'xtrm-logger-'));
+    tempDirs.push(root);
+    await mkdir(join(root, '.beads'));
+    const previousPath = process.env.PATH;
+    process.env.PATH = join(root, 'empty-bin');
+
+    try {
+      const { logEvent } = await loadLogger();
+      logEvent({
+        cwd: root,
+        sessionId: 'session-1',
+        runtime: 'pi',
+        kind: 'bd.claimed',
+        outcome: 'allow',
+        issueId: 'xtrm-123',
+        data: { source: 'test' },
+      });
+    } finally {
+      process.env.PATH = previousPath;
+    }
+
+    const db = new DatabaseSync(join(root, '.xtrm', 'debug.db'), { readOnly: true });
+    const row = db.prepare('SELECT session_id, runtime, kind, outcome, issue_id, data FROM events').get();
+    db.close();
+
+    expect(row).toEqual({
+      session_id: 'session-1',
+      runtime: 'pi',
+      kind: 'bd.claimed',
+      outcome: 'allow',
+      issue_id: 'xtrm-123',
+      data: '{"source":"test"}',
+    });
+  });
+
+  it('remains fail-open when event data cannot be serialized', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'xtrm-logger-'));
+    tempDirs.push(root);
+    await mkdir(join(root, '.beads'));
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const { logEvent } = await loadLogger();
+
+    expect(() => logEvent({ cwd: root, sessionId: 'session-1', kind: 'tool.call', data: circular })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Core requires Node 24, which ships `node:sqlite`. The pre-existing hook logger shelled out to an external `sqlite3` binary via `spawnSync`; on hosts without it (which is most machines), every hook/Beads event was silently lost to `/dev/null` while the fail-open catch masked the failure. This is the prerequisite for the cross-repo lifecycle observability work in **xtmux-ck7** — that consumer path can only stream events that were actually persisted.

## What lands

- `.xtrm/hooks/xtrm-logger.mjs` — `spawnSync('sqlite3', ...)` + string-escaped SQL replaced with `DatabaseSync(path).prepare(...).run(...)`. Same schema, same `PRAGMA busy_timeout` + `journal_mode=WAL`, same silent-fail semantics.
- `cli/src/tests/xtrm-logger.test.ts` — new. Two tests:
  - Provisions a PATH without `sqlite3`, calls `logEvent`, asserts the row lands in `.xtrm/debug.db` — reproduces the exact failure this closes.
  - Passes a non-serializable (circular) `data` object; asserts `logEvent` never throws (fail-open contract preserved).
- `.xtrm/registry.json` — hash rotation for the new logger bytes.

## Preserved

- Fail-open contract: any error during logging is silently swallowed.
- `db.close()` in a `finally { try … catch { /* fail-open */ } }` so a partial-open never crashes the hook.
- Same event schema: no consumer needs to change.

## Provenance

The core work was drafted by session `%6353` (xtmainorch/pi, working xtmux-ck7 in `~/dev/xtmux`) which discovered the missing-sqlite3 failure mode while trying to observe live events. The bead `xtrm-etmv4.1` was closed prematurely without opening a PR — this reopens+lands it properly.

Closes **xtrm-etmv4.1**. Unblocks **xtmux-ck7**.

## Test plan

- [x] `npx vitest run src/tests/xtrm-logger.test.ts` — 2/2 green locally.
- [ ] CI full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)