### PR TITLE
feat(contracts): publish Beads lifecycle event schema

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -19,12 +19,13 @@ Publishes the wire/record schemas the three repos agree on, as **JSON Schemas**
 ## Usage
 
 ```ts
-import { validate, assertValid, isValid, SCHEMA_ID } from '@xtrm/contracts';
-import type { RuntimeOriginV1 } from '@xtrm/contracts';
+import { validate, assertValid, isValid, SCHEMA_ID, uuidV7TimestampMs } from '@xtrm/contracts';
+import type { RuntimeOriginV1, BeadsLifecycleEventV1 } from '@xtrm/contracts';
 
 const { valid, errors } = validate(SCHEMA_ID.runtimeOrigin, payload);
 assertValid('xtrm.branch.integration.v1', event); // throws with a readable message
 if (isValid(SCHEMA_ID.piExtensionManifest, data)) { /* data: PiExtensionManifestV1 */ }
+const occurredAtMs = uuidV7TimestampMs(beadsEvent.id);
 ```
 
 Consumers who only want the raw schemas can read `@xtrm/contracts/schemas/<id>.json`.
@@ -33,7 +34,8 @@ Consumers who only want the raw schemas can read `@xtrm/contracts/schemas/<id>.j
 
 Core: `xtrm.runtime-compatibility.v1`, `xtrm.interactive-role-envelope.v1`,
 `xtrm.pi-extension-manifest.v1`, `xtrm.command-deprecations.v1`, `xtrm.runtime-matrix.v1`.
-Lineage/observability: `xtrm.runtime-origin.v1`, `xtrm.branch.integration.v1`.
+Lineage/observability: `xtrm.runtime-origin.v1`, `xtrm.branch.integration.v1`,
+`xtrm.beads.lifecycle-event.v1`.
 xtmux runtime: `xtrm.xtmux.topology.v1`, `xtrm.xtmux.message.v1`, `xtrm.xtmux.obligation.v1`,
 `xtrm.xtmux.monitor.v1`, `xtrm.xtmux.wait.v1`, `xtrm.xtmux.bridge.v1`, `xtrm.agent-role-launched.v1`.
 Legacy specialists: `xtrm.specialist-role-envelope.v1` (registry version `"1"`).
@@ -52,6 +54,12 @@ npm test           # vitest
 
 ## Notes
 
+- Beads owns lifecycle facts for Claude, Pi, and raw shells through its Dolt
+  `events` table. Project them as `bd.<event_type>`; do not treat legacy hook or
+  explicit telemetry rows (`bd.claim`, `bd.close`) as additional source facts.
+- `xtrm.beads.lifecycle-event.v1` uses the Beads UUIDv7 event ID for idempotency
+  and UTC milliseconds. Beads 1.1.0 may serialize `created_at` as local wall time
+  with a `Z` suffix, so consumers must use `occurred_at_ms` for ordering/time.
 - Un-versioned xtmux CLI responses (message/obligation/monitor/wait) carry no
   `schema_version` on the wire; their schemas mirror the current CLI output shape.
 - `format` (e.g. `date-time`) is documentation only — not enforced (no ajv-formats dep).

--- a/packages/contracts/fixtures/golden.json
+++ b/packages/contracts/fixtures/golden.json
@@ -9,6 +9,7 @@
         "contracts": {
             "runtime_origin": "xtrm.runtime-origin.v1",
             "runtime_compatibility": "xtrm.runtime-compatibility.v1",
+            "beads_lifecycle_event": "xtrm.beads.lifecycle-event.v1",
             "specialist_role_envelope": "1"
         }
     },
@@ -197,6 +198,20 @@
         "id": 1,
         "method": "pane.capture",
         "params": { "pane_id": "%17", "lines": 200 }
+    },
+    "xtrm.beads.lifecycle-event.v1": {
+        "schema_version": "xtrm.beads.lifecycle-event.v1",
+        "source": "beads.events",
+        "id": "019f847d-530b-77a1-9603-25eeeae6ea27",
+        "issue_id": "xtrm-etmv4.2",
+        "event_type": "claimed",
+        "actor": "jaggerxtrm",
+        "old_value": { "status": "open" },
+        "new_value": { "assignee": "jaggerxtrm", "status": "in_progress" },
+        "comment": null,
+        "created_at": "2026-07-21T13:43:53Z",
+        "occurred_at_ms": 1784634233611,
+        "timestamp_source": "uuidv7"
     },
     "xtrm.agent-role-launched.v1": {
         "instance_id": "7cc0b27f",

--- a/packages/contracts/fixtures/invalid.json
+++ b/packages/contracts/fixtures/invalid.json
@@ -108,6 +108,20 @@
         "id": 2,
         "method": "message.send"
     },
+    "xtrm.beads.lifecycle-event.v1": {
+        "schema_version": "xtrm.beads.lifecycle-event.v1",
+        "source": "xtrm-hook",
+        "id": "not-a-uuidv7",
+        "issue_id": "xtrm-etmv4.2",
+        "event_type": "claim",
+        "actor": "jaggerxtrm",
+        "old_value": "",
+        "new_value": "",
+        "comment": null,
+        "created_at": "2026-07-21T13:43:53Z",
+        "occurred_at_ms": -1,
+        "timestamp_source": "created_at"
+    },
     "xtrm.agent-role-launched.v1": {
         "role": 123
     },

--- a/packages/contracts/schemas/xtrm.beads.lifecycle-event.v1.json
+++ b/packages/contracts/schemas/xtrm.beads.lifecycle-event.v1.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.beads.lifecycle-event.v1",
+    "title": "xtrm Beads lifecycle event",
+    "description": "Canonical projection of one row from Beads' Dolt events table. Beads owns lifecycle facts for every runtime and raw shell. Core hooks and xtmux telemetry are not source events. The UUIDv7 id is the idempotency key and UTC timestamp source; Beads 1.1.0 created_at may contain local wall time mislabeled with Z.",
+    "type": "object",
+    "required": [
+        "schema_version",
+        "source",
+        "id",
+        "issue_id",
+        "event_type",
+        "actor",
+        "old_value",
+        "new_value",
+        "comment",
+        "created_at",
+        "occurred_at_ms",
+        "timestamp_source"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "schema_version": { "const": "xtrm.beads.lifecycle-event.v1" },
+        "source": { "const": "beads.events" },
+        "id": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "issue_id": { "type": "string", "minLength": 1 },
+        "event_type": {
+            "type": "string",
+            "enum": ["created", "claimed", "updated", "closed", "reopened", "status_changed"]
+        },
+        "actor": { "type": "string", "minLength": 1 },
+        "old_value": {},
+        "new_value": {},
+        "comment": { "type": ["string", "null"] },
+        "created_at": { "type": "string", "minLength": 1 },
+        "occurred_at_ms": { "type": "number", "minimum": 0 },
+        "timestamp_source": { "const": "uuidv7" }
+    }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,6 +9,7 @@ export {
     getValidator,
     validate,
     assertValid,
+    uuidV7TimestampMs,
     type JsonSchema,
     type ValidationResult,
 } from './validate.js';

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -12,6 +12,7 @@ export const SCHEMA_ID = {
     runtimeMatrix: 'xtrm.runtime-matrix.v1',
     runtimeOrigin: 'xtrm.runtime-origin.v1',
     branchIntegration: 'xtrm.branch.integration.v1',
+    beadsLifecycleEvent: 'xtrm.beads.lifecycle-event.v1',
     xtmuxTopology: 'xtrm.xtmux.topology.v1',
     xtmuxMessage: 'xtrm.xtmux.message.v1',
     xtmuxObligation: 'xtrm.xtmux.obligation.v1',
@@ -111,6 +112,23 @@ export interface BranchIntegrationV1 {
     target: { branch: string; worktree: string; role?: string };
     status: 'merged';
     commit: string;
+}
+
+// --- xtrm.beads.lifecycle-event.v1 ---
+export type BeadsLifecycleEventType = 'created' | 'claimed' | 'updated' | 'closed' | 'reopened' | 'status_changed';
+export interface BeadsLifecycleEventV1 {
+    schema_version: 'xtrm.beads.lifecycle-event.v1';
+    source: 'beads.events';
+    id: string;
+    issue_id: string;
+    event_type: BeadsLifecycleEventType;
+    actor: string;
+    old_value: unknown;
+    new_value: unknown;
+    comment: string | null;
+    created_at: string;
+    occurred_at_ms: number;
+    timestamp_source: 'uuidv7';
 }
 
 // --- xtrm.xtmux.topology.v1 ---
@@ -321,6 +339,7 @@ export interface ContractTypeMap {
     'xtrm.runtime-matrix.v1': RuntimeMatrixV1;
     'xtrm.runtime-origin.v1': RuntimeOriginV1;
     'xtrm.branch.integration.v1': BranchIntegrationV1;
+    'xtrm.beads.lifecycle-event.v1': BeadsLifecycleEventV1;
     'xtrm.xtmux.topology.v1': XtmuxTopologyV1;
     'xtrm.xtmux.message.v1': XtmuxMessageV1;
     'xtrm.xtmux.obligation.v1': XtmuxObligationV1;

--- a/packages/contracts/src/validate.ts
+++ b/packages/contracts/src/validate.ts
@@ -42,6 +42,14 @@ export function getValidator(id: string): ValidateFunction {
     return validator as ValidateFunction;
 }
 
+const UUID_V7 = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+/** Decode the authoritative UTC millisecond timestamp embedded in a UUIDv7 event id. */
+export function uuidV7TimestampMs(id: string): number {
+    if (!UUID_V7.test(id)) throw new Error(`Expected UUIDv7 event id, got: ${id}`);
+    return Number.parseInt(id.replaceAll('-', '').slice(0, 12), 16);
+}
+
 export interface ValidationResult {
     valid: boolean;
     errors: ErrorObject[];

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import { SCHEMA_IDS, SCHEMA_ID, validate, getSchema, isValid } from '../src/index.js';
+import { SCHEMA_IDS, SCHEMA_ID, validate, getSchema, isValid, uuidV7TimestampMs } from '../src/index.js';
 
 const fixturesDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'fixtures');
 const golden = JSON.parse(readFileSync(path.join(fixturesDir, 'golden.json'), 'utf8')) as Record<string, unknown>;
@@ -44,6 +44,37 @@ describe('invalid fixtures are rejected', () => {
             expect(validate(id, invalid[id]).valid).toBe(false);
         });
     }
+});
+
+describe('Beads lifecycle event contract', () => {
+    const id = 'xtrm.beads.lifecycle-event.v1';
+    const base = {
+        schema_version: id,
+        source: 'beads.events',
+        id: '019f847d-530b-77a1-9603-25eeeae6ea27',
+        issue_id: 'xtrm-etmv4.2',
+        actor: 'jaggerxtrm',
+        old_value: { status: 'open' },
+        new_value: { status: 'in_progress' },
+        comment: null,
+        created_at: '2026-07-21T13:43:53Z',
+        occurred_at_ms: 1784634233611,
+        timestamp_source: 'uuidv7',
+    };
+
+    it.each(['created', 'claimed', 'updated', 'closed', 'reopened', 'status_changed'])('accepts %s', (event_type) => {
+        expect(validate(id, { ...base, event_type }).valid).toBe(true);
+    });
+
+    it('rejects legacy imperative aliases and hook sources', () => {
+        expect(validate(id, { ...base, event_type: 'claim' }).valid).toBe(false);
+        expect(validate(id, { ...base, event_type: 'claimed', source: 'xtrm-hook' }).valid).toBe(false);
+    });
+
+    it('derives UTC milliseconds from the UUIDv7 identity', () => {
+        expect(uuidV7TimestampMs(base.id)).toBe(base.occurred_at_ms);
+        expect(() => uuidV7TimestampMs('not-a-uuidv7')).toThrow(/UUIDv7/);
+    });
 });
 
 describe('validator behavior', () => {


### PR DESCRIPTION
## Summary
- publish `xtrm.beads.lifecycle-event.v1` in `@xtrm/contracts`
- constrain source to `beads.events` and event types to `created`, `claimed`, `updated`, `closed`, `reopened`, and `status_changed`
- add TypeScript shape, golden/invalid fixtures, runtime validation, and `uuidV7TimestampMs`
- document that Beads owns lifecycle facts across Claude, Pi, and raw shells

## Ownership and migration
Core defines the shared projection contract but does not originate a second lifecycle record. Legacy hook/telemetry sources (`bd.claim`, `bd.close`, or `source=xtrm-hook`) do not validate as canonical source events. Consumers deduplicate on the Beads UUIDv7 `id`.

Beads 1.1.0 can serialize `created_at` as local wall time with a `Z` suffix. The contract therefore requires `occurred_at_ms`, derived from the UUIDv7 identity, for authoritative UTC ordering.

## Verification
- `npm test --workspace @xtrm/contracts` — 46 passing
- `npm run typecheck --workspace @xtrm/contracts`
- `npm run build --workspace @xtrm/contracts`
- pre-push Semgrep and OSV checks passed

Tracks xtrm-etmv4.2.1; leave open pending merge.
