### PR TITLE
fix(hooks): use Beads as sole lifecycle source

### DIFF
--- a/.xtrm/hooks/beads-claim-sync.mjs
+++ b/.xtrm/hooks/beads-claim-sync.mjs
@@ -7,7 +7,6 @@ import { spawnSync } from 'node:child_process';
 import { readFileSync, existsSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join, dirname, isAbsolute } from 'node:path';
 import { resolveSessionId } from './beads-gate-utils.mjs';
-import { logEvent } from './xtrm-logger.mjs';
 
 function readInput() {
   try {
@@ -96,16 +95,6 @@ function main() {
         writeFileSync(join(xtrmDir, resolveClaimFileName(cwd)), issueId);
       } catch { /* non-fatal */ }
 
-      logEvent({
-        cwd,
-        runtime: 'claude',
-        sessionId,
-        layer: 'bd',
-        kind: 'bd.claimed',
-        outcome: 'allow',
-        issueId,
-      });
-
       process.stdout.write(JSON.stringify({
         additionalContext: `\n✅ **Beads**: Session \`${sessionId}\` claimed issue \`${issueId}\`.`,
       }));
@@ -128,16 +117,6 @@ function main() {
         cwd,
         stdio: ['pipe', 'pipe', 'pipe'],
         timeout: 5000,
-      });
-
-      logEvent({
-        cwd,
-        runtime: 'claude',
-        sessionId,
-        layer: 'bd',
-        kind: 'bd.closed',
-        outcome: 'allow',
-        issueId: closedIssueId,
       });
     }
 

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -7,7 +7,7 @@
       "install_scope": "global",
       "files": {
         "beads-claim-sync.mjs": {
-          "hash": "a9663671113f8fd540e6588d6825963a0301679bac8a661c9cc35a2d6b474eed",
+          "hash": "14b3b19302b6764f7536e66967fd99cbc2f0824c41627c98ee2b8e47a8135d26",
           "version": "0.11.1"
         },
         "beads-commit-gate.mjs": {

--- a/cli/src/tests/beads-claim-sync.test.ts
+++ b/cli/src/tests/beads-claim-sync.test.ts
@@ -1,0 +1,62 @@
+import { access, chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const hookPath = new URL('../../../.xtrm/hooks/beads-claim-sync.mjs', import.meta.url);
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function runHook(command: string) {
+  const root = await mkdtemp(join(tmpdir(), 'beads-claim-sync-'));
+  tempDirs.push(root);
+  await mkdir(join(root, '.beads'));
+  const bin = join(root, 'bin');
+  await mkdir(bin);
+  const bd = join(bin, 'bd');
+  await writeFile(bd, '#!/bin/sh\nexit 0\n');
+  await chmod(bd, 0o755);
+
+  const input = JSON.stringify({
+    hook_event_name: 'PostToolUse',
+    tool_name: 'Bash',
+    cwd: root,
+    session_id: 'session-1',
+    tool_input: { command },
+    tool_response: { exit_code: 0 },
+  });
+  const result = spawnSync(process.execPath, [hookPath.pathname], {
+    input,
+    encoding: 'utf8',
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+  });
+
+  return { root, result };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('beads claim sync lifecycle ownership', () => {
+  it.each([
+    ['claim', 'bd update xtrm-1 --claim'],
+    ['close', 'bd close xtrm-1 --reason done'],
+  ])('keeps %s workflow behavior without emitting a competing lifecycle database', async (_name, command) => {
+    const { root, result } = await runHook(command);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('Beads');
+    expect(await exists(join(root, '.xtrm', 'debug.db'))).toBe(false);
+  });
+});

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -109,7 +109,20 @@ Runs via Claude Code's `statusLine` injection. Reads claim state from `.xtrm/sta
 | `beads-gate-core.mjs` | Core gate decision logic (commit gate, stop gate) |
 | `beads-gate-utils.mjs` | Claim resolution, work-state helpers |
 | `beads-gate-messages.mjs` | Shared message formatting for gate blocks; memory gate uses 4-criteria filter (hard to rediscover, non-obvious, future-relevant, still relevant in 14 days) |
-| `xtrm-logger.mjs` | Event logger for hooks/bd lifecycle — writes to `xtrm_events` table in beads Dolt DB |
+| `xtrm-logger.mjs` | Fail-open hook diagnostics logger — writes to `.xtrm/debug.db`; it is not a Beads lifecycle source |
+
+### Beads lifecycle ownership
+
+Beads owns lifecycle facts in its Dolt `events` table for Claude, Pi, and raw
+shell mutations. Canonical source actions are `created`, `claimed`, `updated`,
+`closed`, `reopened`, and `status_changed`; consumers may display these as
+`bd.<event_type>`. Core claim hooks only maintain session KV, statusline, and
+memory-gate state.
+
+Older Core hooks emitted `bd.claimed` / `bd.closed` diagnostics, while explicit
+xtmux telemetry used `bd.claim` / `bd.close`. These are compatibility records,
+not additional lifecycle facts. New consumers must source from Beads `events`
+and deduplicate by its event ID.
 
 ## Claim Workflow
 


### PR DESCRIPTION
## Summary
- retire Claude hook diagnostic rows `bd.claimed` / `bd.closed` as competing lifecycle facts
- preserve claim KV, statusline state, close memory-gate state, and user-facing hook context unchanged
- document Beads' Dolt `events` table as the sole lifecycle source across Claude, Pi, and raw shells
- regenerate the managed hook registry hash

## Runtime parity
Pi already maintained claim/close workflow state without writing a separate lifecycle database. Claude now follows the same ownership rule. Consumers source canonical `created`, `claimed`, `updated`, `closed`, `reopened`, and `status_changed` events from Beads and treat old hook/explicit telemetry rows as compatibility records only.

## Verification
- new subprocess tests prove Claude claim and close behavior succeeds without creating `.xtrm/debug.db`
- `npm test --workspace cli -- --run src/tests/beads-claim-sync.test.ts test/extensions/beads-claim-lifecycle.test.ts`
- `npm run typecheck --workspace cli`
- full CLI suite: 926 passed, 98 skipped; one unrelated duration threshold failed under concurrent load (`19082ms < 15000ms`), then `test/init-cli.test.ts` passed in isolation
- registry hash matches `beads-claim-sync.mjs`
- pre-push Semgrep and OSV checks passed

Tracks xtrm-etmv4.2.2; leave open pending merge.
