### PR TITLE
feat(contracts): publish xtrm.topology.projection.v1 aggregated projection schema (xtrm-d1fod.2)

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -39,6 +39,10 @@ Lineage/observability: `xtrm.runtime-origin.v1`, `xtrm.branch.integration.v1`,
 xtmux runtime: `xtrm.xtmux.topology.v1`, `xtrm.xtmux.message.v1`, `xtrm.xtmux.obligation.v1`,
 `xtrm.xtmux.monitor.v1`, `xtrm.xtmux.wait.v1`, `xtrm.xtmux.bridge.v1`, `xtrm.agent-role-launched.v1`.
 Legacy specialists: `xtrm.specialist-role-envelope.v1` (registry version `"1"`).
+Aggregation: `xtrm.topology.projection.v1` — the read-only join across xtmux, tmux,
+Specialists, Beads, git and GitHub emitted by `xt topology --json` (audit P2-05). It is a
+per-invocation snapshot, never a persisted graph, and it deliberately cannot carry pane
+capture: no content/preview/output field exists at any level.
 
 Each schema documents its authoritative source file in its `description`. The
 JSON Schema is the source of truth — the TS types mirror it and the fixture test

--- a/packages/contracts/fixtures/golden.json
+++ b/packages/contracts/fixtures/golden.json
@@ -241,5 +241,127 @@
             },
             "prompt": { "task_template": "Summarize the following text.\n\n$content", "output_schema": { "required": ["summary"] } }
         }
+    },
+    "xtrm.topology.projection.v1": {
+        "schema_version": "xtrm.topology.projection.v1",
+        "generated_at_ms": 1784656342032,
+        "host": { "host_id": "workstation", "tmux_server_id": "default" },
+        "sources": [
+            { "name": "xtmux", "status": "ok", "reason": null, "duration_ms": 41 },
+            { "name": "tmux", "status": "ok", "reason": null, "duration_ms": 12 },
+            { "name": "specialists", "status": "ok", "reason": null, "duration_ms": 88 },
+            { "name": "beads", "status": "ok", "reason": null, "duration_ms": 61 },
+            { "name": "git", "status": "ok", "reason": null, "duration_ms": 9 },
+            { "name": "github", "status": "unavailable", "reason": "gh not found on PATH", "duration_ms": 0 }
+        ],
+        "panes": [
+            {
+                "pane_id": "%1656",
+                "session_id": "$1495",
+                "session_name": "role-claude-chain-coordinator-xtrm-6hey0",
+                "window_id": "@88",
+                "current_command": "claude",
+                "current_path": "/repo/.xtrm/worktrees/coordinator-epic",
+                "agent": {
+                    "state": "idle",
+                    "role": "chain-coordinator",
+                    "task": "role:chain-coordinator",
+                    "bead_id": "xtrm-6hey0",
+                    "worktree": "/repo/.xtrm/worktrees/coordinator-epic",
+                    "branch": "xt/coordinator-epic",
+                    "parent_session_id": "$1"
+                },
+                "jobs": [
+                    {
+                        "job_id": "382786",
+                        "specialist": "executor",
+                        "status": "running",
+                        "bead_id": "xtrm-6hey0.1",
+                        "epic_id": "xtrm-6hey0",
+                        "chain_id": "382786",
+                        "chain_root_job_id": "382786",
+                        "is_chain_root": true,
+                        "branch": "sp/executor-382786",
+                        "worktree_path": "/repo/.worktrees/xtrm-6hey0.1/executor",
+                        "integration_target_branch": "xt/coordinator-epic",
+                        "started_at_ms": 1784211149565,
+                        "owning_pane_id": "%1656"
+                    }
+                ],
+                "bead": {
+                    "id": "xtrm-6hey0",
+                    "status": "in_progress",
+                    "title": "[epic] coordinator invariants",
+                    "issue_type": "epic",
+                    "priority": 1,
+                    "parent_id": null
+                },
+                "worktree": {
+                    "path": "/repo/.xtrm/worktrees/coordinator-epic",
+                    "branch": "xt/coordinator-epic",
+                    "head_sha": "15888bbf47122aea9b5732a487a075d18c041249",
+                    "detached": false,
+                    "shared_by_pane_ids": ["%1656"]
+                },
+                "pull_request": {
+                    "number": 466,
+                    "state": "MERGED",
+                    "url": "https://github.com/xtrm-dev/core/pull/466",
+                    "title": "feat(cli): coordinator launch validation",
+                    "head_branch": "xt/coordinator-epic",
+                    "base_branch": "main",
+                    "is_draft": false,
+                    "merged_at": "2026-07-21T17:04:11Z",
+                    "checks_state": "SUCCESS"
+                }
+            },
+            {
+                "pane_id": "%2",
+                "session_id": "$1",
+                "session_name": "orch",
+                "window_id": null,
+                "current_command": "zsh",
+                "current_path": "/repo",
+                "agent": null,
+                "jobs": [],
+                "bead": null,
+                "worktree": {
+                    "path": "/repo",
+                    "branch": "main",
+                    "head_sha": "15888bbf47122aea9b5732a487a075d18c041249",
+                    "detached": false,
+                    "shared_by_pane_ids": ["%2"]
+                },
+                "pull_request": null
+            }
+        ],
+        "orphans": {
+            "jobs": [
+                {
+                    "job_id": "371002",
+                    "specialist": "reviewer",
+                    "status": "error",
+                    "bead_id": "xtrm-h42ka.3",
+                    "epic_id": "xtrm-h42ka",
+                    "chain_id": "371002",
+                    "chain_root_job_id": "371002",
+                    "is_chain_root": true,
+                    "branch": "feature/xtrm-h42ka.3-reviewer",
+                    "worktree_path": "/repo/.worktrees/xtrm-h42ka.3/reviewer",
+                    "integration_target_branch": null,
+                    "started_at_ms": 1784211149565,
+                    "owning_pane_id": null
+                }
+            ],
+            "worktrees": [
+                {
+                    "path": "/repo/.xtrm/worktrees/core-postmerge-425",
+                    "branch": null,
+                    "head_sha": "5a8326d16625f291ee778175c8b2db39271bf20a",
+                    "detached": true,
+                    "shared_by_pane_ids": []
+                }
+            ]
+        }
     }
 }

--- a/packages/contracts/fixtures/invalid.json
+++ b/packages/contracts/fixtures/invalid.json
@@ -131,5 +131,13 @@
             "execution": { "model": null },
             "prompt": {}
         }
+    },
+    "xtrm.topology.projection.v1": {
+        "schema_version": "xtrm.topology.projection.v1",
+        "generated_at_ms": 1784656342032,
+        "host": { "host_id": "workstation" },
+        "sources": [{ "name": "xtmux", "status": "degraded", "reason": null, "duration_ms": 41 }],
+        "panes": [],
+        "orphans": { "jobs": [], "worktrees": [] }
     }
 }

--- a/packages/contracts/schemas/xtrm.topology.projection.v1.json
+++ b/packages/contracts/schemas/xtrm.topology.projection.v1.json
@@ -1,0 +1,193 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "xtrm.topology.projection.v1",
+    "title": "xtrm aggregated topology projection",
+    "description": "Read-only aggregated projection produced by Core (`xt topology --json`, audit ~/dev/11.md P2-05). Joins tmux pane -> interactive runtime -> role -> coordinator -> specialist jobs -> bead -> worktree -> branch -> integration target -> pull request, reading each fact live from its owning system's published CLI surface at invocation time. NOT a persisted graph: nothing here is cached, materialized, or written back, and no field is authoritative over its source. snake_case, matching the xtrm.xtmux.topology.v1 cross-repo convention. Deliberately incapable of carrying terminal content: no pane-capture, preview, output or free-text-status field exists at any level, so the audit's 'pane capture is diagnostic and must never be journalled or persisted' rule is enforced by the type system rather than by discipline.",
+    "type": "object",
+    "required": ["schema_version", "generated_at_ms", "host", "sources", "panes", "orphans"],
+    "additionalProperties": false,
+    "properties": {
+        "schema_version": { "const": "xtrm.topology.projection.v1" },
+        "generated_at_ms": { "type": "number", "minimum": 0 },
+        "host": {
+            "type": "object",
+            "required": ["host_id"],
+            "additionalProperties": false,
+            "properties": {
+                "host_id": { "type": "string", "minLength": 1 },
+                "tmux_server_id": { "type": ["string", "null"] }
+            }
+        },
+        "sources": {
+            "description": "Per-source outcome ledger. The projection's own observability surface, and the ONLY way a consumer can distinguish a degraded projection from an empty world: an absent `sp` and zero running jobs both yield an empty jobs array, and only this ledger separates them.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["name", "status", "reason", "duration_ms"],
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "description": "Owning system queried. Each maps to one published read-only CLI surface.",
+                        "enum": ["xtmux", "tmux", "specialists", "beads", "git", "github"]
+                    },
+                    "status": {
+                        "description": "ok = queried and parsed. unavailable = the binary is not installed or not applicable on this host (not a bug). error = installed but the query failed, timed out, or returned unparseable output (a bug signal).",
+                        "enum": ["ok", "unavailable", "error"]
+                    },
+                    "reason": {
+                        "description": "Human-readable cause for unavailable/error, null when ok. Never contains command output, secrets, or tokens.",
+                        "type": ["string", "null"]
+                    },
+                    "duration_ms": { "type": "number", "minimum": 0 }
+                }
+            }
+        },
+        "panes": {
+            "description": "The join spine. One entry per live tmux pane, carrying everything the other five systems know about it.",
+            "type": "array",
+            "items": { "$ref": "#/definitions/pane" }
+        },
+        "orphans": {
+            "description": "Facts that belong to no live pane. Without this a specialist job whose coordinator pane died, or a worktree whose session was killed, silently vanishes from the projection — which is exactly the leak an operator needs to see.",
+            "type": "object",
+            "required": ["jobs", "worktrees"],
+            "additionalProperties": false,
+            "properties": {
+                "jobs": { "type": "array", "items": { "$ref": "#/definitions/job" } },
+                "worktrees": { "type": "array", "items": { "$ref": "#/definitions/worktree" } }
+            }
+        }
+    },
+    "definitions": {
+        "pane": {
+            "type": "object",
+            "required": [
+                "pane_id", "session_id", "session_name", "current_command", "current_path",
+                "agent", "jobs", "bead", "worktree", "pull_request"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "pane_id": { "type": "string", "minLength": 1 },
+                "session_id": { "type": "string", "minLength": 1 },
+                "session_name": { "type": "string" },
+                "window_id": { "type": ["string", "null"] },
+                "current_command": { "type": "string" },
+                "current_path": { "type": "string" },
+                "agent": {
+                    "description": "Lineage published by Core's launcher as @agent_* pane options (PR #465). Null for a pane that is not an xtrm-launched agent — a plain shell, an editor, the operator's own terminal.",
+                    "oneOf": [
+                        { "type": "null" },
+                        {
+                            "type": "object",
+                            "required": ["state", "role", "task", "bead_id", "worktree", "branch", "parent_session_id"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "state": {
+                                    "description": "@agent_state. A lifecycle signal owned by the runtime's own hook — NOT a completion signal. Completion is read from bead.status, pull_request.merged_at or job.status only.",
+                                    "type": ["string", "null"]
+                                },
+                                "role": {
+                                    "description": "@agent_role (P2-03). Plain role identity; `task` still carries the legacy `role:<name>` encoding and is preserved, not replaced.",
+                                    "type": ["string", "null"]
+                                },
+                                "task": { "type": ["string", "null"] },
+                                "bead_id": { "type": ["string", "null"] },
+                                "worktree": { "type": ["string", "null"] },
+                                "branch": {
+                                    "description": "@agent_branch. For a coordinator pane this doubles as the integration target its specialist chains derive from (audit P1-03).",
+                                    "type": ["string", "null"]
+                                },
+                                "parent_session_id": { "type": ["string", "null"] },
+                                "parent_pane_id": { "type": ["string", "null"] },
+                                "instance_id": { "type": ["string", "null"] }
+                            }
+                        }
+                    ]
+                },
+                "jobs": {
+                    "description": "Specialist jobs attributed to this pane, by bead/epic/worktree match. Chain roots and descendants alike; use is_chain_root and chain_root_job_id to rebuild the lineage tree.",
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/job" }
+                },
+                "bead": { "oneOf": [{ "type": "null" }, { "$ref": "#/definitions/bead" }] },
+                "worktree": { "oneOf": [{ "type": "null" }, { "$ref": "#/definitions/worktree" }] },
+                "pull_request": { "oneOf": [{ "type": "null" }, { "$ref": "#/definitions/pull_request" }] }
+            }
+        },
+        "job": {
+            "description": "One specialist job as published by `sp ps --json`. Mirrors Specialists' field names; Core does not reinterpret them.",
+            "type": "object",
+            "required": ["job_id", "specialist", "status", "bead_id", "branch", "worktree_path", "is_chain_root"],
+            "additionalProperties": false,
+            "properties": {
+                "job_id": { "type": "string", "minLength": 1 },
+                "specialist": { "type": "string" },
+                "status": {
+                    "description": "Specialists-owned job status verbatim. Enumerating it here would fossilize another repo's vocabulary, so it stays an open string.",
+                    "type": "string"
+                },
+                "bead_id": { "type": ["string", "null"] },
+                "epic_id": { "type": ["string", "null"] },
+                "chain_id": { "type": ["string", "null"] },
+                "chain_root_job_id": { "type": ["string", "null"] },
+                "is_chain_root": { "type": "boolean" },
+                "branch": { "type": ["string", "null"] },
+                "worktree_path": { "type": ["string", "null"] },
+                "integration_target_branch": {
+                    "description": "The @agent_branch of the coordinator pane this job is attributed to — the branch its work is destined to integrate into. Null when the job has no live owning pane.",
+                    "type": ["string", "null"]
+                },
+                "started_at_ms": { "type": ["number", "null"] },
+                "owning_pane_id": { "type": ["string", "null"] }
+            }
+        },
+        "bead": {
+            "description": "Beads state as published by `bd`. status is one of the two authoritative completion signals in this projection (the other is pull_request.merged_at).",
+            "type": "object",
+            "required": ["id", "status"],
+            "additionalProperties": false,
+            "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "status": { "type": "string" },
+                "title": { "type": ["string", "null"] },
+                "issue_type": { "type": ["string", "null"] },
+                "priority": { "type": ["number", "null"] },
+                "parent_id": { "type": ["string", "null"] }
+            }
+        },
+        "worktree": {
+            "description": "git worktree metadata from `git worktree list --porcelain`.",
+            "type": "object",
+            "required": ["path", "branch", "head_sha", "detached"],
+            "additionalProperties": false,
+            "properties": {
+                "path": { "type": "string", "minLength": 1 },
+                "branch": { "type": ["string", "null"] },
+                "head_sha": { "type": ["string", "null"] },
+                "detached": { "type": "boolean" },
+                "shared_by_pane_ids": {
+                    "description": "Every live pane whose cwd resolves into this worktree. Length > 1 is the worktree-collision warning the multiplexing doctrine calls out.",
+                    "type": "array",
+                    "items": { "type": "string" }
+                }
+            }
+        },
+        "pull_request": {
+            "description": "GitHub PR evidence for a branch, from `gh pr list --json`. merged_at is an authoritative completion signal; nothing else in this projection may be read as one.",
+            "type": "object",
+            "required": ["number", "state", "head_branch"],
+            "additionalProperties": false,
+            "properties": {
+                "number": { "type": "number" },
+                "state": { "type": "string" },
+                "url": { "type": ["string", "null"] },
+                "title": { "type": ["string", "null"] },
+                "head_branch": { "type": "string", "minLength": 1 },
+                "base_branch": { "type": ["string", "null"] },
+                "is_draft": { "type": ["boolean", "null"] },
+                "merged_at": { "type": ["string", "null"] },
+                "checks_state": { "type": ["string", "null"] }
+            }
+        }
+    }
+}

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -21,6 +21,7 @@ export const SCHEMA_ID = {
     xtmuxBridge: 'xtrm.xtmux.bridge.v1',
     agentRoleLaunched: 'xtrm.agent-role-launched.v1',
     specialistRoleEnvelope: 'xtrm.specialist-role-envelope.v1',
+    topologyProjection: 'xtrm.topology.projection.v1',
 } as const;
 
 export type SchemaId = (typeof SCHEMA_ID)[keyof typeof SCHEMA_ID];
@@ -331,6 +332,112 @@ export interface SpecialistRoleEnvelopeV1 {
 }
 
 /** Map from schema id to its TypeScript payload type. */
+// --- xtrm.topology.projection.v1 ---
+/**
+ * Owning system behind one projection source. Each maps to one published
+ * read-only CLI surface; Core never reads another repo's database directly.
+ */
+export type TopologySourceName = 'xtmux' | 'tmux' | 'specialists' | 'beads' | 'git' | 'github';
+/**
+ * `unavailable` (binary absent) vs `error` (present but failed) is a load-bearing
+ * distinction: only the latter is a bug signal.
+ */
+export type TopologySourceStatus = 'ok' | 'unavailable' | 'error';
+export interface TopologySource {
+    name: TopologySourceName;
+    status: TopologySourceStatus;
+    reason: string | null;
+    duration_ms: number;
+}
+/** Lineage published by Core's launcher as `@agent_*` pane options (PR #465). */
+export interface TopologyPaneAgent {
+    /** Runtime lifecycle signal — never a completion signal. */
+    state: string | null;
+    /** `@agent_role` (audit P2-03); `task` keeps the legacy `role:<name>` encoding. */
+    role: string | null;
+    task: string | null;
+    bead_id: string | null;
+    worktree: string | null;
+    /** For a coordinator pane, also the integration target its chains derive from. */
+    branch: string | null;
+    parent_session_id: string | null;
+    parent_pane_id?: string | null;
+    instance_id?: string | null;
+}
+export interface TopologyJob {
+    job_id: string;
+    specialist: string;
+    /** Specialists-owned vocabulary, passed through unreinterpreted. */
+    status: string;
+    bead_id: string | null;
+    epic_id?: string | null;
+    chain_id?: string | null;
+    chain_root_job_id?: string | null;
+    is_chain_root: boolean;
+    branch: string | null;
+    worktree_path: string | null;
+    integration_target_branch?: string | null;
+    started_at_ms?: number | null;
+    owning_pane_id?: string | null;
+}
+export interface TopologyBead {
+    id: string;
+    /** One of the two authoritative completion signals (with `merged_at`). */
+    status: string;
+    title?: string | null;
+    issue_type?: string | null;
+    priority?: number | null;
+    parent_id?: string | null;
+}
+export interface TopologyWorktree {
+    path: string;
+    branch: string | null;
+    head_sha: string | null;
+    detached: boolean;
+    /** Length > 1 is a worktree collision. */
+    shared_by_pane_ids?: string[];
+}
+export interface TopologyPullRequest {
+    number: number;
+    state: string;
+    url?: string | null;
+    title?: string | null;
+    head_branch: string;
+    base_branch?: string | null;
+    is_draft?: boolean | null;
+    /** Authoritative completion signal. */
+    merged_at?: string | null;
+    checks_state?: string | null;
+}
+export interface TopologyPane {
+    pane_id: string;
+    session_id: string;
+    session_name: string;
+    window_id?: string | null;
+    current_command: string;
+    current_path: string;
+    /** Null for a pane that is not an xtrm-launched agent. */
+    agent: TopologyPaneAgent | null;
+    jobs: TopologyJob[];
+    bead: TopologyBead | null;
+    worktree: TopologyWorktree | null;
+    pull_request: TopologyPullRequest | null;
+}
+/**
+ * A read-only snapshot, recomputed per invocation from live sources. Nothing here
+ * is cached, materialized or written back, and no field is authoritative over its
+ * source. There is deliberately no pane-capture/preview/output field at any level.
+ */
+export interface TopologyProjectionV1 {
+    schema_version: 'xtrm.topology.projection.v1';
+    generated_at_ms: number;
+    host: { host_id: string; tmux_server_id?: string | null };
+    sources: TopologySource[];
+    panes: TopologyPane[];
+    /** Facts belonging to no live pane — the leak an operator needs to see. */
+    orphans: { jobs: TopologyJob[]; worktrees: TopologyWorktree[] };
+}
+
 export interface ContractTypeMap {
     'xtrm.runtime-compatibility.v1': RuntimeCompatibilityV1;
     'xtrm.interactive-role-envelope.v1': InteractiveRoleEnvelopeV1;
@@ -348,4 +455,5 @@ export interface ContractTypeMap {
     'xtrm.xtmux.bridge.v1': XtmuxBridgeV1;
     'xtrm.agent-role-launched.v1': AgentRoleLaunchedV1;
     'xtrm.specialist-role-envelope.v1': SpecialistRoleEnvelopeV1;
+    'xtrm.topology.projection.v1': TopologyProjectionV1;
 }

--- a/packages/contracts/test/contracts.test.ts
+++ b/packages/contracts/test/contracts.test.ts
@@ -77,6 +77,80 @@ describe('Beads lifecycle event contract', () => {
     });
 });
 
+describe('aggregated topology projection contract', () => {
+    const id = SCHEMA_ID.topologyProjection;
+    const base = () => structuredClone(golden[id]) as Record<string, any>;
+
+    it('rejects an unknown top-level property', () => {
+        expect(validate(id, { ...base(), cached_at_ms: 1 }).valid).toBe(false);
+    });
+
+    it.each(['schema_version', 'generated_at_ms', 'host', 'sources', 'panes', 'orphans'])(
+        'rejects a payload missing %s',
+        (key) => {
+            const payload = base();
+            delete payload[key];
+            expect(validate(id, payload).valid).toBe(false);
+        },
+    );
+
+    // The audit's hardest P2-06 rule: pane capture is diagnostic, and must never be
+    // journalled or persisted. Enforcing it by `additionalProperties: false` means a
+    // producer CANNOT smuggle terminal text through this contract even by accident —
+    // the guarantee survives a careless future edit, which a code comment would not.
+    it.each(['content', 'capture', 'preview', 'output', 'terminal_text'])(
+        'refuses to carry pane content in a %s field',
+        (field) => {
+            const payload = base();
+            payload.panes[0][field] = 'some captured terminal text';
+            expect(validate(id, payload).valid).toBe(false);
+        },
+    );
+
+    it('refuses pane content nested under the agent block', () => {
+        const payload = base();
+        payload.panes[0].agent.capture = 'terminal text';
+        expect(validate(id, payload).valid).toBe(false);
+    });
+
+    it('accepts a fully degraded projection (every source down, no panes)', () => {
+        const names = ['xtmux', 'tmux', 'specialists', 'beads', 'git', 'github'];
+        expect(
+            validate(id, {
+                schema_version: id,
+                generated_at_ms: 1,
+                host: { host_id: 'h' },
+                sources: names.map((name) => ({
+                    name,
+                    status: 'unavailable',
+                    reason: `${name} not found on PATH`,
+                    duration_ms: 0,
+                })),
+                panes: [],
+                orphans: { jobs: [], worktrees: [] },
+            }).valid,
+        ).toBe(true);
+    });
+
+    it('requires a reason slot on every source entry so ok/unavailable stay distinguishable', () => {
+        const payload = base();
+        delete payload.sources[0].reason;
+        expect(validate(id, payload).valid).toBe(false);
+    });
+
+    it('rejects an unknown source name rather than silently accepting a typo', () => {
+        const payload = base();
+        payload.sources[0].name = 'xtmuxx';
+        expect(validate(id, payload).valid).toBe(false);
+    });
+
+    it('accepts a pane with no agent lineage (a plain shell)', () => {
+        const payload = base();
+        expect(validate(id, payload).valid).toBe(true);
+        expect(payload.panes[1].agent).toBeNull();
+    });
+});
+
 describe('validator behavior', () => {
     it('rejects a fabricated invalid pi-extension manifest (audit acceptance criterion)', () => {
         const fabricated = {


### PR DESCRIPTION
First of three sequential PRs for **audit sprint wave 5 cluster D — aggregation surface** (epic `xtrm-d1fod`, audit `~/dev/11.md` P2-03/P2-05/P2-06). Contracts-only, based on `main`, per the wave-5 rule that schema changes land as their own PR before any consumer exists.

## Why

P2-05 asks for a read-only projection joining `tmux pane → runtime → role → coordinator → specialist jobs → bead → worktree → branch → integration target → pull request`. Each *piece* already has a contract — `xtrm.xtmux.topology.v1`, `xtrm.branch.integration.v1`, `xtrm.runtime-origin.v1` — but the **join** does not. Without a published shape the producer has nothing to validate against and Console (`forge-df3a`) has nothing to depend on.

## Two design points that carry the audit's non-goals into the type system

**`sources[]` — the degradation ledger.** Per-source `ok` / `unavailable` / `error` + `reason` + `duration_ms`. This is the only way a consumer can distinguish a degraded projection from an empty world: an absent `sp` and zero running jobs both produce an empty jobs array. `unavailable` (binary not installed — not a bug) is deliberately distinct from `error` (installed but failed — a bug signal).

**No pane capture is representable.** There is no `content` / `preview` / `output` / `capture` field at any level, and every object is `additionalProperties: false`. A producer therefore *cannot* smuggle terminal text through this contract even by accident. That is the audit's "pane capture is diagnostic and must not be copied into the durable event journal" rule enforced structurally rather than by convention — it survives a careless future edit in a way a code comment would not. Six test cases assert it.

`orphans{jobs, worktrees}` keeps a job whose coordinator pane died — or a worktree whose session was killed — from silently vanishing from the snapshot. That leak is precisely what an operator needs to see.

Join slots (`agent` / `bead` / `worktree` / `pull_request`) are **required and nullable** rather than optional, so consumers are total: "we looked and found none" is an explicit `null`, and "we did not look" is readable from `sources[]`.

`job.status` is an open string on purpose — enumerating it would fossilize Specialists' private vocabulary inside a Core contract.

## No `validate.ts` change

`loadSchemas()` (`validate.ts:12-16`) discovers schemas by directory scan, so a new schema file self-registers. Only the TS-side `SCHEMA_ID` / `ContractTypeMap` needed touching — and `contracts.test.ts:19-21` already asserts those two sets match exactly, so a schema added without its TS constant fails the suite loudly.

## Validation

| Check | Result |
|---|---|
| `npm run test:contracts` | **65/65 passed** (was 53; +12 new) |
| `npm run build:contracts` | clean (CJS + ESM + DTS) |
| `npm run typecheck -w @xtrm/contracts` | clean |
| `npm run check:runtime-compat` | ok |
| `npm run check:payload-hygiene` | ok — 446 packed files |
| `gitnexus_detect_changes` | 0 changed symbols, risk **low** (purely additive) |

## Scope

Contracts only. No `cli/` change — the producer (`xt topology --json`, `xtrm-d1fod.3`) and the viewer (`xtrm-d1fod.4`) land as PRs 2 and 3, sequentially, after this merges. Not stacked: this repo's CI only fires on PRs targeting `main`.

Closes `xtrm-d1fod.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)