### PR TITLE
chore(policies): strip dead mcp__serena__* alternations from hook matchers (xtrm-wwa37)

### DIFF
--- a/.xtrm/config/hooks.json
+++ b/.xtrm/config/hooks.json
@@ -67,7 +67,7 @@
         ]
       },
       {
-        "matcher": "Read|Write|Edit|Glob|Grep|Bash|mcp__serena__rename_symbol|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol",
+        "matcher": "Read|Write|Edit|Glob|Grep|Bash",
         "hooks": [
           {
             "type": "command",
@@ -103,7 +103,7 @@
         ]
       },
       {
-        "matcher": "Bash|Grep|Read|Glob|mcp__serena__find_symbol|mcp__serena__get_symbols_overview|mcp__serena__search_for_pattern|mcp__serena__find_referencing_symbols|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol|mcp__serena__rename_symbol",
+        "matcher": "Bash|Grep|Read|Glob",
         "hooks": [
           {
             "type": "command",
@@ -113,7 +113,7 @@
         ]
       },
       {
-        "matcher": "Write|Edit|mcp__serena__rename_symbol|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol",
+        "matcher": "Write|Edit",
         "hooks": [
           {
             "type": "command",

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -1432,7 +1432,7 @@
           "version": "0.11.1"
         },
         "hooks.json": {
-          "hash": "50217409cab7bd410e1ad7add30ce799656a64fae9ba84d9a0807c1cdcbc2bda",
+          "hash": "8ee88ac6474d738b54ea4890fef73001aa6a5a342786528842034bc9a3e9574f",
           "version": "0.11.1"
         },
         "instructions/agents-top.md": {

--- a/policies/gitnexus.json
+++ b/policies/gitnexus.json
@@ -8,7 +8,7 @@
     "hooks": [
       {
         "event": "PostToolUse",
-        "matcher": "Bash|Grep|Read|Glob|mcp__serena__find_symbol|mcp__serena__get_symbols_overview|mcp__serena__search_for_pattern|mcp__serena__find_referencing_symbols|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol|mcp__serena__rename_symbol",
+        "matcher": "Bash|Grep|Read|Glob",
         "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/gitnexus/gitnexus-hook.cjs",
         "timeout": 10000
       }

--- a/policies/service-skills-claude.json
+++ b/policies/service-skills-claude.json
@@ -12,12 +12,12 @@
       },
       {
         "event": "PreToolUse",
-        "matcher": "Read|Write|Edit|Glob|Grep|Bash|mcp__serena__rename_symbol|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol",
+        "matcher": "Read|Write|Edit|Glob|Grep|Bash",
         "command": "sh -c 'p=\"$HOME/.xtrm/skills/default/service-skills/scripts/skill_activator.py\"; [ -f \"$p\" ] && python3 \"$p\"; exit 0'"
       },
       {
         "event": "PostToolUse",
-        "matcher": "Write|Edit|mcp__serena__rename_symbol|mcp__serena__replace_symbol_body|mcp__serena__insert_after_symbol|mcp__serena__insert_before_symbol",
+        "matcher": "Write|Edit",
         "command": "sh -c 'p=\"$HOME/.xtrm/skills/default/service-skills/scripts/drift_detector.py\"; [ -f \"$p\" ] && python3 \"$p\" check-hook; exit 0'",
         "timeout": 10000
       }


### PR DESCRIPTION
Closes xtrm-wwa37.

Serena was disabled globally on 2026-07-21 (`enabledPlugins["serena@claude-plugins-official"]=false`), so every `mcp__serena__*` alternation inside a hook `matcher` is a regex branch that can never match. This strips them.

| file | matcher after |
|---|---|
| `policies/gitnexus.json` | `Bash\|Grep\|Read\|Glob` |
| `policies/service-skills-claude.json` | `Read\|Write\|Edit\|Glob\|Grep\|Bash` |
| `policies/service-skills-claude.json` | `Write\|Edit` |

Cleanup only — no non-serena tool removed, no matcher shape change, no tool-coverage policy change. No matcher collapsed to a single tool, so the "keep single-tool alternations" constraint never triggered.

**Validation**
- [x] `grep -R 'mcp__serena__' policies/` → nothing
- [x] `npm run compile-policies` clean; `.xtrm/config/hooks.json` diff is exactly the three matcher lines
- [x] idempotent — re-running `compile-policies` produces no further change
- [x] `npm run gen-registry` (hashes refreshed), `check:registry-pack-parity` 362/362, `check:payload-hygiene` 446 files — green

**Post-merge smoke (operator):** `cd ~/dev/xtmux && xt update --apply` → `.claude/settings.json` diff should be only the matcher strips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)