### PR TITLE
fix(scripts): stop pre-push semgrep detaching the invoking worktree (xtrm-bjbdf)

### DIFF
--- a/scripts/__tests__/semgrep-diff-hook-env.test.mjs
+++ b/scripts/__tests__/semgrep-diff-hook-env.test.mjs
@@ -1,0 +1,158 @@
+// Regression tests for xtrm-bjbdf: pre-push semgrep must never move the
+// invoking worktree's HEAD.
+//
+// Root cause: git exports GIT_DIR into the hook environment. semgrep's
+// --baseline-commit materializes the baseline in a throwaway `git worktree` and
+// runs `git checkout <base>` inside it; with GIT_DIR inherited that checkout
+// retargets the INVOKING worktree, detaching HEAD at the baseline and unwinding
+// the commit being pushed into unstaged changes.
+//
+// semgrep itself is stubbed so these tests are hermetic and offline. The stub is
+// proven faithful by `stub reproduces the failure`, which runs it with GIT_DIR
+// set and asserts the exact damage from the bug report.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const SCRIPT = new URL("../semgrep-diff.sh", import.meta.url).pathname;
+
+// Emulates semgrep's baseline handling: temp `git worktree add --no-checkout`,
+// `git checkout <base>` from inside it, then `git worktree remove` + rmtree.
+// Every git call inherits the caller's environment, as semgrep's do.
+const FAITHFUL_STUB = `#!/usr/bin/env bash
+base=""
+for a in "$@"; do case "$a" in --baseline-commit=*) base="\${a#*=}";; esac; done
+[ -n "$base" ] || exit 0
+here=$(pwd)
+tmp=$(mktemp -d)
+git worktree add --no-checkout "$tmp" "$base" >/dev/null 2>&1
+cd "$tmp" && git checkout "$base" >/dev/null 2>&1
+cd "$here"
+git worktree remove "$tmp" >/dev/null 2>&1 || true
+rm -rf "$tmp"
+exit 0
+`;
+
+// Moves HEAD the way the bug does — detached at the baseline with the index
+// following, working tree left alone — but unconditionally, ignoring the
+// environment. Stands in for any future scanner variant that damages HEAD
+// some other way, and exercises the guard rather than the env strip.
+const HOSTILE_STUB = `#!/usr/bin/env bash
+base=""
+for a in "$@"; do case "$a" in --baseline-commit=*) base="\${a#*=}";; esac; done
+[ -n "$base" ] || exit 0
+git update-ref --no-deref HEAD "$base"
+git read-tree "$base"
+exit 0
+`;
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" },
+  }).trim();
+}
+
+/** Repo shaped like an xt session: linked worktree, a commit to push, untracked files. */
+function makeFixture(stub) {
+  const root = mkdtempSync(join(tmpdir(), "semgrep-diff-"));
+  const main = join(root, "main-repo");
+  const wt = join(root, "wt");
+  const bin = join(root, "bin");
+
+  mkdirSync(main);
+  git(main, "init", "-q", "-b", "main");
+  git(main, "config", "user.email", "t@t.t");
+  git(main, "config", "user.name", "t");
+  writeFileSync(join(main, "a.py"), "print('a')\n");
+  git(main, "add", "-A");
+  git(main, "commit", "-qm", "base");
+  git(main, "worktree", "add", "-q", wt, "-b", "feat");
+
+  // The commit being pushed must MODIFY a tracked file: semgrep only
+  // materializes the baseline when a changed file has a baseline version.
+  writeFileSync(join(wt, "a.py"), "print('a')\nprint('modified')\n");
+  git(wt, "add", "-A");
+  git(wt, "commit", "-qm", "feat");
+
+  // The untracked file this repo always carries (.specialists/user/*). It makes
+  // semgrep pick the worktree strategy over its `git reset --hard` fast path.
+  mkdirSync(join(wt, ".specialists", "user"), { recursive: true });
+  writeFileSync(join(wt, ".specialists", "user", "x.specialist.json"), "{}\n");
+
+  mkdirSync(bin);
+  writeFileSync(join(bin, "semgrep"), stub, { mode: 0o755 });
+
+  return { root, wt, bin, head: git(wt, "rev-parse", "HEAD") };
+}
+
+/** Runs a command in the worktree with the git env a pre-push hook inherits. */
+function runInHookEnv(fx, file, args) {
+  const res = execFileSync(file, args, {
+    cwd: fx.wt,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${fx.bin}:${process.env.PATH}`,
+      GIT_DIR: git(fx.wt, "rev-parse", "--absolute-git-dir"),
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+    },
+    stdio: "pipe",
+  });
+  return res;
+}
+
+test("stub reproduces the failure: bare semgrep + inherited GIT_DIR detaches the worktree", () => {
+  const fx = makeFixture(FAITHFUL_STUB);
+  try {
+    const base = git(fx.wt, "merge-base", "HEAD", "main");
+    runInHookEnv(fx, join(fx.bin, "semgrep"), ["scan", `--baseline-commit=${base}`]);
+
+    assert.equal(git(fx.wt, "rev-parse", "--abbrev-ref", "HEAD"), "HEAD", "expected detached HEAD");
+    assert.equal(git(fx.wt, "rev-parse", "HEAD"), base, "expected HEAD at the baseline commit");
+    assert.match(git(fx.wt, "status", "--short"), /^ ?M a\.py$/m, "expected the commit unwound");
+    assert.match(git(fx.wt, "worktree", "list"), /prunable/, "expected a leaked temp worktree");
+  } finally {
+    rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test("semgrep-diff.sh strips the inherited git env, so the worktree survives", () => {
+  const fx = makeFixture(FAITHFUL_STUB);
+  try {
+    runInHookEnv(fx, SCRIPT, []);
+
+    assert.equal(git(fx.wt, "rev-parse", "--abbrev-ref", "HEAD"), "feat");
+    assert.equal(git(fx.wt, "rev-parse", "HEAD"), fx.head);
+    assert.equal(git(fx.wt, "status", "--short"), "?? .specialists/");
+    assert.doesNotMatch(git(fx.wt, "worktree", "list"), /prunable/);
+  } finally {
+    rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test("semgrep-diff.sh restores HEAD and aborts when the scanner moves it anyway", () => {
+  const fx = makeFixture(HOSTILE_STUB);
+  try {
+    assert.throws(
+      () => runInHookEnv(fx, SCRIPT, []),
+      (err) => {
+        assert.equal(err.status, 1, "expected the push to be aborted");
+        assert.match(err.stderr, /moved HEAD/);
+        return true;
+      },
+    );
+
+    assert.equal(git(fx.wt, "rev-parse", "--abbrev-ref", "HEAD"), "feat");
+    assert.equal(git(fx.wt, "rev-parse", "HEAD"), fx.head);
+    assert.equal(git(fx.wt, "status", "--short"), "?? .specialists/");
+  } finally {
+    rmSync(fx.root, { recursive: true, force: true });
+  }
+});

--- a/scripts/semgrep-diff.sh
+++ b/scripts/semgrep-diff.sh
@@ -10,6 +10,20 @@ if ! command -v semgrep >/dev/null; then
     exit 0
 fi
 
+# Git exports GIT_DIR (and friends) into the hook environment. semgrep's
+# --baseline-commit materializes the baseline in a throwaway `git worktree` and
+# runs `git checkout` inside it — with GIT_DIR inherited, that checkout retargets
+# the INVOKING worktree instead: HEAD detaches at the baseline and the commit
+# being pushed unwinds into unstaged changes (xtrm-bjbdf). Drop the inherited
+# vars so every git call resolves the repo from cwd. No-op when unset, and
+# skipped if the repo isn't discoverable without them.
+GIT_HOOK_ENV="GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX GIT_QUARANTINE_PATH"
+# shellcheck disable=SC2086
+if (unset $GIT_HOOK_ENV; git rev-parse --show-toplevel >/dev/null 2>&1); then
+    # shellcheck disable=SC2086
+    unset $GIT_HOOK_ENV
+fi
+
 # Derive base ref dynamically. Order:
 #   1. branch's tracked upstream ('@{u}') — most reliable
 #   2. common default branches if their *remote* version exists (origin/*)
@@ -19,6 +33,7 @@ fi
 # nothing on every push.
 HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 HEAD_SHA=$(git rev-parse HEAD)
+HEAD_REF=$(git symbolic-ref --quiet HEAD 2>/dev/null || true)
 
 upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)
 BASE_REF=""
@@ -55,7 +70,8 @@ if [ ${#SEMGREP_BASELINE_ARGS[@]} -eq 0 ]; then
     fi
 fi
 
-exec semgrep scan \
+rc=0
+semgrep scan \
     --config=p/default \
     --config=p/security-audit \
     --config=p/secrets \
@@ -65,4 +81,24 @@ exec semgrep scan \
     "${SEMGREP_BASELINE_ARGS[@]}" \
     --error \
     --quiet \
-    --skip-unknown-extensions
+    --skip-unknown-extensions || rc=$?
+
+# A scan must never move the invoking worktree's HEAD. If it does anyway,
+# reattach non-destructively (working tree is left alone, so genuine unstaged
+# edits survive) and fail loudly instead of leaving a silently detached worktree.
+HEAD_REF_AFTER=$(git symbolic-ref --quiet HEAD 2>/dev/null || true)
+HEAD_SHA_AFTER=$(git rev-parse HEAD)
+if [ "$HEAD_REF_AFTER" != "$HEAD_REF" ] || [ "$HEAD_SHA_AFTER" != "$HEAD_SHA" ]; then
+    echo "[semgrep-diff] semgrep moved HEAD (${HEAD_REF:-detached}@${HEAD_SHA} -> ${HEAD_REF_AFTER:-detached}@${HEAD_SHA_AFTER}) — restoring" >&2
+    if [ -n "$HEAD_REF" ]; then
+        git symbolic-ref HEAD "$HEAD_REF"
+    else
+        git update-ref --no-deref HEAD "$HEAD_SHA"
+    fi
+    git reset --quiet --mixed
+    git worktree prune >/dev/null 2>&1 || true
+    echo "[semgrep-diff] HEAD restored to ${HEAD_REF:-$HEAD_SHA}; working tree untouched. Aborting push." >&2
+    exit 1
+fi
+
+exit $rc


### PR DESCRIPTION
Closes xtrm-bjbdf.

## Root cause — it was never the untracked files

Git exports `GIT_DIR` into the hook environment. semgrep's `--baseline-commit`
materializes the baseline via `git worktree add --no-checkout <tmp>`, chdirs in,
and runs `git checkout <base>` (`semgrep/git.py`, `baseline_context`). That
checkout inherits `GIT_DIR` and so **retargets the invoking worktree**:

- HEAD detaches at the baseline commit
- the index moves to the baseline tree while the working tree keeps the commit's
  content — hence the commit appearing as unstaged modifications
- `git worktree remove` then fails and the `/tmp` entry leaks as prunable

`.specialists/user/*.specialist.json` is not the cause. Untracked files only make
semgrep's `_is_repo_clean()` gate reject its safe `git reset --hard` fast path
(`git.py:478`) and take the worktree path instead — which is why this repo hit it
on every push.

## Fix

`scripts/semgrep-diff.sh`:

1. **Strip the inherited git hook env** (`GIT_DIR`, `GIT_WORK_TREE`,
   `GIT_INDEX_FILE`, …) so every git call resolves the repo from cwd. Guarded —
   only applied when the repo is still discoverable without them.
2. **Guard HEAD around the scan.** If a scanner moves it anyway, reattach
   non-destructively (`symbolic-ref` + `reset --mixed`, working tree untouched so
   genuine unstaged edits survive), prune the leak, and abort with a clear
   message. Silent damage becomes a loud failure.

Strategy 1 from the bead's candidate list was considered (compute the diff
ourselves and feed semgrep a file list) but it bounds the blast radius rather
than removing it, and gives up semgrep's baseline finding-matching. Strategy 5
(gitignore `.specialists/user/`) treats a symptom that isn't the cause.

## Verification

A/B with the **real** script and **real** semgrep, identical fixture
(main repo + linked worktree + untracked `.specialists/user/` + a commit that
modifies a file with findings in both revisions):

| | branch after | status | worktrees |
|---|---|---|---|
| pre-fix (`HEAD~1`) | `HEAD` (detached at base) | ` M a.py` | `/tmp/tmp9yym7ut5 … prunable` |
| post-fix | `feat` | clean | none |

Pre-fix reproduces `fatal: '/tmp/tmp9yym7ut5' contains modified or untracked
files` verbatim from the bug report.

The push that opened this PR ran both pre-push hooks green with untracked
`.specialists/user/` present and left HEAD on the branch.

## Tests

`scripts/__tests__/semgrep-diff-hook-env.test.mjs` — hermetic and offline
(semgrep stubbed), under `npm run test:scripts`:

- `stub reproduces the failure` — proves the stub is a faithful reproducer by
  asserting the exact damage (detached HEAD, unwound commit, prunable worktree)
- `strips the inherited git env` — the worktree survives
- `restores HEAD and aborts` — the guard reattaches and exits 1