### PR TITLE
test(integration-suite): opt-in live-agent lane for Suite C steps 7-10 (xtrm-6hey0.5)

### DIFF
--- a/test/integration-suite/README.md
+++ b/test/integration-suite/README.md
@@ -32,10 +32,35 @@ by what is buildable against today's shipped surface:
 |---|---|---|---|
 | **A** `suite-a-installed-artifact.mjs` | 1, 6, 19, 20 | **RUNNABLE** (hermetic) | Install all three RCs; version-conformance vs `docs/runtime-compatibility.json`; `xt update --apply` on stale Pi state; user-owned assets preserved. No tmux. |
 | **B** `suite-b-coordination.mjs` | 12-18 | **RUNNABLE** (capability-gated) | Full reply-obligation → ack → correlated-reply → consume-once → restart-no-dup lifecycle + read-only bridge / mutation-refused, against a **private** `tmux -L` server and isolated state. Skips cleanly where tmux/xtmux are absent. |
-| **C** `suite-c-coordinator-lineage.mjs` | 2-5, 11 (7-10 live-only) | **RUNNABLE** (capability-gated) | Launches a **real subordinate chain coordinator** through the packed Core artifact (`xt claude … --subordinate`) against a private `tmux -L` server and a throwaway git repo, then asserts the lineage invariants: distinct worktree + branch, `@agent_parent_session`/`@agent_role`/`@agent_bead`/`@agent_worktree`/`@agent_branch`, the single-line `session:pane` stdout contract, and main left untouched. Skips cleanly where tmux/git are absent. |
+| **C** `suite-c-coordinator-lineage.mjs` | 2-5, 11 (+ 7-10 opt-in) | **RUNNABLE** (capability-gated) | Launches a **real subordinate chain coordinator** through the packed Core artifact (`xt claude … --subordinate`) against a private `tmux -L` server and a throwaway git repo, then asserts the lineage invariants: distinct worktree + branch, `@agent_parent_session`/`@agent_role`/`@agent_bead`/`@agent_worktree`/`@agent_branch`, the single-line `session:pane` stdout contract, and main left untouched. With `XTRM_SUITE_C_LIVE=1` it additionally dispatches a **real specialist** from the coordinator's session and asserts branch ancestry, runtime-origin lineage and the merge back. Skips cleanly where tmux/git are absent. |
 
-Result: **20 of 20 steps are now addressed** — 16 run, and steps 7-10 are
-explicitly deferred to a live-agent lane rather than reported as blocked.
+Result: **20 of 20 steps are now addressed** — 16 run by default, and steps 7-10
+run for real behind an opt-in gate rather than being reported as blocked.
+
+### The Suite C live lane (`XTRM_SUITE_C_LIVE=1`)
+
+```bash
+XTRM_SUITE_C_LIVE=1 node test/integration-suite/suite-c-coordinator-lineage.mjs /path/to/xtrm-tools.tgz
+# 9 PASS, 0 SKIP, 0 BLOCKED
+```
+
+Off by default: it dispatches a real, API-billed specialist, so it is a
+pre-release lane, never a per-PR gate. It needs `sp`, `bd` and `xtmux` on PATH
+plus the operator's model credentials (`~/.pi/agent/{auth,models,settings}.json`
+and `~/.config/specialists/user.json`), which are **copied** into the sandbox —
+the originals are read-only to the suite. Any missing prerequisite `[SKIP]`s the
+four steps with the concrete reason: an absent API key is not a conformance bug.
+Isolation is unchanged from the default lane — private tmux server, sandbox
+`HOME`/`XDG_STATE_HOME`, throwaway repo.
+
+What the lane actually does: the coordinator commits on its own branch (so step
+8's ancestry cannot hold trivially), a real bead is created in the fixture's own
+beads database, and `sp run <specialist> --bead <id> --worktree` is dispatched
+from a shell window **inside the coordinator's tmux session** — so
+`XTMUX_AGENT_BRANCH` has to arrive by inheritance, which is the Core half of
+P1-03. Override the specialist with `XTRM_SUITE_C_LIVE_SPECIALIST` (default
+`explorer`: READ_ONLY and cheap — the subject is branch topology, not agent
+quality).
 
 Suite C graduated in **xtrm-6hey0** (audit P0-05 `--subordinate` + P1-02 lineage
 metadata), which is what unblocked it. It became **gating** in `run-all.mjs` at
@@ -53,12 +78,16 @@ tmux or git stays green, but a genuine lineage regression now fails the run.
   contract, not Specialists' task rendering (Suite A covers that at contract
   level) nor a real LLM turn. A real `sp render-task` needs a beads database and
   a real agent needs credentials — shimming both is what makes steps 2-5 and 11
-  assertable at all.
-- **Suite C steps 7-10 are `[SKIP]`, not `[PASS]`.** They dispatch an actual
-  specialist chain and inspect the branches it creates — Specialists-side
-  behavior requiring live agents. Core only *publishes* the base branch via
-  `@agent_branch` (audit P1-03); it does not create `sp/*` branches, so faking
-  them here would assert nothing about Core.
+  assertable at all. The shims stay in place even in the live lane, which
+  dispatches the real `sp` by absolute path: steps 2-5 are byte-identical across
+  both lanes.
+- **Suite C steps 7-10 are `[SKIP]` by default, never faked into a `[PASS]`.**
+  They dispatch an actual specialist chain and inspect the branches it creates —
+  Specialists-side behavior requiring live agents. Core only *publishes* the base
+  branch via `@agent_branch` (audit P1-03); it does not create the specialist
+  branches, so fabricating them here would assert nothing. Opting into the live
+  lane runs them against the real thing instead (`xtrm-6hey0.5`, unblocked by
+  Specialists PR #200 which made `sp` consume the published `@agent_branch`).
 - **Step 20** asserts hooks + extensions are preserved (both code-backed
   foreign-preserved surfaces). A bare, unmarked user *skill* dropped into a
   managed skills projection is **repaired away** by `update --apply`; that is

--- a/test/integration-suite/suite-c-coordinator-lineage.mjs
+++ b/test/integration-suite/suite-c-coordinator-lineage.mjs
@@ -15,36 +15,66 @@
 // ── What is faithful, and what is shimmed (declared, not hidden) ────────────
 // • Core is the REAL packed artifact — `xt` runs from cli/dist/index.cjs of the
 //   tarball under test. Every assertion below is against that binary.
-// • `sp` and the runtime binary (`claude`) are SHIMS. Suite C's subject is
-//   *Core's* lineage contract — which worktree, branch, parent, role and bead a
-//   launch publishes — not Specialists' task rendering (Suite A asserts the
-//   installed Specialists artifact at contract level) and not a real LLM turn.
-//   Shimming them is what makes steps 2-5 and 11 assertable at all: a real
-//   `sp render-task` needs a beads database, and a real agent needs an API key.
+// • `sp` and the runtime binary (`claude`) are SHIMS in the default lane. Suite
+//   C's subject is *Core's* lineage contract — which worktree, branch, parent,
+//   role and bead a launch publishes — not Specialists' task rendering (Suite A
+//   asserts the installed Specialists artifact at contract level) and not a real
+//   LLM turn. Shimming them is what makes steps 2-5 and 11 assertable at all: a
+//   real `sp render-task` needs a beads database, and a real agent needs an API
+//   key.
 // • Steps 7-10 dispatch an actual specialist chain and inspect its branches.
-//   That is Specialists-side behavior requiring live agents, so they stay SKIP
-//   with a stated reason rather than being faked into a pass.
+//   They stay SKIP unless the live lane is opted into (see below), because they
+//   need a real `sp`, a real beads database and real model credentials.
+//
+// ── Opt-in live lane (XTRM_SUITE_C_LIVE=1) ──────────────────────────────────
+// With the gate set, `sp` is NOT shimmed and steps 7-10 run for real:
+//   7  dispatch a specialist from the coordinator's own tmux session + worktree
+//   8  git merge-base --is-ancestor <coordinator-branch> <sp-branch>
+//   9  the job's xtrm.runtime-origin.v1 spawn origin points at the sandbox
+//      coordinator session, not at the operator's real pane
+//  10  merge the accepted specialist branch back into the coordinator branch
+// Isolation is unchanged: private tmux server, sandbox HOME/XDG_STATE_HOME,
+// throwaway repo. Model credentials are COPIED out of the operator's
+// ~/.pi/agent into the sandbox (read-only source, never written back). The gate
+// costs an API-billed agent turn, so it is a pre-release lane, never per-PR CI.
+// A missing prerequisite (no sp, no bd, no credentials) SKIPs with the concrete
+// reason instead of failing — absence of an API key is not a conformance bug.
 //
 // Exit code is 0 when the capability gate closes (no tmux / no git / no core
 // tarball); non-zero only on a genuine conformance failure.
 
 import assert from 'node:assert/strict';
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { makeSandbox, reporter, run } from './lib/harness.mjs';
+import { assertSuccess, makeSandbox, reporter, run } from './lib/harness.mjs';
 
 const r = reporter('suite-c');
 const SOCKET = `p201c-${process.pid}`;
 const BEAD = 'xtrm-6hey0';
 const SLUG = 'coord';
 
-// Steps this lane cannot honestly assert without live agents. Kept explicit so
-// the ledger shows what is still uncovered instead of silently omitting it.
+// Opt-in: steps 7-10 dispatch a real, API-billed specialist. Off by default.
+const LIVE = process.env.XTRM_SUITE_C_LIVE === '1';
+// Cheapest chain that still provisions a worktree: a READ_ONLY specialist with
+// --worktree forced. The subject is branch topology, not agent quality.
+const LIVE_SPECIALIST = process.env.XTRM_SUITE_C_LIVE_SPECIALIST || 'explorer';
+// Credential/model files copied out of the operator's pi agent dir. Read-only
+// source: the sandbox gets copies and the originals are never written.
+const PI_AGENT_FILES = ['auth.json', 'models.json', 'settings.json'];
+
+const STEP_7 = 'step 7: dispatch a specialist child from the coordinator';
+const STEP_8 = 'step 8: verify specialist branch derives from coordinator branch';
+const STEP_9 = 'step 9: verify descendant runtime-origin lineage';
+const STEP_10 = 'step 10: merge accepted specialist branch into coordinator branch';
+
+// Steps the hermetic lane cannot honestly assert without live agents. Kept
+// explicit so the ledger shows what is uncovered instead of silently omitting it.
 const LIVE_ONLY = [
-  ['step 7: dispatch a specialist child from the coordinator', 'needs a live specialist chain (real agent + API credentials)'],
-  ['step 8: verify specialist branch derives from coordinator branch', 'sp creates specialist branches; Core only publishes the base via @agent_branch (audit P1-03)'],
-  ['step 9: verify descendant runtime-origin lineage', 'runtime-origin propagation is Specialists-side (SupervisorStatus), needs a dispatched job'],
-  ['step 10: merge accepted specialist branch into coordinator branch', 'needs step 7-8 branches to exist'],
+  [STEP_7, 'needs a live specialist chain (real agent + API credentials) — set XTRM_SUITE_C_LIVE=1'],
+  [STEP_8, 'sp creates specialist branches; Core only publishes the base via @agent_branch (audit P1-03)'],
+  [STEP_9, 'runtime-origin propagation is Specialists-side (SupervisorStatus), needs a dispatched job'],
+  [STEP_10, 'needs step 7-8 branches to exist'],
 ];
 
 function which(bin) {
@@ -55,6 +85,14 @@ function which(bin) {
 
 const TMUX = which('tmux');
 const GIT = which('git');
+// Resolved before the sandbox PATH shims exist, so these are the operator's
+// real binaries and never the `sp` shim written under box.root/bin.
+const SP = which('sp');
+const BD = which('bd');
+// Specialists captures xtrm.runtime-origin.v1 by shelling out to
+// `xtmux context --current --json`, so step 9 is only assertable when the
+// dispatching shell can resolve xtmux.
+const XTMUX = which('xtmux');
 const coreTgz = process.argv[2] || process.env.P201_CORE_TARBALL;
 
 // ── capability gate ─────────────────────────────────────────────────────────
@@ -115,6 +153,60 @@ function writeShim(dir, name, body) {
   return file;
 }
 
+// ── live lane helpers ───────────────────────────────────────────────────────
+
+// Every sandbox binding a pane needs, exported inside the command for the same
+// reason panePathPrefix is: tmux re-sources the profile for the pane shell, so
+// `-e` on the session does not survive for PATH-like vars. XTMUX_AGENT_* is
+// deliberately NOT exported here — inheriting it from the coordinator session
+// is the Core-side half of P1-03 and step 7 asserts it rather than staging it.
+function sandboxExports() {
+  const exports = [
+    ['HOME', box.home],
+    ['XDG_STATE_HOME', box.state],
+    ['XDG_CONFIG_HOME', path.join(box.home, '.config')],
+    ['XDG_DATA_HOME', path.join(box.home, '.local', 'share')],
+    ['PI_AGENT_DIR', box.piAgentDir],
+  ].map(([k, v]) => `export ${k}="${v}"; `).join('');
+  // xtmux must be resolvable: it is how Specialists captures the runtime
+  // origin (step 9). The sandbox HOME has no profile, so the pane's login
+  // shell rebuilds a PATH that would not otherwise contain it.
+  return `${exports}export PATH="${path.dirname(XTMUX)}:$PATH"; `;
+}
+
+// Copy the operator's model registry + credentials + per-specialist model
+// overrides into the sandbox. Source is read only; the sandbox owns the copies,
+// so a live run can never write back into the operator's real config.
+function seedCredentials() {
+  const piSrc = path.join(os.homedir(), '.pi', 'agent');
+  const missing = PI_AGENT_FILES.filter((f) => !existsSync(path.join(piSrc, f)));
+  if (missing.length) return `missing pi credentials: ${missing.join(', ')} in ${piSrc}`;
+  for (const f of PI_AGENT_FILES) copyFileSync(path.join(piSrc, f), path.join(box.piAgentDir, f));
+
+  // Per-specialist model overrides. Without them `sp run` refuses with
+  // "specialist has no model configured".
+  const spUser = path.join(os.homedir(), '.config', 'specialists', 'user.json');
+  if (!existsSync(spUser)) return `missing specialist model config: ${spUser}`;
+  const spDest = path.join(box.home, '.config', 'specialists');
+  mkdirSync(spDest, { recursive: true });
+  copyFileSync(spUser, path.join(spDest, 'user.json'));
+  return null;
+}
+
+// The dispatched job as Specialists records it. Terminal jobs are included:
+// the lane asserts branch topology and origin, not that the agent finished.
+function findJob(beadId) {
+  const res = run(SP, ['ps', '--json', '--include-terminal'], { cwd: project, env });
+  if (res.status !== 0) return null;
+  try {
+    const jobs = JSON.parse(res.stdout).flat ?? [];
+    return jobs.find((j) => j.bead_id === beadId && j.branch) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+let exitCode = 0;
 try {
   // ── fixture: packed Core + shimmed sp/runtime on an isolated PATH ──────────
   const installed = run('npm', [
@@ -134,7 +226,10 @@ try {
   // the metadata it writes, not what the agent does with the prompt.
   writeShim(bin, 'claude', '#!/bin/sh\nexec sleep 120\n');
   // sp shim: answers the three sub-commands the role launch path calls. The
-  // JSON mirrors the real chain-coordinator envelope's shape (P1-01).
+  // JSON mirrors the real chain-coordinator envelope's shape (P1-01). The shim
+  // stays in place even in the live lane so steps 2-5 are byte-identical across
+  // both: the live lane dispatches the REAL sp by absolute path (SP_BIN), so
+  // Core's launch path and Specialists' dispatch path never share a resolution.
   writeShim(bin, 'sp', [
     '#!/bin/sh',
     'case "$1" in',
@@ -152,10 +247,11 @@ try {
   git(project, 'config', 'user.email', 'suite-c@example.invalid');
   git(project, 'config', 'user.name', 'suite-c');
   writeFileSync(path.join(project, 'README.md'), '# suite-c fixture\n');
-  // Mirror a real xtrm repo: the worktree root is ignored, so step 11's
+  // Mirror a real xtrm repo: the worktree roots are ignored, so step 11's
   // porcelain check stays meaningful (it catches real edits to main's tree
-  // rather than tripping over the coordinator's own worktree directory).
-  writeFileSync(path.join(project, '.gitignore'), '.xtrm/\n');
+  // rather than tripping over the coordinator's or a specialist's own worktree
+  // directory). `.worktrees/` is where Specialists provisions its own.
+  writeFileSync(path.join(project, '.gitignore'), '.xtrm/\n.worktrees/\n');
   git(project, 'add', '-A');
   assert.equal(git(project, 'commit', '-m', 'fixture').status, 0, 'fixture commit failed');
   const mainShaBefore = git(project, 'rev-parse', 'main').stdout.trim();
@@ -216,8 +312,117 @@ try {
   assert.equal(paneOption(coordPane, '@agent_state'), 'idle', '@agent_state not primed to idle');
   r.ok('step 5: verify parent session, role and bead pane metadata', `parent=${orchSession} role=chain-coordinator bead=${BEAD}`);
 
-  // ── STEPS 7-10: live specialist chain (not assertable here) ───────────────
-  for (const [s, why] of LIVE_ONLY) r.skip(s, why);
+  // ── STEPS 7-10: live specialist chain ─────────────────────────────────────
+  if (!LIVE) {
+    for (const [s, why] of LIVE_ONLY) r.skip(s, why);
+  } else if (!SP || !BD || !XTMUX) {
+    const why = `live lane needs ${[!SP && 'sp', !BD && 'bd', !XTMUX && 'xtmux'].filter(Boolean).join(' + ')} on PATH`;
+    for (const [s] of LIVE_ONLY) r.skip(s, why);
+  } else {
+    const credError = seedCredentials();
+    if (credError) {
+      for (const [s] of LIVE_ONLY) r.skip(s, `live lane unavailable: ${credError}`);
+    } else {
+      // The coordinator does a unit of its own work first. Without a commit
+      // that main does not have, step 8's ancestry assertion would hold
+      // trivially — both branches would still point at the fixture commit.
+      writeFileSync(path.join(coordWorktree, 'COORDINATOR.md'), '# coordinator work\n');
+      assert.equal(git(coordWorktree, 'add', '-A').status, 0, 'coordinator stage failed');
+      assert.equal(
+        git(coordWorktree, 'commit', '-m', 'coordinator: integration base').status, 0,
+        'coordinator commit failed',
+      );
+      const coordSha = git(coordWorktree, 'rev-parse', 'HEAD').stdout.trim();
+      assert.notEqual(coordSha, mainShaBefore, 'coordinator commit did not advance its branch');
+
+      // Real beads database in the throwaway repo — `sp run --bead` reads it
+      // through `bd show --json`. --stealth keeps .beads/ out of git status so
+      // step 11's porcelain check stays meaningful.
+      assertSuccess('fixture bd init', run(BD, ['init', '--prefix', 'sc', '--stealth'], { cwd: project, env }));
+      const created = run(BD, ['create', 'suite-c live lineage probe', '-t', 'task', '-p', '3', '--json'], { cwd: project, env });
+      assertSuccess('fixture bd create', created);
+      const beadId = JSON.parse(created.stdout).id;
+      assert.ok(beadId, 'could not resolve fixture bead id');
+
+      // ── STEP 7: dispatch a specialist child from the coordinator ──────────
+      // A window in the COORDINATOR's session, cwd'd into the coordinator's
+      // worktree: the same context a coordinator agent's own shell would have.
+      // XTMUX_AGENT_BRANCH must arrive by inheritance from the session Core
+      // created — that is the published-base contract under test.
+      const coordSessionId = tmux('display-message', '-p', '-t', coordSessionName, '#{session_id}').stdout.trim();
+      assert.ok(coordSessionId, 'could not resolve the coordinator session id');
+      const dispatchWin = tmux('new-window', '-d', '-t', coordSessionName, '-c', coordWorktree, '-P', '-F', '#{pane_id}', 'sh');
+      assert.equal(dispatchWin.status, 0, `could not open a dispatch window: ${dispatchWin.stderr}`);
+      const dispatchPane = dispatchWin.stdout.trim();
+      const branchEnv = paneRun(dispatchPane, 'branch-env', 'printenv XTMUX_AGENT_BRANCH');
+      assert.equal(branchEnv.rc, 0, 'XTMUX_AGENT_BRANCH did not reach the coordinator session');
+      assert.equal(branchEnv.out.trim(), coordBranch, 'XTMUX_AGENT_BRANCH disagrees with @agent_branch');
+
+      // Fire-and-forget: the agent turn outlives the assertions. Provisioning
+      // happens before the first model call, so the branch appears in seconds
+      // while the job itself may still be running when the lane finishes.
+      tmux('send-keys', '-t', dispatchPane,
+        `{ ${sandboxExports()}"${SP}" run ${LIVE_SPECIALIST} --bead ${beadId} --worktree ; } > ${path.join(box.root, 'dispatch.out')} 2>&1 &`,
+        'Enter');
+
+      let job = null;
+      for (let i = 0; i < 240 && !job; i++) {
+        sleepMs(1000);
+        job = findJob(beadId);
+      }
+      const dispatchLog = () => (existsSync(path.join(box.root, 'dispatch.out'))
+        ? readFileSync(path.join(box.root, 'dispatch.out'), 'utf8').slice(-1500)
+        : '(no dispatch output)');
+      assert.ok(job, `no specialist job provisioned a branch for ${beadId}:\n${dispatchLog()}`);
+      r.ok(STEP_7, `job ${job.id} ${LIVE_SPECIALIST} → ${job.branch}`);
+
+      // ── STEP 8: specialist branch derives from the coordinator branch ─────
+      assert.notEqual(job.branch, coordBranch, 'specialist reused the coordinator branch');
+      assert.equal(
+        git(project, 'merge-base', '--is-ancestor', coordSha, job.branch).status, 0,
+        `${job.branch} does not descend from the coordinator's commit ${coordSha.slice(0, 12)} `
+        + `(branch ${coordBranch}); Specialists did not consume the published @agent_branch`,
+      );
+      r.ok(STEP_8, `${coordBranch}@${coordSha.slice(0, 12)} ⊂ ${job.branch}`);
+
+      // ── STEP 9: descendant runtime-origin lineage ─────────────────────────
+      // The branch exists as soon as the worktree is provisioned; the origin
+      // binding is persisted a little later, when the supervisor writes the
+      // job's status. Re-read until it lands rather than racing it.
+      const originOf = (j) => j?.spawn_origin?.runtime_origin ?? j?.root_runtime_origin;
+      let origin = originOf(job);
+      for (let i = 0; i < 60 && !origin; i++) {
+        sleepMs(1000);
+        origin = originOf(findJob(beadId));
+      }
+      assert.ok(origin, `job ${job.id} carries no runtime origin:\n${dispatchLog()}`);
+      assert.equal(origin.schema_version, 'xtrm.runtime-origin.v1', 'unexpected runtime-origin schema');
+      const coordPanes = tmux('list-panes', '-s', '-t', coordSessionName, '-F', '#{pane_id}')
+        .stdout.trim().split('\n');
+      assert.equal(origin.tmux_session_id, coordSessionId, 'runtime origin does not name the coordinator session');
+      assert.ok(coordPanes.includes(origin.tmux_pane_id), `runtime origin pane ${origin.tmux_pane_id} is not in the coordinator session`);
+      r.ok(STEP_9, `origin ${origin.tmux_session_id}:${origin.tmux_pane_id} (${origin.capture_source})`);
+
+      // ── STEP 10: merge the accepted specialist branch ─────────────────────
+      // The commit is a fixture: a READ_ONLY probe specialist produces no
+      // output of its own, and the subject here is the merge topology, not the
+      // agent's work. Everything about the branches themselves is real.
+      writeFileSync(path.join(job.worktree_path, 'SPECIALIST.md'), '# accepted specialist output\n');
+      assert.equal(git(job.worktree_path, 'add', '-A').status, 0, 'specialist stage failed');
+      assert.equal(git(job.worktree_path, 'commit', '-m', 'specialist: accepted output').status, 0, 'specialist commit failed');
+      const specialistSha = git(job.worktree_path, 'rev-parse', 'HEAD').stdout.trim();
+      const merged = git(coordWorktree, 'merge', '--no-ff', '-m', `merge ${job.branch}`, job.branch);
+      assert.equal(merged.status, 0, `merge into the coordinator branch failed: ${merged.stderr}`);
+      assert.equal(
+        git(project, 'merge-base', '--is-ancestor', specialistSha, coordBranch).status, 0,
+        'accepted specialist commit is not reachable from the coordinator branch',
+      );
+      r.ok(STEP_10, `${specialistSha.slice(0, 12)} → ${coordBranch}`);
+
+      // Stop the agent before the sandbox is torn out from under it.
+      run(SP, ['stop', job.id], { cwd: project, env });
+    }
+  }
 
   // ── STEP 11: confirm main remains unchanged ───────────────────────────────
   assert.equal(git(project, 'rev-parse', 'main').stdout.trim(), mainShaBefore, 'main moved during a coordinator launch');
@@ -226,13 +431,17 @@ try {
   r.ok('step 11: confirm main remains unchanged', mainShaBefore.slice(0, 12));
 
   const summary = r.summary();
-  console.log(`suite-c: ${summary.blocked ? 'BLOCKED' : 'PASS'} (${summary.pass} live, ${summary.skip} deferred to a live-agent lane)`);
-  process.exit(0);
+  const deferred = summary.skip ? `, ${summary.skip} deferred to the live-agent lane (XTRM_SUITE_C_LIVE=1)` : '';
+  console.log(`suite-c: ${summary.blocked ? 'BLOCKED' : 'PASS'} (${summary.pass} live${deferred})`);
 } catch (error) {
   console.error(`\n  [FAIL] suite-c: ${error?.message ?? error}`);
   r.summary();
-  process.exit(1);
+  exitCode = 1;
 } finally {
+  // `process.exit()` here would skip this block entirely and strand a tmux
+  // server plus a sandbox tree on every run. Set the code, let cleanup run.
   tmux('kill-server');
   box.cleanup();
 }
+
+process.exit(exitCode);


### PR DESCRIPTION
Closes `xtrm-6hey0.5` (umbrella `xtrm-vtqlg`).

Suite C's steps 7-10 dispatched a real specialist chain and were therefore `[SKIP]`. Specialists PR #200 (`73cf0e77`) made `sp/*` branches derive from the coordinator's published `@agent_branch` — that is what unblocked them.

## What this adds

`XTRM_SUITE_C_LIVE=1` runs all four for real:

- the coordinator commits on its own branch first, so step 8's ancestry assertion **cannot hold trivially** (without it both branches still point at the fixture commit);
- a real bead is created in the fixture's own beads database (`bd init --stealth`);
- `sp run <specialist> --bead <id> --worktree` is dispatched from a shell window **inside the coordinator's tmux session**, so `XTMUX_AGENT_BRANCH` has to arrive by inheritance — the Core half of P1-03;
- step 8 asserts `git merge-base --is-ancestor <coordinator-commit> <specialist-branch>`, step 9 asserts the recorded `xtrm.runtime-origin.v1` binding names the coordinator session/pane, step 10 merges the accepted branch back.

## Verdicts

| Lane | Result |
|---|---|
| default (no gate) | `5 PASS / 4 SKIP / 0 BLOCKED`, exit 0 — **unchanged** |
| `XTRM_SUITE_C_LIVE=1` vs specialists 3.21.0 | `9 PASS / 0 SKIP / 0 BLOCKED` |

Step 8 passes against the current Specialists release, which is the first live confirmation that the P1-03 consumer half actually landed.

## Constraints honored

- **Opt-in only.** Off by default; it bills a real agent turn, so it is a pre-release lane, never a per-PR gate.
- **Skips cleanly.** Missing `sp`/`bd`/`xtmux`/credentials `[SKIP]`s the four steps with the concrete reason — an absent API key is not a conformance bug.
- **Isolation unchanged.** Private `tmux -L` server, sandbox `HOME`/`XDG_STATE_HOME`, throwaway repo. Credentials are *copied* in; the operator's files are read-only to the suite.
- **Shims unchanged.** The `sp` shim stays even in the live lane (the real `sp` is invoked by absolute path), so steps 2-5 are byte-identical across both lanes.
- No change to `worktree-session.ts`.

## Drive-by

Same file leaked a tmux server and a `/tmp` sandbox tree **on every run**: `process.exit()` inside the `try` skips the `finally` that held the cleanup. Now sets `exitCode` and exits after cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)