### PR TITLE
fix(scripts): strip inherited GIT_DIR in osv-diff before the base-tree scan (xtrm-6reex)

### DIFF
--- a/scripts/osv-diff.sh
+++ b/scripts/osv-diff.sh
@@ -10,6 +10,20 @@ if ! command -v osv-scanner >/dev/null; then
     exit 0
 fi
 
+# Git exports GIT_DIR (and friends) into the hook environment. This script later
+# `cd`s into an extracted baseline tree that is NOT a repo — with GIT_DIR
+# inherited, any git lookup made there silently resolves against the INVOKING
+# worktree instead (xtrm-6reex; same hazard that produced the semgrep detach in
+# xtrm-bjbdf). Drop the inherited vars so every git call resolves from cwd.
+# No-op when unset, and skipped if the repo isn't discoverable without them.
+# Third consumer? Extract this into scripts/lib rather than copying it again.
+GIT_HOOK_ENV="GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX GIT_QUARANTINE_PATH"
+# shellcheck disable=SC2086
+if (unset $GIT_HOOK_ENV; git rev-parse --show-toplevel >/dev/null 2>&1); then
+    # shellcheck disable=SC2086
+    unset $GIT_HOOK_ENV
+fi
+
 HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 HEAD_SHA=$(git rev-parse HEAD)
 


### PR DESCRIPTION
Closes xtrm-6reex.

## Problem

`scripts/osv-diff.sh` extracts the baseline via `git archive` into a scratch dir, then `cd`s in and runs `osv-scanner` there. Under the pre-push hook `GIT_DIR` (and friends) are still exported and still point at the **invoking** worktree's gitdir, so any git lookup osv-scanner performs from inside the extracted tree resolves against the wrong repo.

Same hazard class as xtrm-bjbdf, but latent rather than active: osv-scanner does not check out or mutate git state, which is why only semgrep produced the HEAD detach.

## Fix

The same three-line strip already merged into `scripts/semgrep-diff.sh` (PR #471) — drop the inherited git env vars when the repo is still discoverable from cwd. Placed once at the top, so it covers both the current-tree scan and the `cd "$base_tree"` subshell.

Deliberately **not** included: the HEAD capture/restore guard from `semgrep-diff.sh`. That exists because semgrep demonstrably moves HEAD; osv-scanner does not, and the bead explicitly warns against claiming a behavioural fix with no reproduction behind it.

Per the bead: if a third consumer appears, these lines get extracted into `scripts/lib` rather than copied a third time.

## Validation

- `bash -n scripts/osv-diff.sh` — clean.
- Guard unit check: with `GIT_DIR` poisoned to the main repo's gitdir, `git rev-parse --show-toplevel` resolves to the **worktree** after the strip (was the main repo before).
- End-to-end from the worktree with `GIT_DIR=<main-repo>/.git`: `osv-diff: no new vulnerabilities vs baseline`, exit 0, HEAD still attached to the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)