### PR TITLE
test(cli): pin install-integration to a 120s suite timeout (xtrm-5tw31)

### DIFF
--- a/cli/src/tests/install-integration.test.ts
+++ b/cli/src/tests/install-integration.test.ts
@@ -78,7 +78,10 @@ function expectedCommand(commandTemplate: string, hooksRoot: string): string {
   return commandTemplate.replace(/\$\{CLAUDE_PLUGIN_ROOT\}\/hooks\/([^\s"]+)/g, `"${hooksRoot}/$1"`);
 }
 
-describe('runtime maintenance integration', () => {
+// Every case here drives the real installer against a /tmp scaffold, so wall-clock
+// is load-dependent rather than logic-dependent — the 30s global default in
+// cli/vitest.config.ts is a machine-load tripwire, not a regression signal (xtrm-5tw31).
+describe('runtime maintenance integration', { timeout: 120_000 }, () => {
   it('fresh install scaffolds .xtrm and writes absolute hook commands to settings.json', async () => {
     await runInstallCli(['--yes']);
 


### PR DESCRIPTION
Closes xtrm-5tw31.

## Problem

`cli/src/tests/install-integration.test.ts` intermittently times out at the 30s global default from `cli/vitest.config.ts` when the machine is loaded. Every case drives the real installer against a `/tmp` scaffold, so the suite's wall-clock is load-dependent rather than logic-dependent — a timeout here reports machine contention, not a regression.

## Fix

One `describe`-options override scoped to this file. Deliberately not a bump to the global `testTimeout`: genuinely fast suites should keep their tight tripwire.

## Validation

Measured on an idle machine, `npm test --workspace cli -- src/tests/install-integration.test.ts`:

```
✓ src/tests/install-integration.test.ts (8 tests) 59362ms
  ✓ fresh install scaffolds .xtrm ...                                    2310ms
  ✓ creates global default pointers and preserves ...                    6751ms
  ✓ second install is idempotent ...                                    10464ms
  ✓ drifted file is skipped without --force and overwritten with --force 15411ms
  ✓ dry-run prints scaffold actions and writes no files                  1800ms
  ✓ treats retired XTRM_GLOBAL_SKILLS flag as no-op ...                  4110ms
  ✓ hook wiring includes all hooks and preserves permissions.allow      11193ms
  ✓ prune mode removes plugin-era settings keys ...                      7309ms

Test Files  1 passed (1) | Tests  8 passed (8)
```

Slowest case is 15.4s — only ~2x headroom under the old 30s default, which is why it trips under load.

Negative check that the option is actually wired rather than silently ignored: with the suite timeout temporarily set to `1`, all 8 cases fail with `Test timed out in 1ms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)