### PR TITLE
fix(build): gate the prebuild worktree guard on real node_modules (xtrm-sbj1u)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -24,7 +24,7 @@
     "scripts/ghgrep.mjs"
   ],
   "scripts": {
-    "prebuild": "node -e \"if(process.cwd().includes('/.xtrm/worktrees/')){console.error('ERROR: Do not run npm run build from a worktree — dist paths will be contaminated.\\nRun from the main repo: cd <repo-root>/cli && npm run build');process.exit(1)}\"",
+    "prebuild": "node -e \"const f=require('fs'),real=p=>{try{return f.lstatSync(p).isDirectory()}catch{return false}};if(process.cwd().includes('/.xtrm/worktrees/')&&!(real('node_modules')&&real('../node_modules'))){console.error('ERROR: refusing to build — this worktree has no node_modules of its own.\\ntsup would then resolve deps from the main repo and embed worktree-relative paths in cli/dist, so the CI dist check fails.\\nFix: run npm ci at the worktree root AND in cli/, then rebuild.\\nOr build from the main repo: cd <repo-root>/cli && npm run build');process.exit(1)}\"",
     "build": "tsup",
     "dev": "tsx src/index.ts",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Closes xtrm-sbj1u.

## Problem

`cli/package.json`'s `prebuild` (b86d9d68) refused any `npm run build` whose cwd contained `/.xtrm/worktrees/`. The stated reason — tsup embeds deep worktree-relative paths into `cli/dist`, breaking CI's `git diff --exit-code cli/dist/` check — **only holds when the worktree lacks its own dependencies**.

Net effect today: every worktree agent that changes CLI source hits a hard stop on a check that does not apply to them, and either bypasses it blindly (which silently bundles the *root* dep versions instead of `cli/node_modules` — see CI run 29880314814) or cannot produce the tracked dist their PR needs.

## Fix

One-liner, still inline in `prebuild` per the bead's constraint. The guard now fires only when the cwd is a worktree **and** `node_modules` is not a real directory at both `cli/` and the worktree root.

`lstat` rather than `existsSync`, so a `node_modules` symlinked to a sibling worktree still refuses — that layout has the same divergence hazard as having none.

The message keeps explaining *why* and now names the remedy (`npm ci` in the worktree) alongside the existing build-from-main fallback.

Non-goals honored: the guard is not removed (its failure mode is real), tsup config and dist contents are unchanged, CI still builds from the main repo.

## Validation

**1. Worktree WITH its own node_modules — build succeeds and dist is clean**

```
$ npm run build --workspace cli
CJS dist/index.cjs     2.87 MB
CJS ⚡️ Build success in 4331ms
DTS ⚡️ Build success in 25421ms

$ grep -c '/home/' cli/dist/index.cjs cli/dist/index.cjs.map
0
0

$ git diff --exit-code -- cli/dist/
DIST BYTE-IDENTICAL TO MAIN ✓
```

(The 4 residual `.xtrm/worktrees` hits in `index.cjs` are a CLI help string — `"...remove orphan .xtrm/worktrees dirs"` — from source, not path contamination. The byte-identical dist diff is the decisive check.)

**2–4. Guard behavior across cwd shapes** (running the actual `prebuild` string against fabricated cwds)

| case | expected | result |
|---|---|---|
| worktree, no `node_modules` | refuse | `exit=1` + improved message |
| worktree, real `node_modules` at `cli/` + root | allow | `exit=0` |
| worktree, `node_modules` symlinked to a sibling worktree | refuse | `exit=1` |
| main repo, no `node_modules` | allow (guard must not fire) | `exit=0` |

Refusal message:

```
ERROR: refusing to build — this worktree has no node_modules of its own.
tsup would then resolve deps from the main repo and embed worktree-relative paths in cli/dist, so the CI dist check fails.
Fix: run npm ci at the worktree root AND in cli/, then rebuild.
Or build from the main repo: cd <repo-root>/cli && npm run build
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)