### PR TITLE
compat(runtime): bump xtmux range to >=0.1.0 <0.3 (xtrm-reyem.2)

### DIFF
--- a/docs/runtime-compatibility.json
+++ b/docs/runtime-compatibility.json
@@ -11,7 +11,7 @@
     "package": "xtrm-tools",
     "requires": {
       "specialists": ">=3.21.0 <4",
-      "xtmux": ">=0.1.0 <0.2",
+      "xtmux": ">=0.1.0 <0.3",
       "node": ">=24.0.0"
     }
   },


### PR DESCRIPTION
## Summary

Bump `docs/runtime-compatibility.json` xtmux range from `>=0.1.0 <0.2` to `>=0.1.0 <0.3` so a working xtmux 0.2.x install doesn't fail Core's launch preflight (`xt claude` / `xt pi`).

## Why

Phase 0 audit (`xtrm-reyem`) surfaced that xtmux is in a **half-released** state: `v0.2.0` tag pushed to origin, `package.json` bumped, but never published to npm because `NPM_TOKEN` isn't wired. Once that's unstuck (Phase 3 / `xtrm-reyem.2`), installed xtmux will land on `0.2.x`, which the current `<0.2` upper bound rejects at launch time.

Recommend `<0.3` rather than `<1`: matches pre-1.0 semver expectations and does not blanket-approve future breaking changes.

## Test plan

- [ ] `node scripts/check-runtime-compatibility.mjs` still passes
- [ ] `XTRM_SKIP_RUNTIME_COMPAT=1 xt claude` still overrides
- [ ] Do NOT merge until xtmux `v0.2.0` is actually published to npm (the whole point of the bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)