### PR TITLE
ci: add pr-review-gate required-status-check workflow

### DIFF
--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -1,0 +1,91 @@
+name: pr-review-gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+  issue_comment:
+    types: [created, edited, deleted]
+
+jobs:
+  gate:
+    if: github.event.pull_request || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check unresolved LLM-bot threads and bot verdict
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          BOT_RE: ${{ vars.PR_REVIEW_GATE_BOT_RE || '(?i)codex|coderabbit|claude' }}
+        with:
+          script: |
+            const pr = context.payload.pull_request?.number
+                    ?? context.payload.issue?.number;
+            if (!pr) { core.info('no PR context; skipping'); return; }
+            const { owner, repo } = context.repo;
+            const botRe = new RegExp(process.env.BOT_RE);
+
+            let data;
+            try {
+              data = await github.graphql(`
+                query($o:String!,$r:String!,$n:Int!){
+                  repository(owner:$o,name:$r){
+                    pullRequest(number:$n){
+                      reviewThreads(first:100){
+                        nodes{
+                          isResolved
+                          isOutdated
+                          comments(first:1){nodes{author{login}}}
+                        }
+                      }
+                      reviews(first:100){
+                        nodes{ state author{login} submittedAt }
+                      }
+                    }
+                  }
+                }`, { o: owner, r: repo, n: pr });
+            } catch (e) {
+              core.setFailed(`GraphQL failed (fail closed): ${e.message}`);
+              return;
+            }
+
+            const threads = data.repository.pullRequest.reviewThreads.nodes;
+            const unresolvedBot = threads.filter(t =>
+              !t.isResolved && !t.isOutdated &&
+              t.comments.nodes.some(c => botRe.test(c.author?.login ?? ''))
+            );
+
+            const reviews = data.repository.pullRequest.reviews.nodes;
+            const latest = {};
+            for (const r of reviews) {
+              const login = r.author?.login;
+              if (!login || !botRe.test(login)) continue;
+              if (!r.submittedAt) continue; // Codex-shaped: null timestamp; threads-only path
+              const prev = latest[login];
+              if (!prev || new Date(prev.submittedAt) < new Date(r.submittedAt)) {
+                latest[login] = r;
+              }
+            }
+            const blockingBots = Object.entries(latest)
+              .filter(([, r]) => r.state === 'CHANGES_REQUESTED')
+              .map(([login]) => login);
+
+            const problems = [];
+            if (unresolvedBot.length) {
+              const authors = [...new Set(unresolvedBot.flatMap(t =>
+                t.comments.nodes.map(c => c.author?.login).filter(Boolean)))];
+              problems.push(`${unresolvedBot.length} unresolved bot review thread(s) from: ${authors.join(', ')}`);
+            }
+            if (blockingBots.length) {
+              problems.push(`CHANGES_REQUESTED from: ${blockingBots.join(', ')}`);
+            }
+
+            if (problems.length) {
+              core.setFailed('BLOCKED — ' + problems.join(' | '));
+            } else {
+              core.info('OK — no unresolved bot threads, no bot CHANGES_REQUESTED');
+            }

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -8,115 +8,115 @@
       "files": {
         "beads-claim-sync.mjs": {
           "hash": "14b3b19302b6764f7536e66967fd99cbc2f0824c41627c98ee2b8e47a8135d26",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-commit-gate.mjs": {
           "hash": "84a52001625c569d08cace34fa742338c80c19d73f507d7d308b4cbf3c9e13ce",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-compact-restore.mjs": {
           "hash": "6ed590f3da0725328c9fc5502104bef76ae4acba2643b39771326ddc563fe95c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-compact-save.mjs": {
           "hash": "d83e77e9c88050663b1e7bc3fc9b1843268a0eb7b5c54f8990a44d6fef1f1c5b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-edit-gate.mjs": {
           "hash": "6ad0ed59d6d512881d2e9de33b8abf40a2ee4619e2d9960dcebdfff1b9170e95",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-gate-core.mjs": {
           "hash": "a410303f8c44ac25c72ab7e0f13e6fa3b0a47c2b5ebf13cebe5184695517fec3",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-gate-messages.mjs": {
           "hash": "941cb07e8e649c3a958c0d0604199b4cd105fadf238d9fda449fb41812fc8d9c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-gate-utils.mjs": {
           "hash": "4bd24486e5e6ef65c79fbea6f4fb615b1cf0426e0adbb0ec4d540d609309225b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-memory-gate.mjs": {
           "hash": "c2c7875c85d2e174caceac0b2399dac485d50aa3ddfab5988a0410577b99585e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-status-cache.mjs": {
           "hash": "776496f1ce0d71e9627288ebda924e6fec3d05752fb6fd3542dc50641827b1f7",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-status-cache.test.mjs": {
           "hash": "5acab4b3335d373e371fb517e4f45f18ea7a82175a06fc3c161e490c7d69ba2f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "beads-stop-gate.mjs": {
           "hash": "5f75d0dccd724dc30b67a9f964b47c94b457f9174806a4e5f1a9ee21b16e40e5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "gitnexus/gitnexus-hook.cjs": {
           "hash": "d0f88b78c6723d6b6a45dbbd85e37d935bea4461046fd286d658951b16f68680",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "quality-check-env.mjs": {
           "hash": "cb2c483ad0f23b48f5832c4abc62d3490d7e2d79a2ae0f880525952fbcbe3106",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "quality-check.cjs": {
           "hash": "afab38dcba961b566d58ccc5578021827749b749225713e0bbc0bb4303cf09df",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "quality-check.py": {
           "hash": "beaee2b67eeb938a8af5839f910a6c07fa66b8233f7e3bfbb43c36814abf0ca5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "README.md": {
           "hash": "5916b6b480c70dfbe67af09c4c14288f2d7f0397bcb407f9dea070d124f751fe",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "specialists-agent-guard.mjs": {
           "hash": "ef4755858eae64e8a0830d1dcbaa4e08962d9ae107729d4797154acad687621c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "specialists/specialists-complete.mjs": {
           "hash": "bfb398987a2338836ddd4ecf5a590e357c7905a2e81c20bc4e4f6c15c2e7ee4a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "specialists/specialists-memory-cache-sync.mjs": {
           "hash": "2c76e6dea71a0eaf3367656fcd9d0cd7aa5815e3cf87511e3dcee313f467f192",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "specialists/specialists-session-start.mjs": {
           "hash": "44293d88f2c997b70309170b33fc34fa5565910e1f35045163398150bb6e3b5d",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "statusline.mjs": {
           "hash": "bb01a0e5934b68b9ae972216fae23f4c17f11624599149e1e1ccae6725a091f1",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "statusline.test.mjs": {
           "hash": "47a2cc09495ff6fee7c2d30a6f1efafdf2bfeb5f97b87ae867f345dae9020d31",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-xtrm-reminder.mjs": {
           "hash": "0d8e7a837cc267544e1dd408341e7daa3f1842500b8ccd2a79a6023fb9e0d1a6",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "worktree-boundary.mjs": {
           "hash": "4a0daf11ca6733d620bcf60f0411ecffd81dfc086a22f84a6a9c5ff452567d37",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xtrm-logger.mjs": {
           "hash": "865592b9490f47da087f09b872284b7d281a9333a4e2a51f40e0535cf6334854",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xtrm-session-logger.mjs": {
           "hash": "50bcd95a80b5e2174e9ecc498813917910d31a4cf19d46f44f9534e9004e3c15",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xtrm-tool-logger.mjs": {
           "hash": "e562a304a12561e76131838c6b4a6b34c31b8e792f06bcaa5f9d37fe9a3ede21",
-          "version": "0.11.1"
+          "version": "0.11.2"
         }
       }
     },
@@ -127,1003 +127,1007 @@
       "files": {
         "agent-docs-maintainer/references/agents-template.md": {
           "hash": "1c1f9b93ad13c2c76245fb13ff9f2663043bc6cc5fb0448dc16ab11cb4001e01",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "agent-docs-maintainer/references/audit-rules.md": {
           "hash": "db39cd9c881b756f83fd27276f183404405983482072b24bb7bd1e7414d5ed98",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "agent-docs-maintainer/references/claude-template.md": {
           "hash": "ea8b5b0d45c5559704b7b2aa0cbfbe38f3c29abf5e4a1ec3c4170e587e292718",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "agent-docs-maintainer/references/stack-overview-template.md": {
           "hash": "afc85b41baf7738f93c561667117b2e287f0a6e63bc83265458a9ed6b812fdea",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "agent-docs-maintainer/scripts/audit_agent_docs.py": {
           "hash": "ffd6ebd0ac2ed3b447672641088fc8d2115d43fcd1b48677d55cdf0d1ef8a5e2",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "agent-docs-maintainer/SKILL.md": {
           "hash": "a80ff7960f24889f49e3a213cc7f5a191319aa04fbecca2fd1681c8323c09f63",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "clean-code/SKILL.md": {
           "hash": "1b212a0a59f8162587a681b16e20af5bd793e4f6c7fb7c7af2d32a7deef553fb",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "code-review/SKILL.md": {
           "hash": "dbb5bcd6d3e37a3d18a8ee5c2be41c274c382c4e0c8bf8c7c9c9eb135e641f61",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "deepwiki/SKILL.md": {
           "hash": "cd0dadf31266cdf2ecbe9c129357133f105078d93e9c714d929378feaf3c4e63",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "delegating/config.yaml": {
           "hash": "74ab621ffdb27c2c4dbf897220117c14dc30536d342c40df37143f0a7727ecd4",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "delegating/references/orchestration-protocols.md": {
           "hash": "010165d814d660116d72e4860ed0bf5aba68945202112de4a31747c1416cd571",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "delegating/SKILL.md": {
           "hash": "bb1c8ed316735afb98d1d5b8f32e07f869091f8a56d079c9a1ac359f8ee67a9b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "deploy-monitor/SKILL.md": {
           "hash": "cb0f523edb1d4b6394ab991b6ce8aa88cf0687656bc6a3f85b65dadf66cf1e78",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/CHANGELOG.md": {
           "hash": "a3990e4ae7d5b509d8da9ca0dc08c2837e10db63f04711cb53159817ecf0ed00",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/examples/example_pattern.md": {
           "hash": "1cdfbdbd50f1e125269d5da24b133b015ae3bd85fc04bd29997aa69efafe0323",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/examples/example_reference.md": {
           "hash": "3387c352022798a8496e98980d964505fef6c44a8b3a61fcfdfaf26cd3eb66ea",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/examples/example_ssot_analytics.md": {
           "hash": "cbfe9b274aeb9da9e7a7761c02f99abda359ba6be704d0257d2678a4f712d7be",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/examples/example_workflow.md": {
           "hash": "8bcd40bceee97b1ffeb917dc408a9fd39d19853796fc36d3f18f3003c4de3459",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/README.md": {
           "hash": "780e6a9770377f5a654c178b02ff13c72687aaa517e86d6bbc600cb5fb6dcd10",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/references/changelog-format.md": {
           "hash": "579b44c929cbde7b34726e67d45df260ab5c5ca1acf327b484bd18d4449d8e48",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/references/metadata-schema.md": {
           "hash": "ba7ff3dfe7b8c0c8411d236df7aed2b30b9e45ebf5d80d56f32a9e0cd9bb0095",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/references/taxonomy.md": {
           "hash": "0dcab3a9b71297894cd255530ff18554c267988288fbff3aa33d0cfa6909bc4b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/references/versioning-rules.md": {
           "hash": "e68746671820ea1b709e9419fc8c5f6bbb13d34a4fd1f55e8a2b56238ee2372f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/bump_version.sh": {
           "hash": "04a81bcd8eab78ec8332f58647152212a9989b9abc62dfebaebf64cdb82c8c71",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/changelog/__init__.py": {
           "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/changelog/add_entry.py": {
           "hash": "c9d2c3d637acbfcb193f05a13a4d67704881f786e4c0291787f6b010abfdfcd7",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/changelog/bump_release.py": {
           "hash": "130414f48399de5e9f573ffd50dbf913f6b52c46ae34bafd1766b84563ab8759",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/changelog/init_changelog.py": {
           "hash": "18547212ea8d8a381f7b079579c95ec116137c3fbbf2216349353e2718486601",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/changelog/validate_changelog.py": {
           "hash": "90a6e225b769e01921d31f379faec0bb95a87d6ae43822c1e566b809bcfebb6e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/drift_detector.py": {
           "hash": "778d44db176099411abbe4af88e8bc0743817cdd6e3a06832964083c31f0a5ce",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/generate_template.py": {
           "hash": "00063dc81497664c39c6f74782db5a0c1f63c11b422e3506fc0a3af451430475",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/list_by_category.sh": {
           "hash": "358f1dda01637caf2599424418280f6f341f6fbf0e7e3cde248b1c9ebe8845cd",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/orchestrator.py": {
           "hash": "e7521584adc9adda5b9557f1b50eb9fc2622f91d8e3cb7d1da559a3d7fcf7e13",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/scripts/validate_metadata.py": {
           "hash": "f694803e069bda7064d67d8fc02002420c205c9126ae7a22b2c9abeff101b6b0",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/SKILL.md": {
           "hash": "39e342ff2edc75f74c5905b0aa6aaa9477285c1d31619821ae0e3e9ad0661b07",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "documenting/templates/CHANGELOG.md.template": {
           "hash": "148a1e54e5b646a6909bd40dcb5ab0a8f0825a35a68fd2449bca51b5f476abb4",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "find-docs/SKILL.md": {
           "hash": "344d9b44f573c1ef28ab56754a9cf6f08cf4521fb95babbc2e509be38f65333f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "find-skills/SKILL.md": {
           "hash": "54b44dc9539df865fbb060f62fb062e8232e765852a0cf14c38301fe0c1eb264",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "github-search/SKILL.md": {
           "hash": "1d49ba782bf2efde90a3896d0a03e1c79ecdbab41d89bf881f3c75a549af523d",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "gitnexus-cli/SKILL.md": {
           "hash": "e28f79d4ea2473efa0f197611a75bc25428fb4296aeeb54d1e31de2e39ccd8ad",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "gitnexus-debugging/SKILL.md": {
           "hash": "4a1e82aa835c52e38227d853c20ef05ea33be1dfb6aa6511474d15357f1d3f2e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "gitnexus-exploring/SKILL.md": {
           "hash": "ffafeaa0ce52be079e4d4b3a48c0a166728c009380a243c394c4e08f728527bb",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "gitnexus-guide/SKILL.md": {
           "hash": "40b047beeb9a7c5d47f17426b4061d2c2562c85c11288fa7f8da376d910e4f91",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "gitnexus-impact-analysis/SKILL.md": {
           "hash": "a4d6e8003c4a822c380b0e81b2fa0d642612236c734a9d51834e362c4be52f33",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "gitnexus-pr-review/SKILL.md": {
           "hash": "f7bac200a4752191d2e3aa7a2273720ca436d25df88cb2ef48dc19f92ae0934e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "gitnexus-refactoring/SKILL.md": {
           "hash": "6aab994ee0266063245245483ee3280645aca66c0c5e56730ffad3f32ecbbc5c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/examples/load-context.sh": {
           "hash": "0d614599e711c087b381a4ac7ee3c40758af1022669fc998649d199b9dfe15ed",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/examples/quality-check.js": {
           "hash": "a1f6ebdf11f2fac83116b20e5c66b8e0ea515395edfe7ec156cfeae4900329a9",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/examples/validate-bash.sh": {
           "hash": "348c58f4cf38a2e7080ea5272935a7658c7122d83dd6c52d0a1f2ef599c176ab",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/examples/validate-write.sh": {
           "hash": "89a8ef9bb7508e4819080e65834d6783afa5a5a614d458a3821b80a329eb32e5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/references/advanced.md": {
           "hash": "dc2ce5a7777ce5cb6ca4256239fa509f75f645806e1fa15e03594c4b970d2086",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/references/migration.md": {
           "hash": "7f8e7a795829837f46a0c058c26c8f5c4aa8be5c9fb5316b828229d1802ded77",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/references/patterns.md": {
           "hash": "d5dc513af7756dff436bcf5fe09ee4d9a87dfb7d410b83029c64492c90da377c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/scripts/hook-linter.sh": {
           "hash": "85a7d55488f8f38f9b98350b5cb597fb306432d5e61eaa3444e7226ca9309e0b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/scripts/README.md": {
           "hash": "08a28b12ffa9fcb16f257ea685c70a920f4f835978b9ffbbac055137c6f6aca0",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/scripts/test-hook.sh": {
           "hash": "ded642e811b4731f6a2c90c73b02e00c937511d9ee65236bb8cf9964f0069393",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/scripts/validate-hook-schema.sh": {
           "hash": "e7785d6c61d368f5ea5270c979753aea02f776f5b6aa220137ec4585abd720c2",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hook-development/SKILL.md": {
           "hash": "5d2c2d85e7bbe091ba394817f4a1b200570e259af765131440f80f270b7fe0ee",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "init-session/SKILL.md": {
           "hash": "861e5134c41aba3504374cbb522d225b8bdbf065e352009fea11a89593e0040e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "issue-triage/SKILL.md": {
           "hash": "73e69f9611bd5b4cc11c68a27de0cf5c37f49ed769c3d0ad32ed3fa6aa6299da",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/briefing.py": {
           "hash": "58c895621b028f3d265dd4a98d2ab8169d2256c468bd73e6dd3adf765dca2e67",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/evaluate_search_quality.py": {
           "hash": "8f33a48768936091df02aa4d3746576cd3c3e935d93d109607404ea801b8152a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/evaluate-synthesis.py": {
           "hash": "59ee7918109b96dc2668412ddc02e9308ebb94b522bbaa5a2b81b3e3849bf7a4",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/generate-synthesis-inputs.py": {
           "hash": "5382064ea64f04ee0a1dd1e5a284487f3f1a5a940854129d8745b197d077a7e0",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/last30days.py": {
           "hash": "7259e3ebb0b8d71ef711ecbb822ff86d718b98fdf9c0d5fef7f1c2ef058ec23d",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/__init__.py": {
           "hash": "3fb925405f898201188f9b5eea04e214ea8c8a64643397fd727f08ffeea234d9",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/bird_x.py": {
           "hash": "12f3ea370143c74ae1e9294602f3dccdc20ebe9ad725646c56947530eee20480",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/bluesky.py": {
           "hash": "271837db1fe14acbd5a9645f84570bf15ae6332786ad067e4fb7e9a80dda39eb",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/brave_search.py": {
           "hash": "8d7d8a5d4a5a53ebbbd581af6259570752e0c9face7f154d7a68a92b28614b7f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/cache.py": {
           "hash": "2ff8a3fb3fc24cfe1eb543d82c29ef5565f2115af1822033d93abeb6e7bf6904",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/chrome_cookies.py": {
           "hash": "f1d2555e0ea2cbb3d7be61764e83755d3647a7f9f4a322ffc1f254cbc0469491",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/cookie_extract.py": {
           "hash": "a28ece47b1eee31c19ad375613482b5efb155df265304c4deb3a5c1b5de3e0fb",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/dates.py": {
           "hash": "c5b1f01dd4e28ea385cb5a0b10259cce7a642e308575df12424242d3779435af",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/dedupe.py": {
           "hash": "270aaead1c61341a24a003760afbd7727178d207316b403fc3fece99feaef81a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/entity_extract.py": {
           "hash": "cefa39feeeea8b9d4a37abb10a5c1d0693abec19cf51d7fb565a8f5d620a7cf5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/env.py": {
           "hash": "f880066eeb524ab51121174885920de7e47d6763ab91265f1e0fb19a45750a8e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/exa_search.py": {
           "hash": "fde043d73366d7a7d7a9cb53d00e1ae30e09643842d218109b1ab31c550bd63b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/hackernews.py": {
           "hash": "d59d4bd21a11f32f85584a22253e9c2aa0e3c0b840b9eecda06b3d8d03f49ce3",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/http.py": {
           "hash": "adf7aba56fe9b478ee5c6d226eb0248e4ebdfb2d025edaeaa8ab45e6cd16009c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/instagram.py": {
           "hash": "aefe19ef7db5f7ab8c74f2e5bf5ee082cdeb7dfebb4a0979d25109daf85f7fae",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/models.py": {
           "hash": "639c2b5fe58d241fb3a9713e07748e0034526c68ad55082fff64be54cca1d16e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/normalize.py": {
           "hash": "dce13bb1378ced07c5f1afeeb51ba05a6250928da8935e610f0fd70b96ad58fa",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/openai_reddit.py": {
           "hash": "baf706ea08b9b839f95d1e14079db65ba06cccc30abbd9fe897c3a9efc047bae",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/openrouter_search.py": {
           "hash": "e85b2e57370c5903f3b02ef766ddcdad469be61ce59f81754ae6f4cf2ada6743",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/parallel_search.py": {
           "hash": "d04fda409eb0d29843bb596e889343d90b842465074fbc53950939323ed35a04",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/polymarket.py": {
           "hash": "940531d5cfd6196d9b39d3a49e25103757d0a2a4b8a84fcf4d8703c75db4884b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/quality_nudge.py": {
           "hash": "b3865cbb343d64fcc89965af93f41f8015ee6df87759ee14118e2c8392ec6bcd",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/query_type.py": {
           "hash": "021073dc45df000ff3f6412aea82a6a3c33de2f732bf1b0b7b23390db02c6b9e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/query.py": {
           "hash": "6bc2e0649034cdb28471346a66e2448ba58762cb7774c4fce45c055ab160912a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/reddit_enrich.py": {
           "hash": "74bcb8dcbabb9a02a3b69d263575adcb0b2e18527498ec06dc3b0a0e1c8d829e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/reddit_public.py": {
           "hash": "8c18f9a7896b167377e86f0125247dd823cd904512808d570e0da48ccd4b80ce",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/reddit.py": {
           "hash": "aa22eb72e74753f352f4b638e032d8a737f1696f1bd0e6875ab2b4b9886059cb",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/relevance.py": {
           "hash": "730d86c3e205932bfe6edf82e20ef133e5083ad07eb3301c403011ec327e52b4",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/render.py": {
           "hash": "612fc920b83d1e37a97901b78344d26c324fe657e777cc7fe158d08a80193598",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/safari_cookies.py": {
           "hash": "398f6aee95db4f68a0de2e5525295096bbb572f9c22b37daee8d296876d853b6",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/schema.py": {
           "hash": "d5621791a78572bb4a9c987595f0fa71d7853603ee808f155d05cd1d46929d7c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/score.py": {
           "hash": "1ec2712fea1f7f35a81c3d021bd506d5fbf24a96e07610d2defff5602472a285",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/scrapecreators_x.py": {
           "hash": "5e0946e7e4733a8647e0e3aec85e658ad270b62e67e7f4b500a68850b23be0bd",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/setup_wizard.py": {
           "hash": "9ea739515d2625220b616cdb21f84db3993990e4b11603f06eff7fdd74b70f85",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/tiktok.py": {
           "hash": "d6aa2496efd92f278d8a21dfa047276d76b65f30caa4e3ed6490bb887bfc2ef3",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/truthsocial.py": {
           "hash": "5383b161aaaf8508e15a915125368c291e41e02fa35878f3ea737e54ae18ba03",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/ui.py": {
           "hash": "a1267ec37871f33125c5c83d52de645167158044785178f9f87bf6464404b4c3",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/bird-search.mjs": {
           "hash": "428bb621c7f28eb00c59d5cda6ada9d834f53e4e106ca8f812b95ed8d92b6342",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/cookies.js": {
           "hash": "caf52fa2cf9a6ee730f50c192a01fa7a2955df9147676a7f0e96bbebff5e7644",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/features.json": {
           "hash": "36361f4cae0040255f84709459ebb1f0131566a567269ed7b99d073cad930f66",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/paginate-cursor.js": {
           "hash": "5f20227de1d68250ad59b7ad593db4bfb1d0f1a21694963eab3ed413c2d0d5c0",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/query-ids.json": {
           "hash": "eba47a9d26f87d0b4eb8a4f554833ed8d11b3d8728e363deeae702d09f87fc02",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/runtime-features.js": {
           "hash": "f41614d62b6c91dfc85fc4af389e6f49435324bf26460b715a991486609579d8",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/runtime-query-ids.js": {
           "hash": "0f5c61dbaad3de7fb44a14c57ed005228e51f9fc361472eff59bff4cb2a1199e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-base.js": {
           "hash": "ea972b7894458e78edd1927d102a052ae45726a7c967b376ac7f5544f5b65499",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-constants.js": {
           "hash": "27bd1416ff1f5d4f4516d784a8fb9ee08a87413f07b375752821a32e5b0cd6e3",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-features.js": {
           "hash": "4b4f2048069f751a821777cb2084f3b9126d99a958494fef71f0699d8145c4dd",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-search.js": {
           "hash": "3dfbe18ea54215d9a6393ff0884d9977dd9ddf0884a06486bdaee8a4e30d4616",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-types.js": {
           "hash": "6450f74c664db958d703e09288184ef1ca5f622782f9e11a5a9bfa3d3c78c534",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/lib/twitter-client-utils.js": {
           "hash": "b230db5583760ccd0b5b5fb1592f449a7d0bc92f6184808e8ffb6f8968df20e9",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/LICENSE": {
           "hash": "62316704df7426e5a79d2827ff8aca36e9abb3a73b8e68557030749ebefec667",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/vendor/bird-search/package.json": {
           "hash": "96b65305969a179ee7a7735f1b475599d6035f32fda1fd030ea57ee09380cdb5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/websearch.py": {
           "hash": "e613d0f484878309824603a09baf3c4a8d3e20d16a6f67079cda1167bb9a0858",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/xai_x.py": {
           "hash": "7ff1a0987e0896ecf150731c2e995788d1e9535295461acddc9cf998534113c6",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/xiaohongshu_api.py": {
           "hash": "c7a29dfa03f871993dc13a8ad528beed8a648102404b658242ca57878077ef60",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/lib/youtube_yt.py": {
           "hash": "239dc12d68103b05803da5d2dc491b6611d24794aeaab091a725c47bb90bffab",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/store.py": {
           "hash": "eca9d7870804cf31c535a08d7c7391a2f16f4bee5fc533cb7bf15b01e9912cdf",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/sync.sh": {
           "hash": "81af533d0e438994ebc0ee88dc8526264b52fe565e05f641677f62c66be8ff15",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/test-v1-vs-v2.sh": {
           "hash": "01013eda215cf8979ceac30e6ad2ca54da2f7669faeba67640793408825a1a40",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/scripts/watchlist.py": {
           "hash": "2c03ac8e72e07a917bdaa413080bda3c8a3eaeadbf9f55980b9048b76a4c19cd",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "last30days/SKILL.md": {
           "hash": "a437a67e7ae741b2ceaee35740a535a65e8f8aadf14d479d378616c7ccc46232",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "multiplexing-team/SKILL.md": {
           "hash": "efe2c3a9bbff08f408d9577cee3d9ae2151ac8a6c9ab4ab0bf9ea6b47c3824c5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "multiplexing/scripts/verify-deploy-applied.sh": {
           "hash": "a7ed4ebeafb4c87c9c6870e39ba5de0db737bb85b2261eb76480d96b70902f06",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "multiplexing/SKILL.md": {
           "hash": "9cf91e44a7ecdae5ed1b57a2042e951d40bb0f6a8e15011447be5bfc9d369ccc",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "planning/SKILL.md": {
           "hash": "24c22848bd869166c6f47caf071971a5fc581dd9d560b2b9689e0ac33f0294ed",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "pr-reviewer/SKILL.md": {
           "hash": "7ef3fba0d998d09122e19478d428a1537940fe91f1b5eb683428d57c4d431641",
-          "version": "0.11.1"
+          "version": "0.11.2"
+        },
+        "prd-to-plan/SKILL.md": {
+          "hash": "b5891dc0b9e4ee198eb5c0270c386d7c220d6f608550b92b4c7954548afcc1b5",
+          "version": "0.11.2"
         },
         "premortem/SKILL.md": {
           "hash": "25890f164b64076865f504c943b3890ebd73140f16c1f54726163ddfac709fc6",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "prompt-improving/README.md": {
           "hash": "3eaf7f7249096c4892b4cdadf0c67fb978d65efc92572376fe30fcbe34f3a467",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "prompt-improving/references/analysis_commands.md": {
           "hash": "ad407c4b5eafada95bb6b732a13f65ebd36ba801a8f1717150d16b8dfb6b4ad0",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "prompt-improving/references/chain_of_thought.md": {
           "hash": "31e8f49ad40d011eeee7a407aa8b4c45a8d44327cbeadbb7cc09ca585562fa9b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "prompt-improving/references/mcp_definitions.md": {
           "hash": "44dc479b19955b63fff86be354b880b081310759a43d93f99b7d78ec5ed7375e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "prompt-improving/references/multishot.md": {
           "hash": "b1fd4a0f8b7b2cf96ffc3d14731ad1274966866566e2d1d8f86c58dbd93749fd",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "prompt-improving/references/xml_core.md": {
           "hash": "d4c8115983056d595da2afdeceeb3839c688087ed2ddc05b1516a70fe97284fe",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "prompt-improving/SKILL.md": {
           "hash": "3eb21391e4512e6dfa47051159cb6f68d130bba068dbe5b6b4744c422ed18387",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "quality-gates/.claude/hooks/hook-config.json": {
           "hash": "f29b118917ec714bfa2dfefe478ea512f84b8f7ad80aebf647011b22d18a2717",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "quality-gates/.claude/hooks/quality-check.cjs": {
           "hash": "c6bbff2b05dcb810a5dc7437104a253398ef162b4a2403ba676ee136fe698dfb",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "quality-gates/.claude/hooks/quality-check.py": {
           "hash": "b46e1361dcdc0b41401c3a2b5872356391b2bc9877c4a72c058bc158eee82118",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "quality-gates/.claude/settings.json": {
           "hash": "78922a784ee78e9e50587e93628cd3b9d4dfbe49087adc4514e6781cea38cbb9",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "quality-gates/.claude/skills/using-quality-gates/SKILL.md": {
           "hash": "0570f34a7fbca7f4a53fd751503a78152401b0697e95baf06bf1c221b1000f83",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "quality-gates/README.md": {
           "hash": "f161db6c1c6b6cea904057bb89dba559d8518d8e1bdbba7838a343162c4e6cf5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "README.txt": {
           "hash": "d28484cda62e8712fecbaf0fa8871d4f72fb7188557e5bc362caca79ef72cd45",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "releasing/scripts/xt-reports.ts": {
           "hash": "34592dc1bdc2207330270919108b1b89f08c85736192d02d69171249a8898f5c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "releasing/SKILL.md": {
           "hash": "ba340a00c37843a8b9230a1f49650ad808028038c9da1f0b6172f68bb7859d45",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/scripts/security-bootstrap.sh": {
           "hash": "344b9be1ae5d4d7d83eab1e07ac583f262d73badbbad1b534182bfe806c64619",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/SKILL.md": {
           "hash": "cfd328ce7a831270a393fcc12e0a0645d2dab101eb81cde0ac4c7d599e13c90f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/templates/.githooks/pre-push.template": {
           "hash": "71e86abf117b91ed38b8231eb663b4aca4a028ea9a875bdf77b57856de721b80",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/templates/.github/workflows/gitleaks.yml": {
           "hash": "02ecc97f3ae2b360e574c9d47cbc40651f47b17d611ad8cdd84f3988b4d06b87",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/templates/.github/workflows/osv-scanner.yml": {
           "hash": "ad3b92c911957b96635dcb63e2f094b34bfa23fa0d5230f39199dd297851fd7a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/templates/.github/workflows/semgrep.yml": {
           "hash": "75abab6e7aad57a4204fcc0202568e03f8526ca4fcc7f685c067839cd37776f1",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/templates/.gitleaks.toml": {
           "hash": "e6e95082ba3660689c2020d2fc26093b751df158409dbaf96a816ac4c287038d",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/templates/.pre-commit-config.yaml": {
           "hash": "6ede8e2c8a509e15236003d53773cd7fd63021a4f01f4ea9ab80a0ef550f7479",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/templates/.semgrepignore": {
           "hash": "5bd16c26cbf023420e86387b9d266785369a193e75ba396cfd807e3f2812cf6b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/templates/scripts/security-scan.sh": {
           "hash": "a5160b0954989eb11adc69c316acab5fc19cf4727de505e1cbb1ec679be80434",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-pipeline/templates/scripts/semgrep-diff.sh": {
           "hash": "e4efc20d218e6f6689725a4a9aca37958384216ba080bf89ba2307cd529d6dc2",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/install/git-hooks/doc_reminder.py": {
           "hash": "90d33305dcc8fcc73bae2f9ad7390be118617743dbb38808d61710dc1662879b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/install/git-hooks/post_merge_drift_sweep.py": {
           "hash": "39d6f4e0afe7946636e47b2877cfc71afe6589b7ab045f86f0f739a8ccc886b9",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/install/git-hooks/skill_staleness.py": {
           "hash": "39d1ac16dee329bab34a646216e2d851856a07d53f6c0f909709fe217f2ba22f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/install/install-service-skills.py": {
           "hash": "e89bc2fd5fe9cb463f9e56360fcd5f8994479e5fc665044af76404b1ddc3eb29",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/install/service-skills-readme.md": {
           "hash": "95d31a8ae4241255c988d0aa35009070b63ac08fbf31e2cb8025e05f9a8ed585",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/install/settings.json": {
           "hash": "dd832d6f054bda8e82b389b257d923944761f4c28d09ba8b28c7e7196784a657",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/references/creating.md": {
           "hash": "6952c0d0f98f91fa7f3619d6db0925f4d628c583fb84997bb2c87aa05d777441",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/references/routing.md": {
           "hash": "69e5d873bb35bf680cdd568c65963fcb72ee1acc7cb9d86f395c37d8edb8e515",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/references/script_quality_standards.md": {
           "hash": "964476a17aea08505edddae1616899ebcc9f6f1f990e060cf37c1676a7f54b7c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/references/service_skill_contract.json": {
           "hash": "8df02e365d539651f4cff1f8999407c1be2c5a2f895a9f14c9efc65af87855d5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/references/system-guide.md": {
           "hash": "3f07f08f740ea5d3261c1d39f0942064a84a0e40a67a1ccf130cad96f8cbf6da",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/references/updating.md": {
           "hash": "a6db70b6e91e405827e9c31718032a68571d3b38f8932605d7fd1ef089bc7e50",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/references/using.md": {
           "hash": "b6876929a55c7c326d0214b6f06afe2967373e01826bef370bd1d97c19cc5662",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/bootstrap.py": {
           "hash": "0fb9b2dc142c54bf62abaeb80d92aa61491745ab77ba2bd0576950a603ef7016",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/cataloger.py": {
           "hash": "764e7e2684b31ad674ad3d2b0f2b430bbd8e2eef0d513949d963d82e3c508af1",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/deep_dive.py": {
           "hash": "fb28936c7c690566960b63bab419a54588fe55495f009da00b5b153e77f42597",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/drift_detector.py": {
           "hash": "23e805110571cc7c9527259044d5d1c2728aae225110ff1d83ffd50bdf464aec",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/layout_migrator.py": {
           "hash": "c14712c262ba5c5b6bc33fbce759a33a8b0e61632d2382d31107d5a18cf287c8",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/reconcile.py": {
           "hash": "735416ab8c1198ea2ed9941732b4c1b23de02de9883e1bd7ca0511edd30a3da0",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/scaffolder.py": {
           "hash": "07071c8a14b5dd493e095dbba3db70e93a4aa73ff9180811f91480d33c47a384",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/scope.py": {
           "hash": "2f0f5a4d6f4af4a93e3a4fa5db18e32f5aba87743bafc0105905cccbb2f41cf6",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/skill_activator.py": {
           "hash": "b76f7861dacf302f9d958202e8dd60bf54ad1265d098e5f3072423beac0a25a2",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/skill_migrator.py": {
           "hash": "d874fbc829e4da6c4f47526f9d2f914aad9d3e5e1c1a51347b2b38c0211e3c29",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/scripts/umbrella_generator.py": {
           "hash": "842890132fbb5f69c33bf2f5b5f51291ca8f931afce034426724959b15ad71fd",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "service-skills/SKILL.md": {
           "hash": "ca9d1e2ce74b69f2cda6d71995674bcd5f0454e16fc1d6c20311a419fd6e5d30",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "session-close-report/SKILL.md": {
           "hash": "98c170dded2b9ec88e2f38da6cb99d07b40cda7c0df5cd9b8e176747231e9d2c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/agents/analyzer.md": {
           "hash": "bf68f4cac5a56c673a928c2e6d619586c5b93ea364026ab37547772cb45a663a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/agents/comparator.md": {
           "hash": "fe1fc9787c495d864c5d6eada47396478572325fde1b33a96d78bf4b849b7a3e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/agents/grader.md": {
           "hash": "57134da0c1a4eea33fbd74a1c9c44aa814f07d6bc64de303edb586f941e5d21a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/assets/eval_review.html": {
           "hash": "ce477dcc74dc1c0d1d3352646a79167b5a63634e936b1019160025065974e452",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/eval-viewer/generate_review.py": {
           "hash": "fc9d1b9243fe5ab6012ebd579bd76d0035de1b79fd3b969de114defab26478fb",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/eval-viewer/viewer.html": {
           "hash": "a53213426ee1100441d701a3a0d49cda7a842f992d2c36463f4d3cc0258575fa",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/LICENSE.txt": {
           "hash": "58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/references/schemas.md": {
           "hash": "8e8876180a8989b406a4d3edddf875b04cdfd5805cc8616686d552b11ce4455f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/scripts/__init__.py": {
           "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/scripts/aggregate_benchmark.py": {
           "hash": "123ef128ea5ccc01a4b1ac212ef5567f21e9c13d3d240609780beeb3200c49aa",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/scripts/generate_report.py": {
           "hash": "13df7118a3c50c83c4c3250a606d5f2b20b25a3d44cbc392b3d669ec75281453",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/scripts/improve_description.py": {
           "hash": "0dc43232db7ac6361775c894f4a1dbac958cb510c51a1230ff9e7fb30a74a7e8",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/scripts/package_skill.py": {
           "hash": "1a33059b0db1ef73375d46d513e5ea81369d2e8838c970597b0d52ddef8d1c0f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/scripts/quick_validate.py": {
           "hash": "67cf5703402013936c8fb75ad6a1afecd8841d45cc5e606b634eb05825fde365",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/scripts/run_eval.py": {
           "hash": "43e3b8f80dbf69c343967ba77e268fae991d9fa3ed68b32a0ff02532cd48657f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/scripts/run_loop.py": {
           "hash": "bafdb8e25c740813c735c54bf0489b9e87146da4cf697265927513c5430112d7",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/scripts/utils.py": {
           "hash": "3af8ae62c40c73ab712207436a0d9a981e845f25c5a7040229eb189cc8e45bb1",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "skill-creator/SKILL.md": {
           "hash": "ba8bebb2c085444120743af8dc859dd7c2592d6290e93aa5e1c08403109bdce7",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "specialists-creator/scripts/audit-spec-uniformity.mjs": {
           "hash": "0ada06784cfd5c3adfa9c9908a9cd23380e8278fb57329fc616a83140a47fb33",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "specialists-creator/scripts/scaffold-specialist.ts": {
           "hash": "c1bfa3693d644072e6d387d2519e131624d99c5b85521ae638680d7485267403",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "specialists-creator/scripts/validate-specialist.ts": {
           "hash": "3a5f5a3a77c50e98ecf9188634ff2882f8143b19d0f28a53aff5c42e1bd09dfa",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "specialists-creator/SKILL.md": {
           "hash": "f825f500e531e3a04b252c0f9a22b8acaa396f9d093368338d13e21ac43c30d4",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sre-triage/scripts/alert_history.py": {
           "hash": "b33d60299ad2995a213c0147cfab375ec3bce5a86ad8a8c2e6f4ee2a5670b43c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sre-triage/scripts/alert_investigator.py": {
           "hash": "24b79c241cb629bd1ee964db9e5d5762cc1e12dca97e31204d4a3de864501695",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sre-triage/SKILL.md": {
           "hash": "b0d2b3c662064845d4810bff0720ae60f7cf9fc194662d5791e207af5692f608",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sync-docs/references/doc-structure.md": {
           "hash": "bd30ca7777262b582c95d72a9507ad307aad21b806594ee98d855449763a6247",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sync-docs/references/schema.md": {
           "hash": "7429a43169df08d97706833119543eda6e10bd943b3a52b399c24b7561c7b75a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sync-docs/scripts/changelog/add_entry.py": {
           "hash": "c9d2c3d637acbfcb193f05a13a4d67704881f786e4c0291787f6b010abfdfcd7",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sync-docs/scripts/context_gatherer.py": {
           "hash": "52a709949eece660ffd34fe809014b7114dffa986207d9097abb0ffaaee647fd",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sync-docs/scripts/doc_structure_analyzer.py": {
           "hash": "313c99ae326909892aa64213b7720a8bd5337bb1b02b6badc8ea53b3cea29cca",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sync-docs/scripts/drift_detector.py": {
           "hash": "967ec2320810e07388338bd59cd3a0066dd5f238275a38a01734ca86d4ef6d06",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sync-docs/scripts/pre-context.sh": {
           "hash": "b1c3ca39b1a05429b9436a287a55c06cb026e44a063783d6e449b56c617a79f4",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sync-docs/scripts/validate_doc.py": {
           "hash": "f46d547103964f1b462272bdfd462e68167cf71ac0a374fe4d0c3dcceba1ca75",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sync-docs/scripts/validate_metadata.py": {
           "hash": "8f85d3de0d78541a056a32400b0a0c753c277e73c6462492aa44f1723ff62fa2",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "sync-docs/SKILL.md": {
           "hash": "ebcdfe1f4d8e752e1a594ac32fcac2cf7d7817f65202b90fe4d58b266cf8fd33",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "test-planning/SKILL.md": {
           "hash": "6b2d56e6e8daa277632798877ddeeb659053c3d6ffbadc9f580a51fc3fb86205",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "update-specialists/SKILL.md": {
           "hash": "fdf8c680cf3e5dce80c9426f52b56c953f4f7f663c23a33a3378b2b6e4bab5a9",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "update-xt/SKILL.md": {
           "hash": "93e3fa59acb53fff32502b12a39f41dc23882aa10061c9e14ba6cded4ae1ecd4",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "updating-dependencies/schemas/dependency_update_case.schema.json": {
           "hash": "2f29b206593219548c7b8481c3d1d041861bc943a383e6ef15dab1cd8cbb2827",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "updating-dependencies/schemas/upgrade_dossier.schema.json": {
           "hash": "19486d8b0c9563fa63d389e66b2b7df2876e7a0113b9302bd44bdb8ac649de12",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "updating-dependencies/SKILL.md": {
           "hash": "0121ffef95ea24ef4dc3edad69d3e8d5b42d2e53b9928bbee6c54d3cc101b4f8",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "updating-dependencies/templates/post-deploy-watch-spec.md": {
           "hash": "692e1f6bb929888ca89284a14d2536f133edade463c9a773f16b68d9bf2f50e6",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "updating-dependencies/templates/pr-comment.md": {
           "hash": "bd87a587dba75c7fb231fb931f51270720680af5a2de29b83f08b3593dceaf61",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "updating-dependencies/templates/research-matrix.md": {
           "hash": "967b63ac9f436528babf2216d64e3cfa075f6c2f2126b4561f345d5bdf81855a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "updating-dependencies/templates/upgrade-dossier.md": {
           "hash": "425edebf079810d359e72643ba8820a62beaf7bfd0051e4216e1dd5c56354815",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-kpi/SKILL.md": {
           "hash": "dc22c51783b5bfb787c5bb10f46d3585151a33a3486e76ae38e3f43fb09f03bb",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-nodes/SKILL.md": {
           "hash": "742e9d2ad512a05c86855b88ae65f9065370876d9e7c1b10db2b68958248bc7b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-quality-gates/SKILL.md": {
           "hash": "4445e363a2930b8d233d79028eff3759dd90eed031a68f1ef6295fc5167fda93",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-script-specialists/SKILL.md": {
           "hash": "e87511d685eb7bc95c374641056194931a9da79434b624fdfb2805bd9dbac7b6",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-specialists-auto/SKILL.md": {
           "hash": "0668f03dc701d3895defc1e3f3973fa41976355db5a1c38278b6272c95f145c4",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-specialists/references/bead-contracts.md": {
           "hash": "b2c3f08758e5a998d52b37c8b5239db81f496a5ea63d93b680a5f49dd0446db4",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-specialists/references/chain-recipes.md": {
           "hash": "c92e6447f8ec443db30a28b369d59bdec1f8438115803b9f4661437e97f88f75",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-specialists/references/content-migration-map.json": {
           "hash": "32ec8787652b925b5c7dde04adff81baf129a5154decc5ffcd1034655da0bd5f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-specialists/references/dispatch-preconditions.md": {
           "hash": "66c7f52379fe546e79fe3eac0c0d52c47df1fc8d1491f805531f48cf83a89dd8",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-specialists/references/merge-and-integration.md": {
           "hash": "7884a445b5ee7031fd0cf2b548a6f6bf4df8daa2ab1db5ec28f32c47cbc4d6dd",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-specialists/references/monitoring.md": {
           "hash": "7b1aa2cec42756fb752467da14552d1e7233c892232abbc24d563abeb19cd537",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-specialists/references/registry-and-locations.md": {
           "hash": "d02cb1c2e68f59e14f57d8fda7e80e109fe5666bbd33cae4c0ab8f9b10814460",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-specialists/SKILL.md": {
           "hash": "af5725c1e034dd9181452704abdaf5eaa0e0476e2f1c54d9734e3a50e49fbdb7",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-tdd/SKILL.md": {
           "hash": "e584b6fbd0f46fc0bdbf03daafbed874cd4fb02dd585402086bbc3b043bfc1e5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "using-xtrm/SKILL.md": {
           "hash": "c8683a235a8b9bcd2e4e659feae771ff972aa696996040349994a42ed5c1999c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "vaultctl/SKILL.md": {
           "hash": "fe4e5287982be10acc2439727b4b8add7052b037a7c67fb48e7bcf214cc54214",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "verified-audit/SKILL.md": {
           "hash": "1a5e071705a63e37bd5464635856a668884b527411b9577b147fcbf36d122d4a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-debugging/SKILL.md": {
           "hash": "c9ad86ebe685530c92775f28cdab360936617e7dcefba21e054c7a9f0a9ec9aa",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-end/SKILL.md": {
           "hash": "d0b6c9269c04e8c07b5c10417f0927cfcb80cd64e8c39d45b35c056591d8f768",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-merge/SKILL.md": {
           "hash": "4e99071c17bc5a408025328592e3d06a9e4cd1d816a27ef8237eff24cb26473b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         }
       }
     },
@@ -1134,283 +1138,283 @@
       "files": {
         "architecture-design/architecture-patterns/references/advanced-patterns.md": {
           "hash": "e1cb31c83b532e579991de277836a1ea5e3d88b2ca30fc8ac16f6047ceca439e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/architecture-patterns/SKILL.md": {
           "hash": "c53973f453ec828c4761921952acadaa933f3d8dd01eace6102f8c5316cf643f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/PACK.json": {
           "hash": "bac39ce1b4d51e3debf29337bcfdf9ab76466f6e9bf8459960df6c0d0c61b7ba",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/prompt-engineering-patterns/assets/few-shot-examples.json": {
           "hash": "8e1ade9727b0bb1fb5540a781192b67e2692fbb5908ffe9eac3ec7cc2fbc6216",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/prompt-engineering-patterns/assets/prompt-template-library.md": {
           "hash": "c5756b6f9c5558d8ca82d845fd50492b53f1f4d6d02cf27585f411440a4723c2",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/prompt-engineering-patterns/references/chain-of-thought.md": {
           "hash": "41242eb267f1892430bb0001e1361c862cc98f1eafc958280d485cbee7c13e6d",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/prompt-engineering-patterns/references/few-shot-learning.md": {
           "hash": "d8784634f7beb4c60c51add45203ef2d9d0e4e3accbb81ba3295f87d893dba10",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/prompt-engineering-patterns/references/prompt-optimization.md": {
           "hash": "5c25ad9b49045ef35c55b531bd227f04628b0018080b0d4f05cb20b01b44ee41",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/prompt-engineering-patterns/references/prompt-templates.md": {
           "hash": "18db56a32be1639072631f0f7256b153acd678fe6092edad23b2a4a44016e3da",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/prompt-engineering-patterns/references/system-prompts.md": {
           "hash": "88aa10639dad981b07f3bba05539c4eefcc5fba5ed255c60eab0df238778e000",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/prompt-engineering-patterns/scripts/optimize-prompt.py": {
           "hash": "e2bd63207f0b6ed40944d8bb49311e0c97babb40d0fae974580c2dd3be99a671",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/prompt-engineering-patterns/SKILL.md": {
           "hash": "c455dde62511e04c420824be5dd5e516ab34d07842019dd7be2c9b41ca1e46bc",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/subagent-driven-development/code-quality-reviewer-prompt.md": {
           "hash": "06d1e7c2287e5a00bd1809bf39038abd5f413b4cf917c37d30f00c48f6293421",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/subagent-driven-development/implementer-prompt.md": {
           "hash": "a416193f881e5a712c988fffabfe1d5a97bffcd091eb95577c84fe2136588617",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/subagent-driven-development/SKILL.md": {
           "hash": "081ad3869e55c80bf8f890b4768a90c0e8057daf94b1b6fadebfc85ea5b8304a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "architecture-design/subagent-driven-development/spec-reviewer-prompt.md": {
           "hash": "631980e472eec5394de8b89b69d432e54fd3f7f523ecf9afa7eb4cda0c9b2baf",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "code-quality/code-review-excellence/SKILL.md": {
           "hash": "014fff1c8db75807106484d5b16451607f0dde266ae50182a2753d68ad3449ed",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "code-quality/multi-reviewer-patterns/SKILL.md": {
           "hash": "30a8e067af085d6ddbf4f3775b212b0b24137ecc431a3e8570e3d6a09823a62a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "code-quality/PACK.json": {
           "hash": "88fdbfb573fd394ac9d391be98a7c6bae176a7cf6fe8681ac85a0341361acbf0",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "code-quality/systematic-debugging/SKILL.md": {
           "hash": "4999cb851360485eca5074e727bbdd62ef20549c5d5b01216fcbf5831badb473",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "code-quality/verification-before-completion/SKILL.md": {
           "hash": "ea52d15aabaf72bc6b558efe2c126f161b53961090ddcd712000273bfe8c7b6c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "data-engineering/data-analyst/SKILL.md": {
           "hash": "144e82457e8861ae540138f9d0168e1eb7c56761bc8db541733d448cb7cb3e1e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "data-engineering/PACK.json": {
           "hash": "ace1268e5c066b494112cb2ffbb976df7857526a294b4b56d5ca86182a44d938",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "README.txt": {
           "hash": "4eb5182b790a60a7826d625348b69203156df899cd0776cc0b8fed3e95fbd513",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/academic-researcher/SKILL.md": {
           "hash": "93334b34a735942fcfd66a4ddb02df13eea639864c579b47b356c9ad5d67d4d3",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/brainstorming/scripts/frame-template.html": {
           "hash": "fb22ba9d47f3b83b56e0a95d52a3c2727db03b0d4365078d92c850293a62457b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/brainstorming/scripts/helper.js": {
           "hash": "e763d82f32b4ebb320be2f0d08449d3e5a0585778edf5c407c1fdab3f39976a5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/brainstorming/scripts/server.cjs": {
           "hash": "ea81185f581897c67d4b417eeb9bc7a158c50e0932c73047054fe53efc2683ef",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/brainstorming/scripts/start-server.sh": {
           "hash": "3442a54b5ee5511637d27bf696e092b72f94c2324f40b5ba4410da4dd0c23bc8",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/brainstorming/scripts/stop-server.sh": {
           "hash": "f65b7634a27343eab2086bdb6c59ba78695685f471b5a577b08a8817f7c50600",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/brainstorming/SKILL.md": {
           "hash": "bba47904a7f6bbee3bf8a107ebbe84e65d392be683bbb898ded736b29e415f90",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/brainstorming/spec-document-reviewer-prompt.md": {
           "hash": "12cb5ed58aef41b8da6fbb505547c71ca3f5658c83b66ca6e556c936308b3189",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/brainstorming/visual-companion.md": {
           "hash": "a2bc6fc47d0df1df981d02f707a16225b147f462e7059175ad2bc5e6dd29fcae",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/deep-research/SKILL.md": {
           "hash": "5637feab59dcc091d307fb0881907d9dfae74d3eccdf51b9bc8acf879c28c682",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/fact-checker/SKILL.md": {
           "hash": "2a93fc43762d7f626379287f9c4aab02c4a4a6d1d04ca63f9444e6932ca0dade",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "research-methods/PACK.json": {
           "hash": "330d22a58d14685167f0f5490ac01eebd78ed6575ac1168cc1a47ddbb2f72206",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-ops/PACK.json": {
           "hash": "2925caefbbfc65d926d52338a84c29d9bd1b39707f95e7f6ab1413541fe4796e",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "security-ops/security-auditor/SKILL.md": {
           "hash": "794fa5153e7e5fc432783816167055283cc42252feb7ec6a930241554828f532",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/docker-expert/SKILL.md": {
           "hash": "e33b08feeaa8e110c08dddd030970547356514d42aa484e52f51e2fd2d4f451b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/obsidian-cli/SKILL.md": {
           "hash": "b54257cdc0e5d04488b35b0c797bfe427b24359f0848d3c73924dcacf8da6358",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/PACK.json": {
           "hash": "d824669b877a9421c7ed1f5a1a4e7ed5533d4808ad180e982379a0c492c2b4e4",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/python-testing/SKILL.md": {
           "hash": "98ce1865de021c57f416bb41c9630a9d0ee85c790e8d512d4a8c9f2ebc63b501",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-backend/references/api_design_patterns.md": {
           "hash": "5bef532218c1a4f994eef546fd102d124d6052eef4f472ef490079d747d1ccc7",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-backend/references/backend_security_practices.md": {
           "hash": "c565222bd5ce1452614e62f1af0dc3e1b17e140ff261e92238d626b5d821a454",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-backend/references/database_optimization_guide.md": {
           "hash": "e399dfdcf755186f54c34bdb37efda089e359932abb543adac2d5c398252243a",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-backend/scripts/api_load_tester.py": {
           "hash": "dca9b04f0a8e643c720561e1549411064be77c3d85879e93edc5d49633a0f0cf",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-backend/scripts/api_scaffolder.py": {
           "hash": "34c43d83d0f6aacfdba2b82576b2613b398fb0b69c7aaa78c8815d3cd76c0681",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-backend/scripts/database_migration_tool.py": {
           "hash": "37ee8a932c440abf9b400f9b9f5ba046068c64e1e4d268bea49dc80a6dd4ea0d",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-backend/SKILL.md": {
           "hash": "de1c35674ab09c38b0895ab29eddfaf501ceff19ecf4db39617d7fb1cbf8762d",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-data-scientist/references/experiment_design_frameworks.md": {
           "hash": "4bb669406f3a3e2482bfc775e328643bda472a334dea7cdcb41c1b0bb87b4673",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-data-scientist/references/feature_engineering_patterns.md": {
           "hash": "6657db3b24fc5fc721f4a29ce6be0ff0a6da1dae92aca67d56945ecc74858cd0",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-data-scientist/references/statistical_methods_advanced.md": {
           "hash": "2ad183277b8e57a307085ca7265258d31a08761bc5d3f5844a33dbc79a40a48b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-data-scientist/scripts/experiment_designer.py": {
           "hash": "e086c9d66a67910d114c0831e16d6a658c712f11d5356b82f28687ba43de30fb",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-data-scientist/scripts/feature_engineering_pipeline.py": {
           "hash": "706602f103fa3403196ceb0d110e91b56b039c0f21fc0302ebfc7856c1874168",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-data-scientist/scripts/model_evaluation_suite.py": {
           "hash": "e7ce48ead1011fcf20f1cbed140061914ddc76b9ecf022101630bbec816fcc39",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-data-scientist/SKILL.md": {
           "hash": "1e6974ea60451055b3b11ff8b12d6bbb8ef90ab2bf973830718271c8ed53de06",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-devops/references/cicd_pipeline_guide.md": {
           "hash": "1a9081fd856eaad7643ddbb1b704b1e7dcf66f0e531e42e8740b21dd09439ddc",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-devops/references/deployment_strategies.md": {
           "hash": "63d164425e4d097a60d947f2fe515e4e8e60966cba97b418858a6ee5b144660f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-devops/references/infrastructure_as_code.md": {
           "hash": "82f85a94d900384b7f57b13d4519af5c6f4b47a0d2a53129f0b4452f11945374",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-devops/scripts/deployment_manager.py": {
           "hash": "11644f32cacc37d6340c805f698e96f8b3692a79352c16f500f96ccc7dde30f9",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-devops/scripts/pipeline_generator.py": {
           "hash": "716dccacc6edd012e3295880138e28a573eba5185ed843f883f56866b50e387b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-devops/scripts/terraform_scaffolder.py": {
           "hash": "f5c3a34fa93cc91635a957163525cbb0324489451cb869225dccb38f927c6794",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-devops/SKILL.md": {
           "hash": "478aed6e0ef1a629cd1e7b8d3805935ab154a15ed83a9fd928c1114d16abcaad",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-security/references/cryptography_implementation.md": {
           "hash": "d4d994d22c107903fe29c6f6bde732f92e7a5eb26eaa9b200f10a3d4ddbe4adb",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-security/references/penetration_testing_guide.md": {
           "hash": "06aaca9578eb2b91664f0ef964c03621b80c47469260b2982764615aaacdc512",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-security/references/security_architecture_patterns.md": {
           "hash": "86619c5fb1ae5432b2d0be75b897144161f260afaa2ded33fae0988f5da50b1d",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-security/scripts/pentest_automator.py": {
           "hash": "8b2280d6ee02a852b9fe92dc400fae1787998c4ad1d1d3bfbb19d06c05f40b30",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-security/scripts/security_auditor.py": {
           "hash": "ce767c5773cbdd5d99601819061670839b521b6b9d13a4de6f10bd189caa2fe9",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-security/scripts/threat_modeler.py": {
           "hash": "2a62f3043d9d402b15a5e749b3eecc657c0c390e8ddb8d36d9900f57c55ed2a5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "xt-optional/senior-security/SKILL.md": {
           "hash": "d7e26f159d81a9e5ca9a7bc9ff3af116876068349d727b894c6b50020efbd7a7",
-          "version": "0.11.1"
+          "version": "0.11.2"
         }
       }
     },
@@ -1421,59 +1425,59 @@
       "files": {
         ".env.example": {
           "hash": "70e6af83cb0faf13a74676a5a3b79551ac60997cccd226e14c8dbc5887c047d5",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "claude.mcp.json": {
           "hash": "20b811ccc82395f9f3cd9a45ef36b776c3382d553924ef34662dd817a0a1c197",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "claude.mcp.optional.json": {
           "hash": "6cf39ec4a4cf6096a8108c883456c80bd45f0d37430f9403ea44aea1590f4d5c",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "hooks.json": {
           "hash": "8ee88ac6474d738b54ea4890fef73001aa6a5a342786528842034bc9a3e9574f",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "instructions/agents-top.md": {
           "hash": "0e1912c3f3ea4cd84f3107db3eb15537f5e1ff5d79f1e8a91175049eb8b0852d",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "instructions/claude-top.md": {
           "hash": "de94832b0ee551cec52fba8b8b75a9a5fbeac1633bfca5ea95d242b903461532",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "pi.mcp.json": {
           "hash": "fb7f018e15e0d04b46ca473994ea275b46ebb21d741ff59c90188e26be8fb2d2",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "pi/auth.json.template": {
           "hash": "3d608dfc7574015abbf8c0c395845ecd2a2c8d166a25ca1cfda6398a82ee723b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "pi/install-schema.json": {
           "hash": "44d91fd7b9ca6eb7198f1e4cd0f5f849a42dcb3df119b741746211218acf0c2b",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "pi/models.json.template": {
           "hash": "b3c0ba93f087eef9645edbe8790307c44d075a8cbba1806e621ef983db92c4fa",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "pi/pi-worktrees-settings.json": {
           "hash": "7ebd4bed1a3a88dd8d423e8a557d487df009a06c2871658be7da1661e9651891",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "pi/settings.json.template": {
           "hash": "3acfbfd2a13b1319dd228ba2f9ae5f16ab203a2f0290f74b21cb763697ec2713",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "README.md": {
           "hash": "45a8977e6aaf3ce8cf349bc4382ab00e66329e5e240421fa25b04a71073d8aa9",
-          "version": "0.11.1"
+          "version": "0.11.2"
         },
         "settings.json": {
           "hash": "ec83b2db614a707fe2406d6b5907e848f6680bc36f85fc82ffd5e2d6283755ec",
-          "version": "0.11.1"
+          "version": "0.11.2"
         }
       }
     }

--- a/.xtrm/skills/default/prd-to-plan/SKILL.md
+++ b/.xtrm/skills/default/prd-to-plan/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: prd-to-plan
+description: >
+  Turn a spec, PRD, or vague ambition into a runnable bd issue board with sprints,
+  fan-out, cross-repo gates, and specialist orchestration — without over-engineering
+  the plan itself. Ponytail-first: the plan is only as big as it has to be. Use when
+  the user says "plan this", "prd-to-plan", pastes a PRD/roadmap, links a design
+  doc, or when a new audit/report/spec lands and needs decomposition across one or
+  more xtrm repos. Also use when a task spans ≥2 repos, ≥3 sprints, or would benefit
+  from parallel lanes but the user hasn't yet decided the shape.
+priority: normal
+---
+
+# /prd-to-plan — spec → runnable board
+
+You just got a PRD, plan, audit report, roadmap, or vague ambition. Turn it into a bd board that a coordinator + 3 panes can execute — without invalidating ponytail by writing a giant plan document.
+
+## When this fires
+
+- `/prd-to-plan` — user typed it explicitly
+- User pastes a spec / PRD / audit report / design doc
+- User says "plan this", "break this down", "how do we ship this", "let's plan the X epic"
+- New markdown at `docs/design/*.md` or `docs/plans/*.md` lands and user wants it decomposed
+- A task obviously spans ≥2 xtrm repos (`core`, `xtmux`, `specialists`) or ≥3 sprints
+
+## Workflow
+
+Follow in order. Skip steps only when the input clearly doesn't require them.
+
+### 1. Ground the input
+
+- If user pasted inline, use it as-is
+- If user gave a path, read only what you need — for docs >1000 lines use `ctx_execute_file` to extract headings + work-package IDs; don't dump bytes into context
+- If the doc is unclear or contradicts recent PRs, ask **one** clarifying question before scoping (never two)
+
+### 2. Recent-work ack (mandatory)
+
+Before scoping anything, orient to what shipped recently in each affected repo:
+
+```bash
+gh pr list --state=merged --limit 15
+git log --oneline -20
+```
+
+Note if a recent PR already did what the spec is asking. If yes → STOP and surface to user before continuing.
+
+### 3. Understand complexity & scope
+
+Split the input into:
+
+- **Audit-closure vs new-feature** (Track A vs Track B) — never mix in one epic; user's earlier firewall preferences apply
+- **Per-repo lanes** — which of `~/dev/core`, `~/dev/xtmux`, `~/dev/specialists` (or wherever) is touched
+- **Cross-repo release gates** — any change that requires atomic multi-repo release?
+- **Work-package IDs** — if the spec already has them (MSG-01, PACKAGE-A, etc.), respect them
+
+### 4. Adversarial pre-plan audit (only for large/multi-repo)
+
+If the plan spans ≥2 repos or has ≥10 work packages: spawn 2–3 `general-purpose` audit helpers **before** creating any beads. One per repo. Each answers, per claim:
+
+- **still-current?** — is the claim true against HEAD, or has a recent PR fixed it?
+- **implementable-as-described?** — are the proposed files/seams correct? missing coupling?
+- **ponytail-verdict** — accept / simplify-how / cut. Reject new abstractions with one caller, per-caller patches when a shared guard works, "quarantine" over "delete", daemons where a periodic reconciler exists, prose complexity dressed as design
+
+Prefer sequential dispatch (one helper at a time) unless user opts into parallel — helper reports are the base for the fan-out plan.
+
+### 5. Decide fan-out & sprint subdivision
+
+Write a compact epic-head at `docs/design/<slug>-epic-plan.md`:
+
+- Track split (if applicable)
+- Audit-informed deltas (helpers override the spec)
+- Sprints with per-lane task lists
+- Fan-out helpers per sprint (coordinator + panes + specialists)
+- Cross-repo release gates
+- DoD per sprint
+
+Keep it under ~300 lines. Anything longer = ceremony creeping back.
+
+### 6. Materialize bd board
+
+Via `/planning` skill or direct `bd create` script:
+
+- One umbrella epic; one child epic per sprint; tasks under sprint epics
+- Group by "would-ship-together" PR boundary — 1 bead per PR, not 1 bead per file
+- Fill 7-section contract (PROBLEM / SUCCESS / SCOPE / NON_GOALS / CONSTRAINTS / VALIDATION / OUTPUT) — see /planning
+- Wire deps: `blocks` only for hard sequencing; `validates` / `discovered-from` / `caused-by` otherwise
+- Cross-repo gates → `bd dep add <A> <B> --type blocks` between concrete task beads
+- Placeholder epics for deferred programs (child of umbrella, no grandchildren)
+
+Batch-create via a scratchpad script using `bd create --silent --stdin` — single tool call, one long script, IDs captured to `/tmp/bd-created/ids.txt`.
+
+### 7. Cross-cutting rules
+
+Append to the umbrella epic:
+
+- **Help-surface parity** — CLI code changes ship with `--help` update in same PR
+- **Skill drift** — any changed CLI flag with a corresponding `.xtrm/skills/default/**/SKILL.md` mention: update or file follow-up
+- **Bead assignee auto-populate** — when `xt pi/claude --bead <id>` is used
+
+Append explicit help-surface / assignee checkboxes to individual beads only when they concretely touch that surface.
+
+### 8. Handoff
+
+- Show board tree (`bd list --parent <umbrella>`)
+- Show first claimable (`bd ready --limit 3`)
+- Report specialist load per sprint (count of dispatches, not tasks)
+- Note anything uncommitted (epic-head doc, source PRD) so user commits before starting
+
+## Skill routing (what to load when)
+
+| Situation | Load |
+|---|---|
+| Structured bd decomposition after this skill drafts the epic-head | `/planning` |
+| Companion test/smoke/E2E issues per bead layer | `/test-planning` |
+| Coordinator + ≥2 panes for parallel lanes | `/multiplexing` |
+| Dispatch executor/reviewer/debugger/test-runner/security-auditor chains | `/using-specialists` |
+| Any coding bead — enforce lazy solution | `/ponytail:ponytail` (auto-active if operator has it on) |
+| Service/project context before scoping | `/scope` + `/using-service-skills` |
+| Stress-test the plan for blind spots | `/premortem` |
+| Underspec'd PRD — needs research first | `/deep-research` |
+| xtrm workflow / beads gates / hooks | `/using-xtrm` |
+| PR flow / session close | `/xt-end`, `/xt-merge`, `/session-close-report` |
+
+Load skills **just before** the phase that needs them, not upfront.
+
+## Optional: Jira mirror
+
+If the operator uses Jira (Atlassian Rovo MCP connector active — `mcp__claude_ai_Atlassian_Rovo__*`), mirror the umbrella epic and sprint epics into Jira for operator-facing durability. bd stays the execution truth (claims, deps, memory-acks, KV state); Jira is the human-scan view.
+
+- One Jira issue per bd epic (umbrella + sprint children). Do NOT mirror leaf tasks unless the operator asks — that's ceremony.
+- Link each Jira issue to its bd id in the description; put the bd id in a Jira label (e.g. `bd:xtrm-wiy5n`).
+- Dedupe first — `mcp__claude_ai_Atlassian_Rovo__searchJiraIssuesUsingJql` with `labels = "bd:<id>"`.
+- On sprint close, `mcp__claude_ai_Atlassian_Rovo__addCommentToJiraIssue` with release PR link + smoke evidence.
+- Never sync bead notes / KV / memory-ack into Jira — those are execution signals with no operator-scan value.
+
+Ponytail: if the operator hasn't asked for Jira mirroring and no Rovo MCP is available, skip the section entirely. Don't create Jira debt.
+
+## Optional: Calendar time-blocking for future work
+
+If work is planned for future dates (release windows, sprint kickoffs, review gates, cross-repo coordination) AND a calendar connector is available (`mcp__claude_ai_Google_Calendar__*` is the reference; other providers similar), time-block the **moments**, not the beads.
+
+Date-anchor candidates (block only these):
+
+- Sprint kickoff once dependencies clear
+- Coordinated release window
+- Smoke-container review checkpoint
+- Cross-repo release gate operator sign-off
+- External dependency deadline (e.g. an upstream PRD ships)
+
+Ponytail: never one calendar event per bead. Only date-anchored moments. If the operator hasn't asked and no calendar connector is available, skip.
+
+Example (Google Calendar): `mcp__claude_ai_Google_Calendar__create_event` with title `"Sprint 3c release window — <slug>"`, description linking bd umbrella + release PRs, duration = expected wall-clock (a real block, not a 15-min "for later" placeholder).
+
+## Ponytail rules for this skill
+
+- The plan document is not the deliverable — the runnable board is. Keep the doc small.
+- Group beads by PR boundary, not by file. 8 small fixes in one PR = one bead with 8 VALIDATION checkboxes, not 8 beads.
+- Cross-repo release gate = one `blocks` edge between the two release beads. No new orchestration layer.
+- Adversarial audit is not for every plan. Skip if the input is a straightforward single-repo feature and the operator hasn't asked for it.
+- No new bead for tooling meta-work that fits under an existing umbrella claim.
+- If the spec is under 30 lines and touches one repo, skip the epic-head doc entirely — go straight to `/planning`.
+- Never invent format when a canonical one exists (`xtrm.forensic.v1`, existing `pollTimer`, existing `writeUnifiedHandoff` seam, etc.).
+- Ask user question only when it's genuinely a decision they must make (audit fold-in vs new bead, sprint reshape, release-gate strictness). Never ask "should I proceed" after they said "plan this".
+
+## Trigger patterns
+
+| When | Do |
+|---|---|
+| user pastes PRD / audit / roadmap | ground input → recent-work ack → complexity split |
+| doc is >1000 lines | `ctx_execute_file` for headings + work-IDs; don't read all bytes |
+| plan spans ≥2 repos or has ≥10 packages | adversarial audit before beads |
+| operator says "no new bead for X" | fold X's scope into an existing bead via `bd update --append-notes` |
+| bead descriptions balloon past ~80 lines | you're over-planning; cut back |
+| a sprint has >15 tasks | consider splitting the sprint or grouping tasks by PR boundary |
+
+## Output pattern
+
+Every phase reports to the user in one of these shapes:
+
+- **Confirmation of grounding** — "Doc is X lines, ~Y is authoritative content, Z is historical" + verified state of affected repos
+- **Fan-out proposal** — table of helpers/lanes/repos + one `AskUserQuestion` before spawning
+- **Audit deltas** — table: `doc-proposal | helper-verdict | action`
+- **Sprint pre-subdivision** — code block with sprint tree + fan-out helpers per sprint
+- **Board materialized** — `bd list --parent <umbrella>` + `bd ready --limit 3` + specialist load summary + first claimable
+
+Never wall-of-text between phases. Ask user question only at real decision points.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- **Skip merge commits so CI == local (xtrm-reyem.13)** ([26de5cf](https://github.com/xtrm-dev/core/commit/26de5cf69ade9b3567397e356a784cd6a3c8919d)) — 2026-07-23 13:34
+- **/prd-to-plan skill for spec → runnable bd board** ([695006e](https://github.com/xtrm-dev/core/commit/695006e2041315c876ebac142a7bc9d9f266a2dd)) — 2026-07-24 05:32
 
 ### Other changes
 
-- **CI diagnostic dump for changelog divergence** ([01ff65c](https://github.com/xtrm-dev/core/commit/01ff65ca6698849989570404d51bf91e609eb6ee)) — 2026-07-23 13:29
+- **Dump CI changelog:check diagnostics (#489)** ([428a27b](https://github.com/xtrm-dev/core/commit/428a27bfa1dcf3ae6d2e819db92533823ca0aa58)) — 2026-07-23 13:40
 
 ### Project maintenance
 
 - **Auto-refresh CHANGELOG.md — pre-push hook + PR CI check (xtrm-reyem.12) (#488)** ([6e7040d](https://github.com/xtrm-dev/core/commit/6e7040df7ecb9dafd0fc6a732f98e4a9897b3be1)) — 2026-07-23 05:18
+
+- **Audit-reconcile v0724 program plan + consolidated determinism report** ([be2acc8](https://github.com/xtrm-dev/core/commit/be2acc8d4cc287c3d26486f195a0cde198da9427)) — 2026-07-24 05:31
+
+- **Add pr-review-gate required-status-check workflow (xtrm-54zwl.1)** ([83d6eea](https://github.com/xtrm-dev/core/commit/83d6eea7bee6b5bf54dd95fb8c9c03d751409133)) — 2026-07-24 07:50
 
 ## [v0.11.2] — 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Audit-reconcile v0724 program plan + consolidated determinism report** ([be2acc8](https://github.com/xtrm-dev/core/commit/be2acc8d4cc287c3d26486f195a0cde198da9427)) — 2026-07-24 05:31
 
-- **Add pr-review-gate required-status-check workflow (xtrm-54zwl.1)** ([83d6eea](https://github.com/xtrm-dev/core/commit/83d6eea7bee6b5bf54dd95fb8c9c03d751409133)) — 2026-07-24 07:50
+- **Add pr-review-gate required-status-check workflow (xtrm-54zwl.1)** ([1693029](https://github.com/xtrm-dev/core/commit/169302900448648bc557be23a7d3cd8b28a00eb8)) — 2026-07-24 07:50
 
 ## [v0.11.2] — 2026-07-22
 

--- a/docs/design/audit-reconcile-v0724-epic-plan.md
+++ b/docs/design/audit-reconcile-v0724-epic-plan.md
@@ -1,0 +1,185 @@
+# Audit Reconcile v0724 — Epic Plan
+
+**Source report:** `docs/design/audit-reconcile-v0724.md` (3113 lines; authoritative content lines 1–1360).
+**Verified state:** Core `main@428a27bf` (v0.11.2); xtmux `048b742d` (0.2.2); Specialists `05c57e56` (3.21.1) + #206–#208 unreleased.
+**Repos:** `~/dev/core`, `~/dev/xtmux`, `~/dev/specialists`.
+**Umbrella bd epic:** `xtrm-wiy5n`.
+**Track split (mandatory, doc §Final):** **Track A** = close the existing audit. **Track B** = build deterministic orchestration. Do not mix in one PR series.
+
+---
+
+## Audit-informed deltas (helpers overrode the doc)
+
+Three parallel `general-purpose` audit helpers (one per repo) verified every claim against HEAD. Their overrides are canonical for this plan:
+
+| Doc proposal | Helper verdict | Action |
+|---|---|---|
+| **MSG-01** ack semantics: prefer Option B (successful queue) | REJECT Option B; keep Option A (SQLite row read) + `// ponytail:` comment on crash window | Option A stays; document truth |
+| **MSG-03** exact-inbound rewrite | CUT 3.a (`message-get` per row = N round-trips for zero data) and 3.c (summary-promotion guardrail already exists in `pi-inbox-reply.ts`) | Only 3.b survives: flip ack after continuation queue |
+| **MSG-04** assigned to Core | 100 % xtmux — all files live in `xtmux/hooks/claude/` | Reassign fully to xtmux lane |
+| **MSG-05** transitions: waiting + done + error + cancelled + stalled | Start terminal-only (done/error/cancelled). `stalled` not in canonical enum. `waiting` = follow-up, only if measured | 3 seams in `writeUnifiedHandoff`; reuse `xtrm.forensic.v1` payload shape |
+| **MSG-06** quarantine hooks | Files already unwired from `hooks.json`. Delete outright. Update `plugin-era-cleanup.ts` at same time (doc missed the coupling) | Atomic with MSG-05 marker removal in `supervisor.ts:2686,2748` |
+| **DOC-02** slim skills — `multiplexing` ~402 lines | Actually 685 lines. Delete is bigger. `pr-reviewer` at 208 lines is not "moderately heavy" — light-touch only | Targets stand; slim aggressively |
+| **`chain-coordinator`** in Core scope | Owned by Specialists (`config/specialists/chain-coordinator.specialist.json`) | Reassign to specialists lane |
+| **`--background`** = help-line lie | Also in `src/index.ts:1228-1239` and PARSED by `run.ts:115,944,974`. Also trained by `evals.json:71,75,185,193` | Decide fate of CLI branch; fix all four surfaces |
+| **`open-issues.json`** removal | 466 KB currently tracked; leak confirmed. Immutable-runner P0 stays separate track (bd `unitAI-tmeqw.12`) | `git rm` + `.gitignore`, one PR |
+| **EVAL-01/02** matrix + framework | No shared harness. Per-repo unit tests + tiny grep-scripts per gate | No lint framework |
+| **`xtmux-events` rendering** (user-requested extra) | Broken today: `agents.turn.done` invisible; all `sp job.*` terminal events invisible; `agent.ready` singular-vs-plural regex miss; beads cursor `T>space` ASCII bug re-emits every 2s; `messages.cancelled`/`reply.*`/`send.rejected`/`monitor.*`/`wait.wake.orphan`/`audit.*`/`bd.commented` dropped | Widen jq filter + fix cursor comparison in `scripts/test-session-events.sh` |
+| **MSG-05 verified parent** | Already available: `status.spawn_origin.runtime_origin` (captured at spawn, verified via `xtmux context --current --json`) | Read at seam, no new resolver |
+| **`evals.json`** | Trains agents on forbidden `sp merge` — contradicts skill rule #9 | Regenerate alongside DOC-01 |
+
+---
+
+## Sprints
+
+### Sprint 0 — Tooling prereqs (ONE PR, core, no specialists)
+
+Rationale: we're about to use `/multiplexing` for the rest. Slim it first.
+
+- Slim `.xtrm/skills/default/multiplexing/SKILL.md` (685 → 120–160)
+- Slim `multiplexing-team/SKILL.md` (341 → 100–140)
+- Slim `using-specialists/SKILL.md` (256 → 120–150)
+- Slim `deploy-monitor/SKILL.md` (263 → 140–180)
+- `pr-reviewer/SKILL.md` (208): light-touch (≈50-line trim); DOC-03 policy fixes bundled here
+- Update `cli/src/core/plugin-era-cleanup.ts` — remove `specialists-complete.mjs` / `specialists-session-start.mjs` legacy-dedup rows (coupled to MSG-06 landing)
+- Add `scripts/check-skill-root-budget.mjs` (30 lines: `wc -l` per named root, fail over budget)
+
+**DoD:** all 5 roots ≤ budget; skill-root-budget check green; multiplexing skill reflects the retrieval hierarchy (`message-get`, `agent-last`, `sp result --json`).
+
+### Sprint 1 — Track A P1 closure (3 lanes parallel via `/multiplexing`)
+
+**Lane core-P1** (executor + reviewer per fix):
+- Topology projection ledger schema: add `minItems: 6`, `uniqueItems: true`, `contains` per source name (doc §A1)
+- Cross-repo worktree projection (`cli/src/core/topology-projection.ts:306,392`)
+- Obligations route resolves selected pane (`cli/src/core/topology-views.ts:261`)
+- Integration view PR-join per Specialist job branch (`topology-views.ts:198-214`)
+- Serena provisioning vs matcher/permission alignment (`.xtrm/config/hooks.json`, `pi/settings.json.template`)
+- Semgrep recovery: gate `git reset --mixed` on actual HEAD change (`scripts/semgrep-diff.sh:98`)
+- Pi-only Beads cache: verify Pi runtime reuses `.xtrm/hooks/beads-status-cache.mjs` (don't write a second writer)
+- `--subordinate --reuse` worktree order (`cli/src/utils/worktree-session.ts`)
+
+**Lane xtmux-P1** (one PR, direct edits):
+- `scripts/test-session-events.sh:148,157,238-239,316-319` — fix beads cursor text-compare, capture cursor before setup
+- Same PR: widen jq filter to render `agents.turn.done`, `agent.ready`, `sp job.completed/failed/cancelled`, message reply/rejection variants, `monitor.*`, `wait.wake.orphan`, `audit.*`, `bd.commented` (user extra ask — cheaper to land with the cursor fix)
+
+**Lane specialists-P1** (one PR, direct edits):
+- `git rm open-issues.json` + `.gitignore`
+- Immutable-runner P0 stays deferred (bd `unitAI-tmeqw.12`); note in PR description
+
+**DoD:** all three lanes merged; `xtmux-events` renders end-to-end for a live `sp run … && bd close …` scenario.
+
+### Sprint 2 — Track A P2 + MSG semantic wave (3 lanes parallel via `/multiplexing`)
+
+Full specialist chain per lane: `executor` → `reviewer` → `test-runner`. `security-auditor` on specialists lane MSG-05 seam. `debugger` only on failures.
+
+**Lane xtmux-P2:**
+- Positioned bounded transcript tail read (`hooks/claude/claude-agent-turn-capture.mjs:57-63`)
+- Fallback completed-turn row when transcript empty (`claude-agent-turn-capture.mjs:85-86`)
+- Populate `tmux_server_id` (`src/domains/identity/runtime-context.ts:17,102-120`)
+- **MSG-01** — keep Option A; add `// ponytail:` crash-window comment; align README `:113`, `docs/observability-redesign.md:44`, `agent-state-hooks.md`
+- **MSG-02** — preserve `expectsReply` in `extensions/coordination-json.ts`; guard `pi-auto-monitor.ts:66-77` to skip FYI; extend existing `pollTimer` in `pi-inbox-reply.ts:293-300` for sender-owned reconciliation (NO new daemon)
+- **MSG-03.b** — flip ack after `sendUserMessage` succeeds (`pi-inbox-reply.ts:170-174` vs `:268-283`)
+- **MSG-04.a** — 6 lines in `claude-agent-turn-capture.mjs:80-113` for parent-FYI parity (mirror `extensions/pi-agent-state.ts:188-201` wire format)
+- **MSG-04.b** — one Stop-hook: `xtmux obligations list` → stderr reminder. No new widget.
+
+**Lane specialists-P2:**
+- Fix `sp integration record` publication branch target (`src/cli/merge.ts:949`)
+- Flag-shape guard in `src/cli/integration.ts:57-95` required() helper
+- Delete `--background` from `src/cli/help.ts:124` + `src/index.ts:1228-1239`; decide fate of `run.ts:115,944,974` parse branch (recommend: delete branch too, doc "use shell `&`")
+- Label `sp merge` / `sp epic merge` `[broken]` in help; update `config/skills/using-specialists/evals/evals.json:71,75,185,193` to stop training on them
+- Establish clean test baseline (`test:supervisor` etc.)
+- **MSG-05** — `emitParentNotification(statusSnapshot)` helper called from `writeUnifiedHandoff` terminal sites (`supervisor.ts:2539,2572`) + terminal `updateJobStatus('error')`. Terminal-only for v1. Reuse `xtrm.forensic.v1` payload shape; try/catch wraps send so delivery failure never rolls back completion.
+- **DOC-01** — rewrite `config/skills/using-specialists/references/monitoring.md`: remove "Sleep Timers Are Mandatory" (line 7), private-SQLite section (61-119), `completed` spelling (5 sites), polling-first, "DB is authoritative" (line 118). Teach the `sp result --json` / `sp resume` / `message-get` / `agent-last` hierarchy in ~30 lines.
+- **Chain-coordinator prompt fixes** (`config/specialists/chain-coordinator.specialist.json:28`):
+  - s/turn_end/agent_end/
+  - Add Pi/Claude asymmetry warning ("Claude does not auto-FYI parent")
+  - Inline 12-line XTMUX COMMUNICATION INVARIANTS block
+  - Tag `// TODO: resolver` on hardcoded chain order (Track B removes it)
+
+**Lane core-P2:**
+- **DOC-04** — inline 12-line invariant block into `.xtrm/config/instructions/claude-top.md` + `agents-top.md`; s#/skill-using-xtrm#/using-xtrm# (`claude-top.md:99`)
+- **MSG-06** — `git rm .xtrm/hooks/specialists/specialists-complete.mjs specialists-session-start.mjs`; prune rows in `.xtrm/registry.json:81,89`; `plugin-era-cleanup.ts` already handled in Sprint 0
+- **DOC-03** — `deploy-monitor/SKILL.md:33` add `--expects-reply=false --json` to ready/PASS examples; `pr-reviewer/SKILL.md:142-143,188` fix addressing to `--from/--from-pane/--to/--to-pane`; add `--json` to verdict sends (140-149); add one sentence distinguishing sprint-judge vocab from Specialists reviewer PASS/PARTIAL/FAIL
+- **Re-vendor** updated Specialists `monitoring.md` into Core after DOC-01 lands
+
+**Cross-repo gate:** MSG-05 + MSG-06 must merge in the same release window; bd cross-repo `blockedBy` declared.
+
+**DoD:** all three lanes merged; MSG-05 → Core reminder cycle → `message-get` → `sp result --json` works end-to-end in a `pi coordinator` + `sp run` demo.
+
+### Sprint 3 — Container smoke-test harness + coordinated release
+
+**Sprint 3a — Smoke-test container (helper-built, blocking gate):**
+
+Build a reusable smoke-test harness. Alpine container. Verifies:
+1. `xt`, `sp`, `xtmux` package install from npm registry
+2. Update mechanisms (`xt update --apply`, `npm i -g @jaggerxtrm/xtmux@latest`, `npm i -g @jaggerxtrm/specialists@latest`)
+3. Clone all 3 xtrm repos into container; run pre-edit trio-init; snapshot state
+4. Apply edits (or fetch a target branch); re-run init; diff
+5. Systematic verification: hook wiring intact, registry parity, skill roots within budget, `xtmux-events` renders live scenario, `sp run` completes and terminal notification lands
+
+Ownership: `executor` specialist builds the container + verification scripts; `reviewer` gates. Lives at `scripts/smoke-container/` (or `docker/smoke/`). Ponytail: single `Dockerfile` + one `verify.sh`; no compose, no orchestrator, no Kubernetes.
+
+**Sprint 3b — EVAL gates:**
+- **EVAL-01** — per-repo unit tests for the cross-runtime matcher matrix (doc §8, 11 scenarios). No shared harness — each repo owns its half.
+- **EVAL-02** — grep-scripts: `check-skill-root-budget.mjs` (already Sprint 0), `check-forbidden-phrases.mjs` (bans `--background`, `capture-pane` as result protocol, `completed` status spelling, `session:pane` addressing), `check-vendored-specialists-skill-parity.mjs` (hash equality upstream vs `.xtrm/skills/default/using-specialists/references/monitoring.md`)
+
+**Sprint 3c — Release wave (blocked by 3a green):**
+- Release Specialists 3.21.2 (#206–#208 + MSG-05 + DOC-01 + chain-coordinator + help honesty)
+- Release xtmux 0.2.3 (P2 fixes + MSG-01..04 + `xtmux-events` fixes)
+- Release Core 0.11.3 (slims + MSG-06 + DOC-03/04 + re-vendored monitoring.md)
+- Extended live Suite C lane
+
+**DoD:** smoke-test container green on all three released artifacts; live Suite C passes packed installs; audit closable per doc §Definition of done.
+
+### Sprint 4 — Track B (deferred placeholder epic)
+
+Track B lives in a separate bd epic. Not decomposed here. Must integrate with:
+
+- `~/dev/specialists/docs/design/roadmap/specialists-roadmap.md`
+- `~/dev/specialists/docs/design/roadmap/enhanced-prd.md`
+
+The Specialists team is planning major chain-templates work in those docs. Sprint 4 is the XTRM integration surface for that program — canonical chain templates + resolver + exact dispatch, per audit doc §B1. Also picks up MSG-05 `waiting`-notification follow-up only if measured need.
+
+Placeholder issue records: block Track B start until Track A closed; link to Specialists roadmap + PRD; assign no children yet.
+
+---
+
+## Fan-out helpers per sprint
+
+| Sprint | Coordinator | Panes | Specialists |
+|---|---|---|---|
+| 0 | direct edits (small) | 1 | none |
+| 1 | `/multiplexing` (v2) | 3 | `executor` + `reviewer` on core lane; direct on xtmux + specialists lanes |
+| 2 | `/multiplexing` | 3 | full chain per lane; `security-auditor` on MSG-05 seam; `debugger` only on failure |
+| 3a | `/multiplexing` (single helper for harness) | 1 | `executor` + `reviewer` |
+| 3b | direct edits | 1 | none |
+| 3c | `/releasing` per repo, coordinated via `/multiplexing` | 3 | `reviewer` gate on each release PR |
+| 4 | separate epic | — | tbd from Specialists roadmap |
+
+---
+
+## Cross-repo release gate
+
+Same-release-window policy for the MSG-05 / MSG-06 pair (option 1 per operator):
+
+1. Specialists 3.21.2 build → published to npm
+2. xtmux 0.2.3 build → published to npm
+3. Core 0.11.3 build → published to npm (MSG-06 marker removal in same version)
+4. Sprint 3a smoke-container run against all three released artifacts
+5. If any step fails, roll forward (fix + patch release); do not delay only one — the dead-writer/reader gap is worse than a re-release
+
+The smoke container is the checkpoint. Green = release closed.
+
+---
+
+## Definition of done per sprint
+
+**Sprint 0.** 5 skill roots within budgets; skill-root-budget check green; `plugin-era-cleanup.ts` updated for MSG-06 landing.
+
+**Sprint 1.** All P1 items closed; `xtmux-events` renders end-to-end scenario; `open-issues.json` gone from public tree.
+
+**Sprint 2.** All P2 + MSG-01..06 items closed per audit-overridden scope; MSG-05 → Core reminder → `message-get` → `sp result --json` works; chain-coordinator prompt runtime-aware.
+
+**Sprint 3.** Smoke container green on all three released artifacts; audit closable per doc §Definition of done audit-closed criteria; EVAL gates enforced in CI.
+
+**Sprint 4.** N/A — placeholder only.

--- a/docs/design/audit-reconcile-v0724.md
+++ b/docs/design/audit-reconcile-v0724.md
@@ -1,0 +1,3113 @@
+# XTRM Orchestration Determinism — Final Consolidated Audit and Architecture Conclusion
+
+**Status:** final consolidated report; implementation wave merged, audit closure conditional
+**Last verified:** 2026-07-24, Europe/Rome
+**Repositories:** `xtrm-dev/core`, `Jaggerxtrm/xtmux`, `xtrm-dev/specialists`
+**Experimental comparison:** Archon workflows
+**Primary objective:** consolidate the earlier cross-repository audit and the newest evidence, then make XTRM multiplexing and Specialists orchestration more deterministic without creating duplicate runtimes, state stores, notification systems, or workflow authorities.
+
+**Revision note:** this version supersedes all earlier audit drafts. It now also includes the 2026-07-24 cross-runtime messaging, hook-matcher, managed-instruction, CLI-help, and orchestration-skill audit. The final conclusion below is authoritative; later sections retain the chronological evidence and intermediate snapshots for traceability.
+
+---
+
+## Final conclusion
+
+### 1. Overall verdict
+
+The completed work across Core, xtmux, and Specialists has produced a substantially stronger foundation:
+
+- runtime versions are compatible and released;
+- coordinator→Specialist branch ancestry is explicit and live-tested;
+- runtime origin and descendant lineage are reconstructable;
+- topology carries role, branch, worktree, and parent-pane context;
+- integration evidence has public write and read surfaces;
+- exact messages and completed agent turns have dedicated retrieval commands;
+- Specialists now emits a structured Pi-compatible NDJSON progress stream;
+- release, package, installer, and changelog machinery is materially more reliable.
+
+The implementation program should therefore be considered **successfully landed**.
+
+The audit itself is **not yet closed**. Several previously reproduced correctness and security findings remain current. The next work must be split into two deliberately separate tracks:
+
+```text
+Track A — close the existing audit
+Track B — build deterministic orchestration
+```
+
+Do not mix routine defect closure with the new workflow architecture into one large epic or PR series.
+
+### 2. Authoritative current state
+
+| Surface | Current state |
+|---|---|
+| Core package | `xtrm-tools` 0.11.2 |
+| Core source head verified | `428a27bfa1dcf3ae6d2e819db92533823ca0aa58` |
+| xtmux package | `@jaggerxtrm/xtmux` 0.2.2 |
+| xtmux source head verified | `048b742d01db5d0c05e5d4e413ecdedeba47a8e5` |
+| Specialists package | `@jaggerxtrm/specialists` 3.21.1 |
+| Specialists source head verified | `05c57e568e8e11286bd159ecbc985f58e9ee5782`; #206–#208 are newer than release 3.21.1 |
+| Runtime compatibility | Core accepts Specialists `>=3.21.0 <4` and xtmux `>=0.1.0 <0.3` |
+| Changelog freshness hardening | Landed through Core #488/#489, xtmux #70/#71, and Specialists #208 |
+| Historical review state | Previous audit snapshot: 15 current unresolved threads and 4 outdated unresolved threads; recount before closure |
+| Archon | experiment/reference workflow engine, not an adopted XTRM authority |
+
+Core #488 has merged. Changelog freshness is now part of the landed maintenance baseline, not an open orchestration dependency. Core #490 is open at this snapshot but concerns service-skill orphan detection and is outside this messaging/orchestration closure wave.
+
+### 3. What is now definitively landed
+
+#### Runtime and lineage
+
+```text
+Core coordinator
+→ published pane/session/role/branch/worktree identity
+→ Specialist job branch derived from coordinator branch
+→ descendant jobs inherit root runtime origin
+→ xtrm.forensic.v1 reconstructs the chain
+```
+
+The live Suite C lane proves:
+
+- a coordinator-only commit exists;
+- the Specialist branch descends from it;
+- the job records the coordinator runtime origin;
+- the accepted branch integrates back into the coordinator branch.
+
+This closes the earlier uncertainty around whether the contracts merely existed on paper or actually composed in a real run.
+
+#### Result and event retrieval
+
+The retrieval hierarchy is now:
+
+```text
+exact coordination message
+→ xtmux message-get <message-key> --json
+
+latest completed generic agent turn
+→ xtmux agent-last <pane|session> --json
+
+structured Specialist progress
+→ sp run --json / sp feed --json
+
+complete authoritative Specialist result
+→ sp result <job-id> --json
+
+live interactive terminal state
+→ pane capture
+```
+
+Pane capture is not the result protocol.
+
+#### Branch-integration evidence
+
+```text
+Git merge/cherry-pick/PR merge
+→ sp integration record
+→ xtrm.branch.integration.v1
+→ sp integration list
+```
+
+Git remains the merge authority. The event is evidence, not a second merge state machine.
+
+#### Release and packaging
+
+- Core 0.11.2 carries the corrected xtmux compatibility range.
+- xtmux 0.2.2 uses npm Trusted Publishing through OIDC and provenance.
+- Specialists 3.21.1 packages the audit wave through PR #203.
+- xtmux release ownership between the external release driver and tag workflow is no longer duplicated.
+- package bin paths and installed-artifact contracts are covered.
+
+### 4. New architectural evidence from Specialists NDJSON
+
+PRs #206–#207 change the practical integration boundary.
+
+The structured progress path is now:
+
+```text
+sp run --json
+→ session
+→ agent_start
+→ turn/message/tool events
+→ retry/compaction events
+→ agent_end
+→ agent_settled
+```
+
+Properties that matter:
+
+- events are projected from the persisted timeline;
+- internal forensic envelopes are not leaked as the public workflow stream;
+- replay uses the persisted job worktree as `cwd`;
+- SQLite is preferred, with file fallback;
+- fallback suppresses already emitted sequences;
+- per-job order is canonical by `seq`;
+- multiple jobs are merged through a stable k-way chronological merge.
+
+This is the correct stream for Archon and future workflow adapters.
+
+It does not replace `sp result --json`, which remains the complete terminal result surface.
+
+### 5. Authority model
+
+| Concern | Authority |
+|---|---|
+| Workflow graph, dependencies, deterministic transitions | canonical chain template; Archon only inside an Archon-owned experiment |
+| Interactive coordinator placement | Core |
+| Specialist execution, status, timeline, result | Specialists |
+| Pane/session identity, messages, obligations, monitors, wakes | xtmux |
+| Durable task contract and acceptance state | Beads |
+| Branch, commit, merge truth | Git |
+| Integration observation | `xtrm.branch.integration.v1` |
+| Runtime correlation and reconstruction | `xtrm.forensic.v1` |
+| Hard operational thresholds | deterministic code |
+| Semantic judgment and exceptions | coordinator/Specialist |
+| Production mutation authority | operator or explicitly authorized workflow gate |
+
+No new work should create a competing owner for any row in this table.
+
+---
+
+## Messaging, hook, managed-instruction, and skill-contract re-audit — 2026-07-24
+
+### Purpose
+
+This section is the implementation brief for local agents assigned to align the current runtime, hook enforcement, CLI help, documentation, and orchestration skills.
+
+The operator’s primary concern is not merely whether a command exists. Agents routinely forget coordination duties. The system therefore needs all four layers to agree:
+
+```text
+small always-loaded instruction
+→ on-demand skill procedure
+→ runtime hook/extension reminder
+→ durable state and deterministic gate
+```
+
+A skill alone is insufficient. A reminder alone is insufficient. A hook matcher that depends on an exact output shape without reconciliation is insufficient.
+
+### Executive verdict
+
+| Capability | Current state | Disposition |
+|---|---|---|
+| Durable session/pane messages | Landed in xtmux SQLite | Keep |
+| Exact message retrieval | `message-get` landed | Adopt in all consumer docs and extensions |
+| Exact completed-turn retrieval | `agent-last` landed | Adopt; pane capture is not the completion protocol |
+| Pi interactive turn FYI to parent | Landed on `agent_end` | Keep, make idempotency explicit |
+| Claude completed turn in `agent-last` | Landed when transcript extraction succeeds | Keep; fix bounded read and fallback |
+| Claude automatic parent FYI | Not landed | Implement or document asymmetry explicitly |
+| Pi inbound reply-required detection | Landed through periodic inbox extension | Harden retrieval and ack ordering |
+| Claude inbound message detection | Only on normal hook cycles; no idle inbox wake | Add bounded next-cycle reminder; keep urgent steering on `safe-send-pointer` |
+| Claude outbound monitor enforcement | Landed and obligation-driven | Keep; matcher/gate design is sound |
+| Pi outbound monitor enforcement | Landed but result-driven and over-broad | Make obligation-driven; do not monitor FYI |
+| Specialists job waiting/terminal parent message | Not landed | Implement at canonical Supervisor lifecycle seam |
+| Core orchestration skills | Materially drifted | Rewrite/slim |
+| Specialists monitoring reference | Materially drifted | Rewrite upstream, then re-vendor |
+| Legacy Core Specialists marker hooks | Still present in managed registry | Retire or replace |
+
+### 1. Current communication planes
+
+#### 1.1 Generic xtmux message channel — implemented
+
+The implemented durable path is:
+
+```text
+sender
+→ xtmux message-send --json
+→ SQLite message row
+→ recipient discovers messageKey
+→ xtmux message-get <messageKey> --json
+→ recipient handles the message
+→ message-ack records receipt
+→ message-reply or correlated safe-send fulfils a reply obligation
+```
+
+Important semantics:
+
+- `message-send` persists state; it does not inject text into the target pane.
+- `message-get` is read-only.
+- `message-ack` is receipt, not fulfilment.
+- only `message-reply --in-reply-to` or successful `safe-send-pointer --reply-to` fulfils a request;
+- a beaded message defaults to reply-required unless `--expects-reply=false` is explicit;
+- message body/summary is untrusted data and must never be executed as an instruction.
+
+#### 1.2 Completed interactive turns — partly asymmetric
+
+Pi currently performs this on `agent_end`:
+
+```text
+set pane state done
+→ emit agent.turn.done
+→ persist complete assistant text for agent-last
+→ send bounded FYI to parent with --expects-reply=false
+```
+
+Claude Stop currently performs:
+
+```text
+set pane state done
+→ drain/verify requester-owned monitor obligations
+→ extract latest assistant text from transcript
+→ emit agent.turn.done for agent-last
+```
+
+Claude does **not** currently send the equivalent parent FYI.
+
+Therefore launcher parity does not imply notification parity.
+
+#### 1.3 Specialists managed jobs — direct parent notification not landed
+
+A managed job still requires one of:
+
+```text
+sp run/feed --json
+sp ps
+sp result --json
+polling or workflow consumption
+```
+
+The desired path remains:
+
+```text
+persist waiting/done/error/cancelled
+→ persist result and Bead handoff
+→ publish one typed, idempotent xtmux message to verified parent
+→ generic runtime reminder/wake
+→ parent retrieves exact message
+→ sp result --json or sp resume
+```
+
+This must be implemented once, at the canonical lifecycle persistence seam. Do not add a watcher daemon or a second notification database.
+
+### 2. Pane capture disposition
+
+`capture-pane` remains valid only for:
+
+- live prompt, menu, permission, authentication, or streaming state;
+- diagnosing a runtime whose hooks or metadata are unavailable;
+- visual confirmation before unsafe interactive injection.
+
+It is not the default for:
+
+- an exact coordination message: use `message-get`;
+- a completed generic agent turn: use `agent-last`;
+- Specialist progress: use `sp run/feed --json`;
+- a complete Specialist result: use `sp result --json`.
+
+Every updated skill must contain this hierarchy once and remove contradictory polling/scraping prose.
+
+### 3. Hook and extension matcher audit
+
+#### 3.1 Claude matcher wiring
+
+Current installer wiring is structurally valid:
+
+| Event | Matcher | Installed action | Assessment |
+|---|---|---|---|
+| `SessionStart` | none | state `idle` | Correct |
+| `UserPromptSubmit` | none | state `running` | Correct |
+| `PreToolUse` | empty/all | state `running` | Correct but broad by design |
+| `Notification` | none | state `needs-input` | Correct |
+| `PostToolUse` | `Bash` | outbound message/monitor reminder | Correct case-sensitive Claude tool matcher |
+| `PostToolUse` | `Monitor|Bash` | consume terminal wake | Correct regex matcher |
+| `Stop` | none | state `done`, monitor drain, turn capture | Correct: Stop does not use tool matchers |
+| `SessionEnd` | none | state `off` | Correct |
+
+The Claude design is robust because the Stop gate does not trust memory of the earlier Bash result. It queries durable sender-owned obligations and requires a fresh requester/target/pane-matched wait before allowing Stop.
+
+The cheap shell prefilter for outbound coordination may remain:
+
+```text
+message-send
+safe-send-pointer
+tmux send-keys
+```
+
+The Node hook must remain the authority for parsing the successful JSON result and deciding whether a reply is expected.
+
+Required refinements:
+
+1. keep the broad shell grep only as a cold-start optimization;
+2. keep the Stop obligation query as the correctness backstop;
+3. add fixtures for the current Claude `PostToolUse` payload and native `Monitor` payload;
+4. test project/user/plugin hook coexistence and installer idempotency;
+5. add next-cycle inbound message surfacing; do not claim an idle Claude session can be woken by a passive SQLite insert;
+6. use `safe-send-pointer` for urgent interactive delivery.
+
+#### 3.2 Pi matcher wiring
+
+The Pi tool matcher itself is correct:
+
+```text
+event.toolName === "bash"
+```
+
+The current weakness is the result contract, not the tool name.
+
+`coordinationResult()` intentionally recognizes only one standalone coordination JSON object. It ignores unrelated JSON, NDJSON, and multiple JSON values. This is a good trust boundary, but it means auto-monitoring is missed when an agent:
+
+- omits `--json`;
+- chains the command with another JSON-producing command;
+- wraps the result in a script that produces multiple structured values.
+
+More importantly, the parsed `message-send` result drops `expectsReply`, and `pi-auto-monitor` currently arms a monitor for every recognized send/reply/safe-send except ack. Consequences:
+
+- FYI `message-send --expects-reply=false --json` can arm an unnecessary monitor;
+- a correlated reply can arm another monitor even though the reply cannot expect a reply;
+- parser misses can suppress monitor arming entirely.
+
+Required design:
+
+```text
+tool-result parser = latency optimization
+durable obligations reconciliation = correctness authority
+```
+
+Pi must periodically reconcile sender-owned obligations and arm only missing, fresh, reply-required waits. The parser may trigger an immediate refresh but must not decide monitor necessity alone.
+
+#### 3.3 Inbound detection and agent forgetfulness
+
+Current Pi inbox behavior is useful:
+
+- pane-scoped periodic query;
+- bounded row and operation budgets;
+- one continuation at a time;
+- untrusted summaries excluded from prompts;
+- durable reconstruction after restart.
+
+But it currently acknowledges unacked messages during DB load, before successful continuation queueing, and it does not call `message-get`.
+
+The report adopts this preferred delivery contract:
+
+```text
+message-list discovers bounded keys
+→ message-get retrieves exact row
+→ validate and construct bounded reminder
+→ successfully queue follow-up/system reminder
+→ message-ack
+```
+
+If maintainers choose `ack = database read` instead, that is acceptable only if the contract, help, extension comments, tests, and report all say so. Do not keep ambiguous semantics.
+
+Pi reminder content should include:
+
+- exact validated message keys;
+- sender/bead labels only when safe;
+- explicit commands: `message-get`, then reply/cancel as appropriate;
+- no raw message summary promoted to instructions.
+
+Claude needs a bounded inbox check on normal runtime cycles:
+
+```text
+UserPromptSubmit / selected PostToolUse / Stop
+→ pane-scoped unacked/pending query
+→ inject only validated keys and exact inspection commands
+```
+
+This does not make Claude real-time while idle. Document that limitation. An urgent message uses correlated `safe-send-pointer`.
+
+### 4. Always-loaded instruction audit
+
+Current managed blocks:
+
+```text
+core/.xtrm/config/instructions/claude-top.md
+core/.xtrm/config/instructions/agents-top.md
+```
+
+correctly preserve `messageKey` and distinguish receipt from fulfilment, but they omit the behaviors agents most often forget:
+
+- use `--json` on coordination mutations when runtime automation depends on the result;
+- use `--expects-reply=false` for FYI/status/PASS;
+- after sending a reply-required message, verify a fresh monitor exists;
+- inspect pending inbound keys before long waits and before session close;
+- retrieve exact content with `message-get`;
+- retrieve completed turns with `agent-last`;
+- do not use `capture-pane` as a result protocol;
+- managed Specialist jobs use `sp result`/`sp resume`, not generic message summaries.
+
+Add one compact invariant block to both managed instructions, no more than approximately 12 lines:
+
+```text
+XTMUX COMMUNICATION INVARIANTS
+- Coordination mutations are standalone `--json` commands.
+- FYI/status/PASS use `--expects-reply=false`.
+- Decision/blocker requests preserve `messageKey` and require a fresh requester-owned monitor.
+- Read exact inbound content with `message-get`; ack only according to the declared receipt contract.
+- Fulfil through `message-reply` or successful correlated safe-send.
+- Use `agent-last` for a completed interactive turn.
+- Use `sp result` / `sp resume` for managed Specialist jobs.
+- Pane capture is live-state diagnosis only.
+- Before waiting or closing, inspect inbox, obligations, and monitors.
+```
+
+Also verify the Claude skill invocation syntax in `claude-top.md`. It currently contains `/skill-using-xtrm`, while the current Claude-facing contract elsewhere uses `/<name>` such as `/using-xtrm`. Resolve the outlier and add a test.
+
+### 5. Skill-set audit and slimming plan
+
+#### 5.1 Current weight
+
+Approximate current root lengths:
+
+| Skill | Current root size | Assessment |
+|---|---:|---|
+| `multiplexing` | ~402 lines | Too long and internally contradictory |
+| `multiplexing-team` | ~343 lines | Too long for every delegated pane |
+| `deploy-monitor` | ~265 lines | Heavy but role-specific |
+| `pr-reviewer` | ~210 lines | Moderately heavy |
+| `using-specialists` | ~258 lines | Router concept is correct, root still overloaded |
+| `using-specialists/references/monitoring.md` | ~206 lines | Phase reference, but materially stale |
+
+`chain-coordinator` force-loads both `multiplexing` and `using-specialists`. That is roughly 660 lines before any on-demand reference or task context. It undermines the coordinator’s stated purpose of avoiding parent-context monitoring rot.
+
+#### 5.2 Target structure
+
+Use progressive disclosure consistently.
+
+| Root skill | Target root | Move to references |
+|---|---:|---|
+| `multiplexing` | 120–160 lines | sprint protocol, coordinator launch, V2 internals, recovery, hygiene, deploy-gap doctrine, legacy fallbacks |
+| `multiplexing-team` | 100–140 lines | inbound/reply procedure, waits/wakes, subdelegation, sibling rules, recovery |
+| `using-specialists` | 120–150 lines | draft-Bead doctrine, title conventions, role catalog, SCRUTINY details, long examples |
+| `deploy-monitor` | 140–180 lines | provider-specific Tempo/Prometheus recipes, incident history, edge-probe implementation, sampling templates |
+| `pr-reviewer` | 120–150 lines | Codex fetch recipes, recurring hazard catalog, board examples, detailed disagreement templates |
+
+Root files should keep only:
+
+- purpose and non-goals;
+- authority boundary;
+- five to ten non-negotiable rules;
+- routing table to references;
+- minimal happy path;
+- failure/escalation trigger;
+- exact current retrieval hierarchy.
+
+Add a CI budget:
+
+```text
+router root line/byte/token budget
+reference files exempt but individually bounded
+forbid contradictory deprecated phrases
+verify every command example against CLI help fixtures
+```
+
+Suggested lint failures:
+
+- root exceeds agreed budget;
+- `capture-pane` described as final result retrieval;
+- `--background` under `sp run`;
+- `@agent_prompt_file` described as active Core launcher transport;
+- beaded FYI without `--expects-reply=false`;
+- message mutation used without `--json` in a flow that expects automation;
+- `message-list` shown as exact message retrieval without `message-get`;
+- combined `session:pane` passed where CLI expects separate session and pane flags.
+
+### 6. Per-skill required changes
+
+#### `core/.xtrm/skills/default/multiplexing/SKILL.md` — major rewrite
+
+Current contradictions include:
+
+- says no native push/custom bus is needed and default completion is polling;
+- later documents SQLite messaging and Pi auto-notification;
+- later again says back-channel notification is not primary;
+- recommends capture-pane summaries where `agent-last`, `message-get`, or structured state exist;
+- does not teach `message-get` or the retrieval hierarchy;
+- describes prompt-file metadata that Core has retired;
+- mixes operator router, sprint doctrine, deploy incidents, team-member protocol, and recovery manual in one root.
+
+Required result:
+
+```text
+multiplexing/SKILL.md = compact router and operator invariants
+references/communication.md
+references/launch-and-topology.md
+references/monitoring-and-wakes.md
+references/sprint-orchestration.md
+references/recovery-and-hygiene.md
+```
+
+#### `multiplexing-team/SKILL.md` — medium rewrite
+
+Keep:
+
+- Bead as durable contract;
+- messages as bounded pointer/decision channel;
+- ack distinct from fulfilment;
+- no multiline pane injection;
+- safe metadata handling.
+
+Change:
+
+- add `message-get`;
+- add `agent-last`;
+- document Pi/Claude asymmetry;
+- adopt the selected ack ordering;
+- remove active reliance on `@agent_prompt_file`;
+- reduce manual polling prose;
+- route detailed inbox/wake/subdelegation procedures to references.
+
+#### `deploy-monitor/SKILL.md` — correctness fixes plus slim
+
+Current contradiction:
+
+- prose says ready/PASS FYI must set `--expects-reply=false`;
+- ready and final PASS examples omit the flag and therefore create obligations.
+
+Required message policy:
+
+| Event | Message contract |
+|---|---|
+| ready | FYI, `--expects-reply=false --json` |
+| routine T+ sample OK | FYI, `--expects-reply=false --json` |
+| final PASS | FYI, `--expects-reply=false --json` |
+| HOLD | reply-required `--json` |
+| BLOCKED | reply-required `--json` |
+| irreversible decision | reply-required `--json` |
+
+Move provider recipes and incident narratives to references.
+
+#### `pr-reviewer/SKILL.md` — correctness fixes plus slim
+
+Fix addressing examples to the canonical shape:
+
+```text
+--from <session-id> --from-pane <pane-id>
+--to <session-id> --to-pane <pane-id>
+```
+
+Do not use combined `session:pane` unless the CLI explicitly adds and tests that grammar.
+
+Verdict message policy:
+
+| Verdict | Default |
+|---|---|
+| PASS | FYI |
+| PASS_WITH_NOTES | FYI unless a decision is requested |
+| NEEDS_CHANGES | reply-required or correlated interactive steer |
+| BLOCKED | reply-required |
+
+Add standalone `--json`.
+
+Explicitly distinguish this interactive sprint-judge vocabulary from the Specialists reviewer vocabulary (`PASS` / `PARTIAL` / `FAIL`). Do not silently treat them as one schema.
+
+#### `specialists/config/skills/using-specialists/references/monitoring.md` — replace upstream
+
+Remove:
+
+- “sleep timers are mandatory” as the primary doctrine;
+- direct private SQLite queries as the preferred public interface;
+- status spelling `completed`;
+- polling-first completion logic;
+- the statement that the private DB is the consumer contract.
+
+Teach:
+
+```text
+foreground run → consume returned stream/result
+background/workflow run → sp run/feed --json
+terminal truth → sp result --json
+waiting → sp result + sp resume
+generic interactive turn → agent-last
+coordination message → message-get
+```
+
+Then re-vendor the updated Specialists skill into Core. Do not patch only the vendored copy.
+
+#### `specialists/src/cli/help.ts` — help honesty
+
+Remove the impossible example:
+
+```text
+specialists run executor --background ...
+```
+
+The same help currently states native shell backgrounding elsewhere. Retain one truthful path.
+
+Resolve the contradiction between help advertising `sp merge` / `sp epic merge` and the canonical skill declaring both known-broken and prohibited. Options:
+
+1. fix and certify the commands;
+2. hide/deprecate them from help;
+3. label them explicitly unsafe/experimental.
+
+Do not leave the CLI advertising a path the canonical skill forbids.
+
+#### `specialists/config/specialists/chain-coordinator.specialist.json`
+
+Correct:
+
+- “On turn_end” to the actual Pi `agent_end` behavior;
+- state clearly that automatic parent FYI is Pi-specific today;
+- remove hard-coded full chain order when canonical chain-template resolution lands;
+- reduce the force-loaded skills after their roots are slimmed;
+- include the compact communication invariant, or depend on a small dedicated coordination skill.
+
+### 7. Legacy hook inconsistencies
+
+#### Core `specialists-complete.mjs`
+
+This hook:
+
+- reads `.specialists/ready` marker files;
+- reads per-job `status.json`;
+- injects completion only on a later Claude hook cycle;
+- deletes the marker.
+
+It is a second, Claude-only completion path outside current SQLite/NDJSON/public CLI contracts.
+
+Disposition:
+
+- retire it when direct Specialists→parent notification lands;
+- until then, clearly label it compatibility-only;
+- do not extend it;
+- add migration/removal handling to the managed hook registry.
+
+#### Core `specialists-session-start.mjs`
+
+This hook still:
+
+- scans `.specialists/jobs/*/status.json`;
+- looks for `*.specialist.yaml`;
+- reads deprecated user-scope specialist locations;
+- repeats stale CLI examples.
+
+It does not match the current JSON config and project-only model. Replace it with public CLI queries or retire it. Do not repair its private-file traversal into another long-lived API.
+
+### 8. Implementation work packages for local agents
+
+#### MSG-01 — Freeze receipt semantics
+
+**Repos:** xtmux, Core docs/skills
+**Decision:** choose one:
+
+```text
+A. ack = SQLite row read
+B. ack = successfully queued to recipient runtime
+```
+
+Recommended: **B**.
+
+**Acceptance:**
+
+- contract text exists in CLI help and README;
+- Pi extension tests prove no ack before successful queue;
+- failed queue leaves row unacked;
+- restart retries safely;
+- ack remains idempotent.
+
+#### MSG-02 — Pi obligation-driven outbound monitor reconciliation
+
+**Files:**
+
+```text
+xtmux/extensions/coordination-json.ts
+xtmux/extensions/pi-auto-monitor.ts
+xtmux/extensions/pi-inbox-reply.ts
+xtmux/tests/contracts/coordination-json.test.ts
+xtmux/tests/contracts/pi-auto-monitor.test.ts
+xtmux/tests/contracts/pi-inbox-reply.test.ts
+```
+
+**Required:**
+
+- preserve `expectsReply` in parsed send result;
+- FYI send does not arm a monitor;
+- correlated reply does not arm a monitor;
+- safe-send only arms when it creates an actual outstanding duty;
+- periodic sender-owned obligation reconciliation arms a missing fresh monitor even when tool-result parsing misses;
+- parser remains strict and ignores multi-JSON/NDJSON.
+
+#### MSG-03 — Exact inbound retrieval
+
+**Repos:** xtmux
+**Required:**
+
+```text
+message-list → bounded key discovery
+message-get → exact row
+validation → bounded runtime reminder
+successful queue → ack
+```
+
+No message summary becomes executable instructions.
+
+Add FYI policy:
+
+- decide whether FYI creates a bounded next-cycle reminder;
+- coalesce multiple FYIs;
+- do not create reply obligations;
+- terminal Specialist notifications must be visible to an active Pi parent without manual pane capture.
+
+#### MSG-04 — Claude inbox and parent-FYI parity
+
+**Files:**
+
+```text
+xtmux/hooks/claude/claude-agent-turn-capture.mjs
+new or existing Claude inbox hook
+xtmux/scripts/install.mjs
+installer and hook contract tests
+```
+
+**Required:**
+
+- send one idempotent parent FYI after a completed Claude turn, or explicitly reject parity and document it;
+- add bounded pending-message reminder on normal hook cycles;
+- no raw summaries as instructions;
+- no duplicate FYI on repeated Stop;
+- missing/malformed transcript still yields a retrievable fallback completed-turn record;
+- urgent idle delivery remains `safe-send-pointer`.
+
+#### MSG-05 — Specialists lifecycle parent notification
+
+**Repo:** Specialists
+**Seam:** the single Supervisor path that persists status/result and writes the unified Bead handoff.
+
+**Transitions:**
+
+```text
+waiting
+done
+error
+cancelled
+stalled, only if canonical
+```
+
+**Payload:**
+
+- schema/version;
+- transition;
+- job ID and Specialist;
+- Bead/chain/node IDs when present;
+- verified parent runtime identity;
+- bounded summary;
+- exact `sp result --json` or `sp resume` command;
+- trace/span correlation;
+- stable idempotency key.
+
+**Non-goals:**
+
+- no full result in message;
+- no notification database;
+- no watcher daemon;
+- no pane scraping;
+- delivery failure must not roll back job completion.
+
+#### MSG-06 — Retire compatibility notification hooks
+
+**Repo:** Core
+**Files:**
+
+```text
+.xtrm/hooks/specialists/specialists-complete.mjs
+.xtrm/hooks/specialists/specialists-session-start.mjs
+.xtrm/registry.json
+hook installer/reconcile tests
+```
+
+Either remove them in a migration-safe release or clearly quarantine them as compatibility-only until MSG-05 ships.
+
+#### DOC-01 — Rewrite canonical Specialists monitoring docs
+
+Update upstream Specialists first, then re-vendor Core.
+
+Acceptance:
+
+- no `--background`;
+- no direct private-DB recommendation;
+- current statuses;
+- NDJSON public flow;
+- `message-get` / `agent-last` / `sp result` hierarchy;
+- direct notification marked proposed until MSG-05 lands.
+
+#### DOC-02 — Slim orchestration skill roots
+
+Refactor the five roots according to the target budgets. Add references and routing tests.
+
+Acceptance:
+
+- chain-coordinator always-loaded skill content is materially smaller;
+- no policy is lost—content migration map records every moved section;
+- evaluation prompts still trigger the right reference;
+- no contradictory legacy completion doctrine remains.
+
+#### DOC-03 — Fix role-specific communication examples
+
+Update `deploy-monitor` and `pr-reviewer` message semantics, addressing, `--json`, and verdict policy.
+
+#### DOC-04 — Help/README/managed-instruction parity
+
+Update:
+
+```text
+Core managed instructions
+xtmux README/help only where runtime changes require it
+Specialists help
+Core top-level docs and skill registry
+```
+
+Generate command snippets from fixtures where practical.
+
+#### EVAL-01 — Cross-runtime hook/matcher suite
+
+The release gate must cover:
+
+| Scenario | Claude | Pi |
+|---|---:|---:|
+| reply-required standalone `message-send --json` | Stop requires fresh wait | fresh wait armed |
+| reply-required send without parseable output | Stop DB gate still catches | periodic obligation reconciliation catches |
+| FYI send | no wait required | no wait armed |
+| correlated reply | no new wait | no new wait |
+| successful wait completion | wake consumed once | wake consumed once |
+| inbound reply-required message | surfaced next normal cycle | continuation queued, then ack |
+| inbound FYI | bounded policy, no duty | bounded policy, no duty |
+| restart with pending state | reconstructed | reconstructed |
+| hostile metadata | not reflected/executed | not reflected/executed |
+| duplicate Stop/settled events | idempotent | idempotent |
+| idle urgent steering | correlated safe-send | correlated safe-send |
+
+#### EVAL-02 — Skill and documentation drift gates
+
+Add:
+
+- root size budgets;
+- command-example tests;
+- forbidden stale phrase checks;
+- upstream/vendored Specialists skill hash parity;
+- managed instruction syntax tests;
+- hook installer snapshot tests;
+- one live coordinator scenario for Pi and Claude.
+
+### 9. Updated ordering
+
+This messaging/hook/skill wave belongs between audit correctness closure and the new chain-template program:
+
+```text
+existing P1/security closure
+→ existing P2 correctness closure
+→ message/hook semantic alignment
+→ skill/docs slimming and re-vendor
+→ Specialists patch release
+→ canonical chain resolver and exact dispatch
+→ direct Specialists lifecycle notification if not already included
+→ extended live Suite C
+```
+
+MSG-05 may proceed in parallel with the documentation rewrite, but docs must not claim it landed until a released trio passes the live test.
+
+### 10. Definition of done for this wave
+
+This wave is complete only when:
+
+- no normal completion path requires pane capture;
+- Pi and Claude parity/asymmetry is explicitly documented and tested;
+- reply-required sends always result in a fresh monitor even when result parsing misses;
+- FYI sends never create reply obligations or unnecessary monitors;
+- inbound message retrieval uses the declared exact-row contract;
+- ack semantics are unambiguous and tested;
+- active Pi and Claude agents receive bounded reminders;
+- urgent idle delivery uses safe correlated injection;
+- managed Specialists transitions notify the verified parent exactly once;
+- legacy marker hooks are removed or explicitly quarantined;
+- all five skill roots meet agreed budgets;
+- Core’s vendored Specialists monitoring skill equals upstream;
+- CLI help contains no unsupported command examples;
+- managed instructions carry the compact communication invariant;
+- the live cross-runtime suite passes from packed/released artifacts.
+
+---
+
+## Track A — Audit closure
+
+### A1. Current P1 and security closure
+
+The following items remain closure blockers.
+
+#### Complete topology source ledger
+
+`xtrm.topology.projection.v1.sources` must contain exactly one result for every expected source:
+
+```text
+xtmux
+tmux
+specialists
+beads
+git
+github
+```
+
+An empty, partial, or duplicate ledger must not validate.
+
+#### xtmux Beads cursor correctness
+
+Fix both problems together:
+
+1. retain the exact raw `created_at` representation, or normalize the SQL side and cursor identically;
+2. capture the initial repository cursor before dashboard and follower startup work.
+
+Acceptance must prove:
+
+- no duplicate event on repeated polling;
+- no event loss during startup;
+- stable `(created_at, id)` progression.
+
+#### Public operational export
+
+Remove `open-issues.json` from the public Specialists tree.
+
+The repository should not expose:
+
+- live runner identifiers and labels;
+- fork or runner policy;
+- operator email addresses;
+- known security backlog;
+- infrastructure findings intended for private operational triage.
+
+The separate immutable runner-denial P0 must be verified independently; removing the export is not remediation of the underlying runner policy.
+
+### A2. Current P2 correctness closure
+
+#### Core
+
+- avoid provisional worktree creation before `--reuse` resolves an existing session;
+- make topology worktree discovery correct across repositories;
+- route obligations to the pane selected from the snapshot;
+- join PR evidence against each Specialist job branch;
+- reconcile Serena installation/support with hook matchers and permissions;
+- preserve the caller’s staged index during Semgrep recovery;
+- restore or delegate a bounded Beads cache writer for Pi-only sessions;
+- retire or quarantine the marker-based Specialists completion/session-start hooks;
+- align managed Claude/Pi instructions with `message-get`, `agent-last`, monitor duties, FYI semantics, and current Claude skill syntax;
+- slim and synchronize the multiplexing, team, deploy-monitor, and PR-reviewer skills.
+
+#### xtmux
+
+- use a positioned bounded tail read rather than full transcript `readFileSync`;
+- emit a fallback completed-turn row when Claude transcript extraction has no usable text;
+- resolve the `tmux_server_id` producer/contract discrepancy if still present in live validation;
+- freeze ack semantics and implement the chosen ordering;
+- make Pi monitor correctness obligation-driven and suppress FYI/reply over-monitoring;
+- adopt exact `message-get` retrieval in the Pi inbox path;
+- add bounded Claude inbound reminders and decide/implement parent-FYI parity;
+- add the cross-runtime hook/matcher acceptance matrix.
+
+#### Specialists
+
+- record the real temporary publication branch as the integration target;
+- reject unknown flags, missing values, and flag-shaped values in `sp integration record`;
+- establish an intentional clean test baseline for the CLI suites;
+- remove the unsupported `run --background` help example;
+- resolve help-versus-skill disagreement on merge commands;
+- replace the polling/private-DB monitoring reference with public NDJSON/result/message contracts;
+- implement typed, idempotent waiting/terminal parent notification at the canonical Supervisor seam;
+- correct and slim the chain-coordinator prompt/skill payload.
+
+### A3. Review administration
+
+Every current thread must end in one of two states:
+
+```text
+reproduced → fixed → regression test → resolved
+
+superseded → evidence-backed reply naming commit/PR → resolved
+```
+
+Merge status is not thread resolution.
+
+### A4. Release closure
+
+Specialists #206–#207 landed after 3.21.1. Cut a patch release before claiming the installed package exposes the new NDJSON contract.
+
+A coordinated release verification should execute:
+
+```text
+xt version --json
+xtmux-obs version --json
+sp version --json
+runtime compatibility preflight
+packed install smoke
+live Suite C
+sp run --json replay smoke
+```
+
+---
+
+## Track B — Deterministic orchestration
+
+Track B is the next architecture program. It is not a continuation of the bug-fix audit disguised as feature closure.
+
+### B1. Canonical chain templates and deterministic dispatch must land together
+
+The source material is:
+
+- the Specialists roadmap;
+- **Specialists Prompt, Chain Context, Interactive Coordination, Observability and Evaluation Modernization**;
+- the chain-template proposals already discussed in this report.
+
+A chain template must define:
+
+```text
+nodes
+Specialist role per node
+dependencies
+parallelism
+scrutiny level
+input/output contracts
+when conditions
+review gates
+retry
+waiting behavior
+integration authority
+target branch
+cleanup
+completion criteria
+```
+
+One canonical resolver must produce:
+
+```text
+selected template
+→ resolved DAG
+→ exact Specialist and dispatch flags
+→ parent/coordinator assignment
+→ expected notification or monitor behavior
+→ typed result contract
+→ eligible next transitions
+```
+
+Do not implement separate partial resolvers in Core, xtmux, Specialists, prompts, and Archon adapters.
+
+### B2. Direct Specialists→parent notification
+
+At the same canonical lifecycle seam where Specialists persists the result and appends the Bead handoff:
+
+```text
+persist status/result
+→ append Bead handoff
+→ send typed xtmux message to verified parent
+→ generic xtmux wake
+```
+
+Initial actionable transitions:
+
+```text
+waiting
+done
+error
+cancelled
+stalled, only if already canonical
+```
+
+The notification should contain:
+
+- schema version;
+- transition kind;
+- job ID;
+- Specialist;
+- status;
+- Bead/chain/node identifiers when available;
+- verified parent;
+- bounded summary;
+- exact `sp result` / `sp resume` / inspection command;
+- trace/span correlation.
+
+It must not contain the complete result.
+
+Delivery is best-effort relative to job completion. Do not introduce an outbox, daemon, retry worker, notification database, or Specialist-specific Pi/Claude extension until measured delivery loss requires one.
+
+### B3. Generic xtmux delivery semantics
+
+The receiving path remains:
+
+```text
+message-get
+→ continuation successfully queued
+→ message-ack
+```
+
+Do not merge these concepts:
+
+```text
+delivered
+retrieved
+receipt acknowledged
+reply obligation fulfilled
+```
+
+A terminal Specialist notification is usually reply-free FYI. A waiting notification is normally fulfilled through `sp resume`, not a coordination reply.
+
+### B4. Merge and hygiene
+
+The deterministic merge pattern is:
+
+```text
+eligible integration set computed by code
++ unresolved review blockers checked independently
++ repository/ancestry preflight
++ advisory model risk summary
++ coordinator/operator approval
+→ merge in predetermined order
+→ sp integration record
+→ independent Git/GitHub verification
+→ post-merge hygiene
+```
+
+Worktree hygiene remains proposal-first:
+
+- preserve dirty worktrees;
+- preserve unlanded commits;
+- preserve worktrees without reliable integration evidence;
+- release only resources owned by terminal jobs automatically;
+- do not auto-prune merely because a job is terminal.
+
+---
+
+## Archon conclusion
+
+### Origin of the Archon discussion
+
+The Archon analysis began from the Confluence working PRD/workflow plan:
+
+**Archon + XTRM — QuestDB Maintenance Workflow Plan**
+
+The derivation was:
+
+```text
+QuestDB workflow plan
+→ concrete read-only Archon experiment
+→ extract reusable deterministic workflow patterns
+→ compare them with XTRM chains
+→ feed the conclusions into this audit
+```
+
+### Current role
+
+Archon is:
+
+- an experimental workflow engine;
+- a builder/viewer reference;
+- a source of DAG, typed-output, deterministic-gate, approval, and verification patterns.
+
+Archon is not currently:
+
+- the XTRM source of truth;
+- the owner of Specialists jobs;
+- the owner of xtmux messages or pane identity;
+- the owner of Beads;
+- the owner of Git integration truth;
+- the default owner of XTRM worktrees.
+
+### QuestDB experiment
+
+The PRD separates:
+
+```text
+questdb-v2-maintenance-planning
+→ read-only evidence
+→ deterministic GO/NO-GO
+→ proposed plan
+
+questdb-v2-maintenance-execution
+→ approved plan only
+→ fresh preflight
+→ explicit approval
+→ checkpointed mutation
+→ verification and rollback
+```
+
+Only the planning experiment should be used to evaluate the integration initially.
+
+### Thin adapter after #206–#207
+
+The adapter can now remain genuinely thin:
+
+```text
+Archon node
+→ sp run --json
+→ consume ordered NDJSON
+→ observe terminal settlement
+→ sp result --json
+→ return typed node output
+```
+
+It must not:
+
+- scrape a pane;
+- parse human logs;
+- read private Specialists SQLite schemas;
+- create another XTRM worktree;
+- duplicate job lifecycle;
+- reinterpret a deterministic NO-GO.
+
+### Comparative experiment
+
+Run the same planning DAG in two forms:
+
+```text
+A — Archon-native nodes
+B — selected nodes delegated to Specialists
+```
+
+Score:
+
+- graph determinism;
+- role fidelity;
+- routing correctness;
+- structured-output reliability;
+- pause/resume behavior;
+- failure semantics;
+- evidence traceability;
+- preserved XTRM identities;
+- adapter size;
+- operator intervention;
+- cost;
+- UI clarity.
+
+Do not design the production mutation workflow until the read-only comparison produces evidence.
+
+---
+
+## Final implementation sequence
+
+### Phase 1 — close P1/security
+
+1. Remove the public operational export and verify runner policy.
+2. Fix xtmux Beads cursor duplication and startup loss.
+3. Enforce the complete topology source ledger.
+
+### Phase 2 — close current P2 and review threads
+
+4. Resolve Core topology/routing/reuse/Serena/index/cache findings.
+5. Resolve xtmux Claude capture and topology identity findings.
+6. Resolve Specialists integration target and parser findings.
+7. Resolve all outdated threads with evidence.
+8. Establish a clean Specialists test baseline.
+
+### Phase 2B — align messages, hooks, instructions, and skills
+
+9. Freeze receipt/ack semantics.
+10. Make Pi monitor arming obligation-driven and FYI-safe.
+11. Add exact inbound retrieval and bounded cross-runtime reminders.
+12. Add Claude completion notification parity or explicitly document/test the asymmetry.
+13. Implement typed Specialists waiting/terminal parent notification.
+14. Retire or quarantine legacy marker-based Core Specialists hooks.
+15. Rewrite and slim canonical orchestration skills, then re-vendor.
+16. Repair Specialists and xtmux/Core help/documentation parity.
+17. Run the cross-runtime matcher, restart, hostility, and packed-install suites.
+18. Release Specialists with #206–#208 and the messaging/doc changes; coordinate xtmux/Core releases if their runtime artifacts change.
+
+### Phase 3 — deterministic orchestration foundation
+
+19. Land canonical chain templates and their resolver.
+20. Land exact deterministic dispatch from that resolver.
+21. Extend live Suite C through notification, exact retrieval, integration evidence, and terminal cleanup.
+
+### Phase 4 — experiments
+
+22. Run the QuestDB Archon planning workflow natively.
+23. Run the same DAG with selected Specialists-backed nodes.
+24. Complete the scorecard.
+25. Evaluate merge FIFO and worktree hygiene separately.
+
+### Phase 5 — architecture decision
+
+26. Decide whether Archon remains:
+    - an external workflow engine for selected workflows;
+    - a workflow builder/viewer that exports canonical XTRM templates;
+    - only a reference implementation whose patterns are absorbed into XTRM.
+
+No production execution engine or Archon→Substrate compiler should be built before this decision.
+
+---
+
+## Definition of done
+
+### Audit closed
+
+The audit may be marked closed only when:
+
+- all P1/security findings are fixed;
+- all current P2 findings are fixed or explicitly rejected with evidence;
+- all review threads are resolved;
+- the installed trio passes compatibility and packed-install checks;
+- Specialists has a published release containing its current public JSON contracts;
+- ack semantics, FYI behavior, and monitor ownership are documented and enforced identically by help, skills, hooks, and tests;
+- Core has no active stale marker-based Specialists notification path;
+- the canonical orchestration skill roots meet agreed context budgets and vendored copies match upstream;
+- CLI help contains no unsupported examples;
+- live Suite C plus the cross-runtime message/hook matrix pass on the released trio.
+
+### Deterministic orchestration foundation complete
+
+The next architecture milestone is complete only when:
+
+- a versioned canonical chain template resolves to one exact dispatch plan;
+- a real coordinator dispatches a Specialist from that plan;
+- waiting/terminal state generates one typed, idempotent parent message;
+- an active parent receives a bounded reminder, retrieves the exact message with `message-get`, and acknowledges it according to the frozen receipt contract;
+- progress is available through ordered NDJSON;
+- the complete result is retrieved through `sp result --json`;
+- the accepted branch integrates into the coordinator branch;
+- integration evidence is recorded;
+- terminal owned resources are released;
+- unfinished jobs and preserved worktrees are explicitly accounted for.
+
+### Archon experiment complete
+
+The Archon investigation is complete only when:
+
+- the read-only QuestDB planning workflow has run in both variants;
+- deterministic gates cannot be overridden by model prose;
+- no duplicate authority or worktree ownership appears;
+- artifacts and XTRM identities remain traceable;
+- the comparison scorecard supports a concrete adoption decision.
+
+---
+
+## Final architectural position
+
+The system should converge on:
+
+```text
+canonical declarative chain
++ one deterministic resolver
++ exact dispatch
++ Specialists-owned execution and result
++ ordered structured progress events
++ direct typed parent notification
++ xtmux-owned delivery and wake
++ Beads-owned task contract
++ Git-owned integration truth
++ forensic correlation
++ explicit approval and cleanup
+```
+
+Archon strengthens this direction by demonstrating how DAGs, deterministic gates, typed artifacts, approvals, and independent verification can work. It should influence XTRM through measured experiments, not by taking ownership away from existing components.
+
+The previous implementation wave established the necessary substrate. The remaining audit fixes should now be closed cleanly, followed by a separate, narrowly scoped deterministic-orchestration program.
+
+---
+
+## Historical evidence and intermediate snapshots
+
+The sections below preserve the complete prior audit, delta analyses, finding matrix, and implementation rationale. Where an older section conflicts with the **Final conclusion**, the final conclusion is authoritative.
+
+## Hardening delta re-audit — later 2026-07-22
+
+### Revised verdict
+
+The latest work materially improves release safety and machine-consumable runtime behavior. It also closes two blockers identified by the preceding audit:
+
+- Core no longer rejects xtmux 0.2.x;
+- the three repositories now have coordinated release identities: Core 0.11.2, xtmux 0.2.2, Specialists 3.21.1.
+
+The system is nevertheless **not audit-closed**. The hardening work is mostly orthogonal to the unresolved topology, event-cursor, lifecycle-retrieval, public-export, integration-recording, and cleanup findings.
+
+This distinction matters:
+
+```text
+release and transport hardening improved
+≠
+all previously reproduced correctness findings fixed
+```
+
+### Latest repository state
+
+| Repository | Current source/package state | Latest material changes |
+|---|---|---|
+| Core | `xtrm-tools` 0.11.2 | xtmux compatibility widened to `<0.3`; coordinated release cut. |
+| xtmux | `@jaggerxtrm/xtmux` 0.2.2 | npm Trusted Publishing through OIDC; release workflow ownership corrected; changelog updater landed. |
+| Specialists | `@jaggerxtrm/specialists` 3.21.1 plus unreleased #206–#207 | Pi-compatible NDJSON for `sp run/feed --json`; SQLite-first replay; deterministic per-job ordering. |
+
+Core PR #488 remains open at this snapshot. Its changelog pre-push/CI enforcement is not yet landed and is not counted as completed hardening.
+
+### Closed since the previous audit
+
+#### Core↔xtmux compatibility
+
+Core now accepts:
+
+```json
+{
+  "specialists": ">=3.21.0 <4",
+  "xtmux": ">=0.1.0 <0.3",
+  "node": ">=24.0.0"
+}
+```
+
+This closes the previous blocker where Core 0.11.1 rejected xtmux 0.2.0 at launch.
+
+#### Release identity and publication pipeline
+
+- Core released 0.11.2.
+- Specialists released 3.21.1, covering the integration record/list and roleless Bead work through PR #203.
+- xtmux reached 0.2.2 and moved publication authentication from a long-lived npm token to Trusted Publishing through GitHub OIDC and provenance.
+- xtmux removed duplicate GitHub Release creation from the tag-triggered workflow because the external release driver already owns that operation.
+- xtmux gained an idempotent `[Unreleased]` updater.
+
+These are legitimate closure improvements even though they were not necessarily derived from this audit.
+
+### Specialists JSON transport: important new evidence
+
+PRs #206 and #207 substantially improve Specialists as a deterministic workflow component.
+
+`sp run --json` and `sp feed --json` now emit Pi-compatible NDJSON containing structured lifecycle records such as:
+
+```text
+session
+agent_start
+turn_start / turn_end
+message_start / message_update / message_end
+tool_execution_start / update / end
+compaction_start / end
+auto_retry_start / end
+agent_end
+agent_settled
+```
+
+The implementation projects the persisted Specialists timeline instead of exposing internal forensic envelopes or asking a consumer to parse human feed output.
+
+Review found and fixed three substantive defects before merge:
+
+1. replay/live session `cwd` used the caller checkout rather than the persisted job worktree;
+2. SQLite-success followed by file fallback could replay already emitted events;
+3. mixed timestamp/sequence sorting across jobs was non-transitive and could violate per-job ordering.
+
+The final implementation groups events by job, sorts each job stream by canonical `seq`, and performs a k-way chronological merge across queue heads.
+
+### Consequence for Archon and deterministic workflows
+
+This new NDJSON surface is now the preferred streaming boundary for a thin workflow adapter:
+
+```text
+start sp run --json
+→ consume structured Pi-compatible events
+→ correlate tools/messages/turns
+→ observe agent_end / agent_settled
+→ retrieve the authoritative final result with sp result --json
+```
+
+It removes the need to:
+
+- poll and parse the human `sp feed`;
+- scrape terminal panes;
+- infer completion from prose;
+- invent an Archon-specific Specialists event parser.
+
+The authority split remains:
+
+```text
+sp run/feed --json = structured progress stream
+sp result --json   = authoritative complete result
+Supervisor status  = authoritative job lifecycle
+```
+
+The new stream does **not** replace the proposed direct Specialists→parent xtmux message. An interactive coordinator still benefits from an automatic typed terminal/waiting notification rather than maintaining a live stream for every child.
+
+### Review and CI quality of the new hardening
+
+- Core 0.11.2 release head passed CI, Semgrep, Gitleaks, and OSV.
+- xtmux’s latest hardening head passed CI and CodeQL.
+- Specialists #207 passed Gitleaks, OSV, Semgrep, and package-payload.
+- Specialists #206 and #207 received actionable Codex review and resolved all findings raised on those PRs.
+- Several xtmux release-hardening PRs did not receive Codex review because the review quota was exhausted. Their green CI is evidence of tested behavior, not evidence of an independent semantic review.
+
+### Findings still current after the hardening delta
+
+The recent PR file scopes do not touch the following defects, and their review threads remain current and unresolved.
+
+#### Core
+
+- `xtrm.topology.projection.v1` still allows an empty, partial, or duplicated source ledger.
+- topology still collects Git worktrees from only the invocation repository while collecting panes server-wide.
+- the rendered obligations route still resolves the invoking pane rather than the selected pane.
+- the integration view still does not join PR state for each Specialist job branch.
+- Serena remains provisioned while relevant GitNexus/service-skill hook matchers omit Serena tools.
+- Semgrep recovery still uses `git reset --mixed`, which can unstage unrelated work.
+- the Pi-only footer still rereads but does not generate the Beads status cache.
+- `--subordinate --reuse` can still provision an unused worktree before session reuse is detected.
+
+#### xtmux
+
+- the Beads event follower still normalizes the stored cursor differently from the raw database timestamp, allowing repeated emission.
+- the startup Beads cursor is still captured after setup work, leaving a loss window.
+- Claude turn capture still reads the complete transcript before slicing its final 1 MiB.
+- Claude turn capture still emits no fallback completed-turn record when transcript extraction returns no text.
+
+#### Specialists
+
+- the public `open-issues.json` operational export remains tracked.
+- automatic branch-integration emission can still report the default branch instead of the temporary publication branch.
+- `sp integration record` still accepts another flag as a missing option value and can persist malformed attribution.
+- the direct typed Specialists→parent lifecycle notification has not landed.
+
+### Review-thread state
+
+The previous unresolved-thread count remains operationally relevant:
+
+| Repository | Current unresolved | Outdated unresolved | Total |
+|---|---:|---:|---:|
+| Core | 9 | 1 | 10 |
+| xtmux | 3 | 2 | 5 |
+| Specialists | 3 | 1 | 4 |
+| **Total** | **15** | **4** | **19** |
+
+Recent Specialists findings on #206 and #207 are not added to this count because they were fixed and resolved before merge.
+
+### Release caveat
+
+Specialists #206 and #207 landed **after** release 3.21.1. The source tree contains the new NDJSON and ordering fixes, but package version 3.21.1 does not identify those commits. A later patch release is needed before treating that behavior as installed-artifact evidence.
+
+Likewise, xtmux #68 and #69 landed after release 0.2.2; they harden the next release cycle rather than changing the already cut 0.2.2 package.
+
+### Updated closure priorities
+
+The compatibility and initial release-identity blockers can be removed from the closure list.
+
+The remaining minimum closure wave is:
+
+1. remove `open-issues.json` from the public repository and verify immutable runner protection;
+2. fix the xtmux Beads cursor duplication and startup loss window;
+3. enforce a complete, unique topology source ledger;
+4. close the remaining Core topology/routing/Serena/index/cache/reuse findings;
+5. fix Claude bounded-tail reading and completed-turn fallback;
+6. correct Specialists integration target and CLI argument validation;
+7. reply to and resolve all superseded review threads;
+8. establish and publish the intended Specialists test baseline;
+9. release Specialists with #206–#207 included;
+10. implement direct Specialists→parent notification and deterministic chain-template dispatch as the next architectural program.
+
+### Architectural conclusion after the new delta
+
+The latest work strengthens the planned architecture rather than replacing it.
+
+Most importantly, Specialists now has a credible structured streaming surface for workflow engines. The preferred future shape becomes:
+
+```text
+chain template resolves exact dispatch
+→ adapter starts sp run --json
+→ workflow consumes ordered structured events
+→ Supervisor persists authoritative result
+→ Specialists directly notifies the interactive parent through xtmux
+→ parent or workflow retrieves sp result --json
+→ deterministic gate selects the next node
+```
+
+This is a better foundation for the Archon comparison and for a canonical chain resolver. It does not reduce the need for direct parent notification, precise dispatch, or explicit hygiene ownership.
+
+---
+
+## Final delta re-audit — 2026-07-22
+
+### Verdict
+
+The implementation wave is **merged**, but the three-repository system is **not audit-closed**.
+
+Positive closure evidence:
+
+- the latest operator-authored PRs are merged;
+- Core’s latest PR head passed CI, Semgrep, Gitleaks, and OSV;
+- xtmux’s v0.2.0 release PR passed CI and CodeQL;
+- Specialists’ latest PR passed Gitleaks, OSV, Semgrep, and package-payload;
+- Core #484 made the global-skill migration durable;
+- Core #485 added final installed-artifact ownership checks;
+- xtmux #62 repaired npm bin packaging;
+- xtmux #63 tagged v0.2.0;
+- Specialists #203 completed the read/write surface for `xtrm.branch.integration.v1`.
+
+Audit-closure blockers:
+
+1. Core 0.11.1 still declares `xtmux >=0.1.0 <0.2`, while xtmux is now 0.2.0. Core’s launch preflight therefore rejects the final source trio.
+2. Nineteen GitHub review threads remain unresolved: fifteen non-outdated and four outdated. Code revalidation shows that one outdated xtmux finding remains substantively valid.
+3. Four P1/security findings remain live: incomplete topology source ledger, duplicate Beads event cursor, public operational issue export, and the runtime compatibility mismatch.
+4. Multiple P2 correctness findings still reproduce in current source.
+5. Specialists’ latest PR records approximately 68 pre-existing failures in `tests/unit/cli/`; the final workflow set does not provide a clean full-suite certification.
+6. The final Specialists changes remain under package version 3.21.0, whose release commit predates PRs #199–#203.
+7. The proposed direct Specialists→parent notification and canonical deterministic chain-template dispatch have not landed. They remain roadmap work, not missing implementation from the completed audit wave.
+
+### Actual final delta
+
+#### Core
+
+- #484 merged: repo-scoped skill state no longer recreates retired `default/` and `optional/` tiers.
+- #485 merged: Suite A verifies preservation of project-owned skills and flat global user packs; temporary suite sandboxes are cleaned correctly.
+- Current source head: `14ef17810d4addec0346c1a558673dae255649de`.
+- Current package version: `0.11.1`.
+
+#### xtmux
+
+- #62 merged: npm bin paths no longer use a leading `./`, preserving all seven commands during publication.
+- #63 merged and tagged: `v0.2.0`.
+- npm publication remains explicitly operator-authorized and was not performed by #63.
+- Current source head: `8eb24cb99d3d7bce71732ad5acc43fe6459926ba`.
+
+#### Specialists
+
+- #203 merged: `sp integration list` reads `xtrm.branch.integration.v1` records and composes with #201 `record`.
+- Current source head: `74b50b247c468ae4e449cf107c9b57fd24dde3c2`.
+- Current package version remains `3.21.0`; PRs #199–#203 are not represented by a new release identity.
+
+### New release blocker: Core rejects xtmux v0.2.0
+
+Current Core contract:
+
+```json
+{
+  "specialists": ">=3.21.0 <4",
+  "xtmux": ">=0.1.0 <0.2"
+}
+```
+
+Current xtmux package:
+
+```json
+{
+  "version": "0.2.0"
+}
+```
+
+Core #476 made this contract an enforced pre-worktree launch gate. Installing or linking xtmux 0.2.0 therefore causes `xt claude` / `xt pi` interactive launch to fail before worktree creation.
+
+Required disposition:
+
+- do not publish/install xtmux 0.2.0 across the fleet until Core’s compatibility contract and tests are updated;
+- validate the real trio with xtmux 0.2.0;
+- widen the range only after that live proof;
+- release/update Core and xtmux in coordinated order.
+
+### Review-thread accounting
+
+| Repository | Current unresolved | Outdated unresolved | Total |
+|---|---:|---:|---:|
+| Core | 9 | 1 | 10 |
+| xtmux | 3 | 2 | 5 |
+| Specialists | 3 | 1 | 4 |
+| **Total** | **15** | **4** | **19** |
+
+Outdated-thread disposition:
+
+- Core #485 user-pack location: fixed in later commits, thread not resolved.
+- Specialists #203 subcommand help: fixed, thread not resolved.
+- xtmux #57 temp-file permissions: fixed with a private temp directory and mode `0600`.
+- xtmux #57 bounded transcript-tail read: marked outdated by line movement, but **not fixed**; current code still calls `readFileSync(transcriptPath)` before taking the final 1 MiB.
+
+### Current P1 and security findings
+
+#### P1 — runtime compatibility mismatch
+
+Core’s enforced range rejects xtmux 0.2.0. This is a release blocker introduced by the final delta.
+
+#### P1 — topology source ledger remains incomplete by contract
+
+`xtrm.topology.projection.v1` still defines `sources` as an unconstrained array. It does not require exactly one entry for each of `xtmux`, `tmux`, `specialists`, `beads`, `git`, and `github`, nor uniqueness.
+
+#### P1 — xtmux Beads cursor still duplicates ISO rows
+
+Current `follow_beads()` still transforms the cursor:
+
+```bash
+.created_at | sub("T"; " ") | rtrimstr("Z")
+```
+
+but compares it against unchanged database `created_at`. ISO values containing `T` can remain greater than the normalized cursor containing a space, causing repeated emission.
+
+#### P1 / security — `open-issues.json` remains public
+
+The repository still tracks an operational export containing a known critical runner vulnerability, runner identity/labels, fork policy, operator email addresses, and internal security backlog.
+
+Required disposition:
+
+- remove it from the public tree;
+- keep future exports outside version control;
+- assess history cleanup and exposure;
+- independently verify whether immutable runner denial has been implemented externally.
+
+### Current P2 correctness findings
+
+#### Core #465 — reuse can orphan a provisional worktree
+
+`--subordinate --reuse` may create a worktree before session reuse is detected, leaving the extra branch and checkout behind.
+
+#### Core #468 — cross-repository worktree projection remains incomplete
+
+`collectProjection()` queries worktrees only from the invocation `cwd`, while pane collection spans the tmux server. Panes from another repository cannot resolve their worktrees correctly.
+
+#### Core #469 — obligations route uses the invoking pane
+
+The rendered command still resolves `#{pane_id}` at execution time rather than using the pane selected in the projection.
+
+#### Core #469 — integration view omits Specialist-job PR state
+
+The integration table shows Specialist job branches, but PR state is read only from `pane.pull_request`, which represents the coordinator/pane branch.
+
+#### Core #470 — Serena provisioning and hook policy disagree
+
+Core still installs Serena, while GitNexus and service-skill policies no longer match Serena navigation and mutation tools.
+
+#### Core #471 — semgrep recovery unstages unrelated work
+
+Recovery still runs `git reset --quiet --mixed`, preserving bytes but resetting the caller’s index.
+
+#### Core #473 — Pi-only footer has no Beads cache writer
+
+The Pi footer only reads and rereads `.xtrm/cache/beads-status.json`; it does not regenerate it.
+
+#### xtmux #56 — startup cursor can lose Beads events
+
+The Beads cursor is captured after dashboard/setup work and other followers, so mutations in that interval are excluded by the strict newer-than query.
+
+#### xtmux #57 — Claude `agent-last` fallback remains missing
+
+The Stop hook returns when transcript extraction yields no text; no fallback completed-turn enrichment is emitted.
+
+#### xtmux #57 — transcript tail remains unbounded I/O
+
+The hook reads the complete transcript, then slices the last 1 MiB.
+
+#### Cross-repo topology contract — `tmux_server_id`
+
+Core’s `xtrm.xtmux.topology.v1` requires `host.tmux_server_id`. Review evidence from xtmux #61 records that the producer emitted only `host_id`, and no later topology implementation PR followed #61.
+
+#### Specialists #199 — automatic merge event can record the wrong target branch
+
+The automatic emitter still falls back to the default branch, even when publication merges into a temporary PR branch.
+
+#### Specialists #201 — flag-shaped values can corrupt integration records
+
+The parser blindly consumes the next argv token as a value. A missing value can consume another flag and persist malformed attribution; the unique integration key may then prevent correction.
+
+#### Specialists test health
+
+The latest PR documents approximately 68 pre-existing `tests/unit/cli/` failures. Targeted and security/package checks pass, but no clean full-suite proof exists for the current head.
+
+### Landed and verified improvements
+
+The re-audit confirms these are complete:
+
+- runtime compatibility is enforced before worktree creation;
+- Specialist branches inherit coordinator ancestry;
+- live Suite C proves ancestry, runtime origin, and integration;
+- topology carries role/worktree/branch/parent-pane lineage;
+- external merges can write integration evidence;
+- integration evidence has a public read surface;
+- roleless Bead turn-1 rendering exists;
+- completed generic agent turns and exact messages have read surfaces;
+- xtmux Claude hook installation converges;
+- Core’s global-skill migration no longer recreates retired repo tiers;
+- latest available PR workflows are green.
+
+### Roadmap items not landed
+
+These are roadmap items, not regressions in the completed wave:
+
+- direct typed Specialists→parent lifecycle notification;
+- `xtrm.specialist.parent-notification.v1`;
+- canonical deterministic chain-template resolver;
+- precise dispatch derived from the roadmap and modernization templates;
+- Archon/XTRM production integration;
+- automatic worktree pruning;
+- production QuestDB execution workflow.
+
+### Minimum closure wave
+
+1. Repair Core↔xtmux 0.2 compatibility and run the real trio.
+2. Remove `open-issues.json` and verify external runner denial.
+3. Fix the xtmux Beads cursor P1.
+4. Fix the Core topology source-ledger P1.
+5. Fix or formally dispose every current review finding.
+6. Reply to and resolve all outdated threads.
+7. Establish a clean, intentional Specialists test baseline.
+8. Cut coordinated releases so package versions and installed artifacts identify the same code.
+
+Only then should the audit state move from **implementation merged** to **system closed**.
+
+---
+
+## 1. Executive decision
+
+The current XTRM stack already contains most of the primitives required for deterministic orchestration:
+
+- Core launches coordinators and subordinate runtimes, owns interactive worktree placement, and publishes agent branch/runtime metadata.
+- Specialists owns specialist job execution, lifecycle, result persistence, Bead handoff, runtime lineage, and subordinate worktrees.
+- xtmux owns pane/session identity, messages, reply obligations, monitors, wakes, topology, event transport, and completed-agent-turn retrieval.
+- Beads owns durable work contracts and task acceptance state.
+- Git owns branch, commit, merge, and integration truth.
+- `xtrm.forensic.v1` owns reconstructable runtime evidence and correlation.
+- Archon is being evaluated as an external declarative workflow engine, not adopted as an XTRM authority.
+
+The main remaining weakness is not missing observability. It is that orchestration still depends too often on an agent remembering procedural machinery:
+
+```text
+dispatch
+→ remember to poll sp ps / sp feed
+→ infer a transition
+→ remember to retrieve sp result
+→ remember to dispatch the next node
+→ remember to integrate the branch
+→ remember to stop or clean jobs
+```
+
+The immediate correction is narrower:
+
+```text
+Specialists persists a meaningful transition
+→ Specialists sends one typed xtmux message to the assigned parent
+→ xtmux performs its existing generic delivery and wake behavior
+→ the parent reads the message
+→ sp result --json remains the authoritative complete result
+→ the chain template determines the eligible next step
+```
+
+No Specialists-specific Pi extension, Claude hook pipeline, notification database, daemon, or result protocol should be added in the first implementation.
+
+---
+
+## 2. Evidence classification
+
+This document uses four evidence classes.
+
+| Class | Meaning |
+|---|---|
+| **Landed** | Merged and available in the repository snapshot. |
+| **Open** | Active PR or explicitly unresolved implementation work. |
+| **Needs revalidation** | Previously observed defect or review finding that may have been affected by later merges. |
+| **Experimental** | Archon workflow behavior being tested; not an adopted XTRM contract. |
+
+Claims about architecture must not silently promote experimental behavior into landed behavior.
+
+---
+
+
+## 3. Prior audit baseline and disposition
+
+This section preserves the findings and contract conclusions established before the Specialists notification and Archon discussion. It is intentionally explicit so the document does not depend on conversation history.
+
+### 3.1 Original audit scope
+
+The original audit covered `xtrm-dev/core`, `Jaggerxtrm/xtmux`, and `xtrm-dev/specialists` as one runtime system rather than as isolated repositories.
+
+The requested work included:
+
+- inspect recent merged and open PRs as the freshest implementation evidence;
+- inspect releases when they were newer than repository documentation;
+- reconcile the existing `open-issues.json` inventory against current code;
+- identify work that was completed, superseded, duplicated, mis-prioritized, or still active;
+- inspect unresolved Codex review findings rather than treating merge status as review completion;
+- verify runtime compatibility and packed-install behavior;
+- verify coordinator, subordinate, worktree, pane, session, branch, Bead, and Specialist lineage;
+- identify stale canonical and vendored skill guidance;
+- distinguish observability evidence from operational authority;
+- produce a later Jira/epic reorganization only after operator approval.
+
+The audit must continue to treat recent code and live contracts as stronger evidence than stale planning documents.
+
+### 3.2 Prior unresolved-review snapshot
+
+At the prior audit snapshot there were **16 unacknowledged Codex findings**:
+
+- **14 current unresolved findings**;
+- **2 unresolved findings considered outdated by later code**, but still requiring an evidence-backed reply and explicit thread resolution.
+
+This count is historical. It must be re-enumerated against the current PR heads before closure because later merges may have fixed, moved, or invalidated individual findings.
+
+A merge does not imply that review obligations are complete.
+
+### 3.3 Prior finding disposition matrix
+
+| Repository / reviewed PR | Severity | Original finding | Current disposition | Later evidence that may affect it | Remaining action |
+|---|---:|---|---|---|---|
+| Core #467 | P1 | The topology `sources` ledger could be empty, partial, or duplicate, making the projection unable to explain which source contributed each fact. | **Needs revalidation** | Core #479 and xtmux #61 widened and populated agent topology fields, but they do not by themselves prove source-ledger completeness or deduplication. | Reproduce against the current aggregation path; fix once in the shared projection ledger if still present. |
+| xtmux #56 | P1 | Timestamp cursor normalization could compare ISO and stored timestamp forms inconsistently and repeatedly select the same Beads rows. | **Needs revalidation; not known closed** | Later event rendering did not explicitly claim to change cursor semantics. | Test mixed timestamp forms and repeated polling against current main; preserve `(created_at, id)` monotonicity. |
+| Specialists #199 | P1 / security | A public `open-issues.json` artifact reportedly exposed runner, security, operator, or environment details inappropriate for a public repository. | **Needs immediate revalidation** | Later Specialists PRs did not explicitly claim removal or redaction. | Confirm whether the artifact remains public; remove, redact, or relocate sensitive operational content. |
+| Core #465 | P2 | `--subordinate --reuse` could provision or retain an orphan worktree when the reuse path did not complete cleanly. | **Needs revalidation** | Live Suite C proves normal ancestry/integration, not reuse failure cleanup. | Exercise reuse success, rejection, timeout, and launcher failure; assert no unowned worktree remains. |
+| Core #468 | P2 | Cross-repository worktrees could disappear from aggregation because discovery or projection remained repository-local. | **Needs revalidation** | xtmux #61 improves remote pane lineage; it does not prove cross-repository worktree inventory completeness. | Test a parent and Specialist spanning different repositories and verify one coherent topology view. |
+| Core #469 | P2 | Obligation routing could associate the wrong pane, and PR state could be derived from the coordinator/current branch rather than the job branch. | **Partially superseded; still needs separate checks** | xtmux #61 publishes `parent_pane_id`; Specialists #200 fixes branch ancestry; #201 records external integration. | Verify requester/target pane routing and job-branch PR lookup independently. Do not close one because the other improved. |
+| Core #470 | P2 | Serena matcher/configuration was removed from one surface while Serena was still provisioned or referenced elsewhere. | **Needs revalidation** | Global-skill migration work changed provisioning paths but did not explicitly close this contract mismatch. | Trace every Serena provisioner, matcher, skill reference, and runtime registration; delete or restore one canonical path. |
+| Core #471 | P2 | A mixed/reset operation could unstage unrelated operator work rather than only the files owned by the workflow. | **Needs revalidation** | No later PR reviewed in this audit explicitly claims this ownership-bound reset fix. | Reproduce with unrelated staged changes; replace broad reset with path-scoped ownership-safe behavior. |
+| Core #473 | P2 | The footer could retain stale agent/runtime state in Pi-only sessions. | **Needs revalidation** | Core #473 substantially simplified the footer into a cache reader, which may supersede the original symptom but does not automatically resolve the review thread. | Run the original stale-state reproduction against current main; reply with evidence and resolve or fix. |
+| xtmux #56 | P2 | Startup cursor capture could race with rows written during initialization and skip or duplicate events. | **Needs revalidation; not known closed** | Later human rendering is unrelated. | Add a deterministic startup-concurrency test around cursor establishment and first poll. |
+| xtmux #57 | P2 | Claude transcript extraction failure could suppress full turn enrichment, causing `agent-last` to report not found despite a completed turn. | **Needs revalidation; high operational relevance** | No later PR explicitly claims a fallback that persists the completed turn when transcript parsing fails. | Simulate malformed/missing transcript; persist bounded fallback output or explicit unavailable reason without suppressing the turn row. |
+| Specialists #199 | P2 | Reported integration target branch could be incorrect. | **Partially superseded** | Specialists #200 establishes coordinator branch ancestry; #201 publishes integration recording with explicit target fields. | Verify actual result/status output, forensic events, and integration rows all report the same target branch. |
+| Two prior review threads | Outdated | Later commits appeared to invalidate the comments, but the threads remained unresolved. | **Administrative closure still required** | Exact identities must be re-enumerated from GitHub. | Reply with the superseding commit/PR and resolve explicitly; do not silently ignore them. |
+
+The matrix records the original defect class, not a claim that each problem still reproduces. The closure rule is evidence, not age.
+
+### 3.4 Prior requirements that have since landed
+
+Several requirements identified during the earlier audit now have direct implementation evidence.
+
+| Requirement | Evidence | Disposition |
+|---|---|---|
+| Publish build identity through machine-readable CLI output | Core and Specialists audit PRs; xtmux build identity work | Landed |
+| Reject incompatible runtime combinations before creating an interactive worktree | Core #476 | Landed |
+| Run packed installer/update smoke earlier on relevant PRs | Core #477 | Landed |
+| Publish coordinator role, branch, worktree, and parent-pane lineage through topology | Core #479 + xtmux #61 | Landed |
+| Make Specialist job branches descend from the coordinator branch | Specialists #200 | Landed |
+| Prove ancestry, runtime origin, and integration in a real opt-in lane | Core #475 | Landed |
+| Record integration performed outside `sp merge` | Specialists #201 | Landed |
+| Render a Bead turn-1 body for roleless launches | Specialists #202 | Landed |
+| Retrieve full completed generic agent turns without pane capture | xtmux #57 `agent-last` | Landed, with transcript-fallback caveat |
+| Retrieve exact coordination message bodies | xtmux #57 `message-get` | Landed |
+| Converge duplicate Claude hook registrations | xtmux #58 | Landed |
+| Stream canonical Beads lifecycle events rather than duplicate hook facts | xtmux #56 | Landed, with cursor caveats pending revalidation |
+
+### 3.5 Completed-turn and message semantics established by the earlier audit
+
+The earlier audit established three distinct retrieval planes.
+
+| Need | Canonical surface | Semantics |
+|---|---|---|
+| Exact coordination body | `xtmux message-get <message-key|id> --json` | Reads the durable message body. It does not mean the message was processed and does not retrieve a generic agent's full turn. |
+| Latest completed generic agent response | `xtmux agent-last <pane|session> --json` | Reads the bounded full completed turn stored in `agent_turns.last_message_text`, subject to the Claude transcript caveat. |
+| Live terminal state | pane capture | Used for streaming output, prompts, menus, authentication, or other state not represented by a completed result. |
+
+The Pi child-to-parent completion path added with xtmux #57 stores the full response separately but sends only a compact one-line FYI summary to the parent. Therefore:
+
+```text
+automatic parent FYI
+≠ full completed response
+```
+
+The parent must use `agent-last` when the full generic-agent conclusion is required.
+
+For Specialists, the authoritative complete output remains:
+
+```text
+sp result <job-id> --json
+```
+
+### 3.6 Pane-capture conclusion
+
+No hard technical prohibition against `tmux capture-pane` was landed.
+
+The intended policy is semantic:
+
+```text
+completed coordination message → message-get
+completed generic agent turn    → agent-last
+completed Specialist job        → sp result --json
+live terminal interaction       → pane capture
+```
+
+At the earlier snapshot, Core's canonical `multiplexing` skill still recommended capture for several ordinary result-discovery and preflight paths. Those instructions must be re-audited and corrected in the canonical source, then re-vendored.
+
+### 3.7 Message acknowledgement conclusion
+
+`message-get` should remain a pure read operation because it is also useful to:
+
+- consoles and viewers;
+- forensic tooling;
+- an orchestrator inspecting another participant;
+- retries and previews.
+
+The receiving runtime should use:
+
+```text
+message-get
+→ successfully queue the continuation
+→ message-ack
+```
+
+This preserves at-least-once delivery and avoids acknowledging a message before its content reaches the model.
+
+Do not conflate:
+
+- wake delivered;
+- message retrieved;
+- receipt acknowledged;
+- correlated reply obligation fulfilled.
+
+A Specialist completion notification is normally reply-free FYI. A Specialist waiting transition normally requires `sp resume`, not `xtmux message-reply`.
+
+### 3.8 Pi wake behavior observed during the earlier audit
+
+The existing Pi coordination extension already:
+
+- polls durable messages expecting replies and durable reply obligations;
+- acknowledges receipts through the coordination path;
+- renders bounded widget/system metadata;
+- consumes terminal wakes with `wait-agent --consume`;
+- sends one follow-up wake;
+- intentionally avoids injecting untrusted inbound message summaries as executable instructions.
+
+The missing bridge at that snapshot was precision. The continuation text was generic and did not reliably carry:
+
+- the exact message key;
+- the exact `message-get` command;
+- the source pane/session for `agent-last`;
+- a typed distinction between a coordination message and a completed-agent notification.
+
+The proposed Specialists direct-message design reduces the need for a Specialists-specific extension. It does not remove the requirement that the generic Pi message wake preserve the stable message key and exact retrieval instruction.
+
+### 3.9 Claude wake behavior observed during the earlier audit
+
+The existing Claude hook path already:
+
+- emits the native `Monitor(... wait-agent ... --consume)` continuation;
+- consumes terminal wakes idempotently;
+- uses xtmux monitor/wake state rather than a new Specialists state store.
+
+The earlier gap was similar:
+
+- no typed Specialists transition payload;
+- no direct instruction to retrieve a Specialist result;
+- no guarantee of Pi/Claude wording parity;
+- no automatic child-to-parent completion FYI parity proven for every Claude path.
+
+The current plan should therefore send one ordinary typed xtmux message from Specialists. Claude should receive it through the generic xtmux coordination path, not through a new Specialists completion hook.
+
+### 3.10 Why typed completion metadata was considered
+
+The compact Pi FYI was originally free-form text. Free-form text makes it difficult to select reliably between:
+
+```text
+message-get <message-key>
+agent-last <source-pane>
+sp result <job-id>
+```
+
+A typed Specialists parent notification is justified because it provides stable fields such as:
+
+- transition kind;
+- job ID;
+- parent job ID;
+- Specialist role;
+- Bead and chain IDs;
+- exact result/action command;
+- correlation IDs.
+
+For generic agent-turn FYIs, a later improvement may add typed source pane/session or turn ID metadata. That is separate from the Specialists notification package and should not be bundled without a concrete consumer.
+
+### 3.11 Prior audit closure requirements
+
+The consolidated audit is not complete until:
+
+1. every previously unresolved review thread is re-enumerated;
+2. every current finding has a reproduction or supersession proof;
+3. every outdated finding receives an explicit evidence-backed response;
+4. open-issue inventory is reconciled against landed PRs and current defects;
+5. canonical skills are updated and vendored copies are regenerated;
+6. packed-install and runtime compatibility checks pass;
+7. the live cross-repository lane proves ancestry, routing, result retrieval, integration evidence, and cleanup;
+8. remaining work is grouped into implementation packages or epics only after the technical disposition is known.
+
+---
+
+## 4. Updated repository evidence
+
+### 4.1 Core
+
+Recent work materially closes several earlier audit gaps.
+
+| Evidence | Status | Consequence |
+|---|---:|---|
+| Core PR #475 — opt-in live Suite C lane | Landed | A real coordinator dispatches a real Specialist, verifies coordinator-branch ancestry, runtime origin, and integration back into the coordinator branch. |
+| Core PR #476 — runtime compatibility preflight | Landed | Incompatible Core/xtmux/Specialists combinations are rejected before worktree creation. |
+| Core PR #477 — PR installer smoke | Landed | Installer/runtime surface changes receive an earlier packed-install smoke. |
+| Core PR #479 — topology contract widening | Landed | `role`, `worktree`, `branch`, and `parent_pane_id` are accepted in `xtrm.xtmux.topology.v1`. |
+| Core PR #483 — prune retired empty skill tiers | Landed | Global-skill migration residue is reduced. |
+| Core PR #484 — stop repo scope from recreating retired tiers | **Open** | The migration is not fully durable until this merges. |
+
+Implication: branch ancestry, runtime compatibility, and topology contract gaps are no longer speculative design work. Follow-up work should reuse these landed contracts.
+
+### 4.2 xtmux
+
+| Evidence | Status | Consequence |
+|---|---:|---|
+| xtmux PR #56 — canonical Beads lifecycle event streaming | Landed | xtmux can observe canonical Beads mutations without duplicating lifecycle authority. |
+| xtmux PR #57 — full completed turns, `agent-last`, `message-get` | Landed | Completed agent conclusions and exact coordination messages are retrievable without pane capture. |
+| xtmux PR #58 — idempotent Claude hook installation | Landed | Duplicate lifecycle hook execution self-heals on install. |
+| xtmux PR #60 — human event rendering and `xtmux-events` | Landed | The event journal is more usable without changing its machine format. |
+| xtmux PR #61 — topology publishes role/worktree/branch/parent pane | Landed | Remote topology no longer needs a second local tmux read to reconstruct agent lineage. |
+
+Implication: xtmux already has the delivery, identity, wake, topology, and retrieval primitives needed by Specialists. A new notification runtime would duplicate existing functionality.
+
+### 4.3 Specialists
+
+| Evidence | Status | Consequence |
+|---|---:|---|
+| Specialists PR #199 — `xtrm.branch.integration.v1` primitive | Landed | Integration can be recorded as evidence without replacing Git as authority. |
+| Specialists PR #200 — job branches derive from coordinator branch | Landed | Specialists see coordinator work and can return changes to the correct branch lineage. |
+| Specialists PR #201 — `sp integration record` | Landed | Manual, `xt`, or GitHub-driven merges can record the integration result through a public Specialists CLI. |
+| Specialists PR #202 — `sp render-bead` | Landed | Bare Bead launches can receive a deterministic turn-1 task body without inventing a Specialist role. |
+| Direct Specialists→parent lifecycle notification | **Not landed** | The parent still lacks a Supervisor-originated typed completion/waiting/failure message. |
+| Automatic terminal resource cleanup audit | **Open** | Existing `sp clean` capabilities do not prove every owned runtime resource is released at the terminal transition. |
+
+Implication: the correct notification seam is now easier to identify. Specialists already performs result persistence and Bead handoff at completion; message publication belongs beside that existing operation.
+
+---
+
+## 5. Architectural ownership
+
+The system must preserve one authority per concept.
+
+| Concept | Authority |
+|---|---|
+| Workflow graph and workflow-local node state | Chain template or experimental Archon workflow |
+| Interactive worktree and coordinator placement | Core |
+| Specialist job lifecycle and complete result | Specialists |
+| Pane/session identity and live runtime routing | xtmux |
+| Message delivery, reply obligations, monitors, and wakes | xtmux |
+| Durable task contract and acceptance state | Beads |
+| Branch, commit, and merge truth | Git |
+| Branch-integration observation | `xtrm.branch.integration.v1` |
+| Runtime evidence and correlation | `xtrm.forensic.v1` |
+| Operational GO/NO-GO thresholds | Versioned deterministic code |
+| Semantic judgment and exception handling | Coordinator or Specialist |
+| Final production authority | Operator |
+
+A component may reference another component’s record. It must not silently become the canonical owner of that state.
+
+---
+
+## 6. Design rule: push transitions, do not poll lifecycle
+
+`sp ps` and `sp feed` remain valuable operator and recovery surfaces. They should not be the normal orchestration protocol.
+
+### Current weak path
+
+```text
+parent dispatches Specialist
+→ parent polls sp ps or sp feed
+→ parent detects done/waiting/error
+→ parent executes sp result
+→ parent reconstructs chain context
+```
+
+Weaknesses:
+
+- repeated process and database reads;
+- agent attention consumed by supervision;
+- missed transitions when the agent forgets to poll;
+- no automatic wake;
+- duplicated result-discovery instructions;
+- follow-up dispatch depends on memory rather than the chain contract;
+- orphaned jobs and sessions are easy to overlook.
+
+### Target path
+
+```text
+Supervisor changes authoritative state
+→ result and handoff are persisted
+→ typed xtmux message is sent to the assigned parent
+→ xtmux uses the existing generic wake path
+→ parent retrieves the complete result with sp result --json
+→ workflow template exposes the next eligible transition
+```
+
+Polling remains available for:
+
+- live diagnostics;
+- recovery after unavailable routing;
+- human dashboards;
+- forensic investigation;
+- old runs without runtime origin.
+
+---
+
+## 7. Specialists direct parent notification
+
+### 7.1 Correct implementation seam
+
+Specialists already has a shared handoff path that:
+
+- formats a unified handoff;
+- appends it to the input Bead;
+- records append failures without failing the run;
+- optionally writes an output artifact.
+
+The parent notification must be emitted from the same completion/waiting lifecycle seam, after authoritative state and result persistence.
+
+Conceptually:
+
+```ts
+persistStatusAndResult();
+appendResultToInputBead();
+notifyAssignedParent();
+```
+
+Do not add notification behavior to:
+
+- `sp feed`;
+- `sp ps`;
+- the CLI result reader;
+- a new Pi extension;
+- a new Claude-specific hook;
+- the legacy ready-marker scanner.
+
+### 7.2 Notification states
+
+Initial implementation should publish only transitions requiring orchestration attention:
+
+- `waiting`;
+- `done`;
+- `error`;
+- `cancelled`;
+- `stalled`, only if this is already a canonical Supervisor transition.
+
+Do not publish:
+
+- streaming text;
+- thinking;
+- every tool call;
+- heartbeats;
+- repeated unchanged status snapshots.
+
+### 7.3 Routing precedence
+
+The target must be derived from verified lineage, never guessed.
+
+1. Explicit assigned parent target, if the dispatch contract already provides one.
+2. Immediate verified parent runtime origin.
+3. For a child Specialist job, resolve the parent job and use its verified runtime target.
+4. Verified root runtime origin.
+5. No target: do not send; retain result, Bead handoff, forensic evidence, and legacy fallback behavior.
+
+A root pane must not receive a duplicate when the immediate parent is already the correct coordinator.
+
+### 7.4 Minimal shared schema
+
+A schema is justified here because the payload crosses Specialists, xtmux, and an agent runtime.
+
+Recommended schema name:
+
+```text
+xtrm.specialist.parent-notification.v1
+```
+
+Minimum envelope:
+
+```json
+{
+  "schema_version": "xtrm.specialist.parent-notification.v1",
+  "kind": "job.completed",
+  "job_id": "49adda",
+  "specialist": "reviewer",
+  "status": "done",
+  "bead_id": "unitAI-123",
+  "parent_job_id": null,
+  "chain_id": "chain-abc",
+  "node_id": "review",
+  "summary": "Review completed with PASS_WITH_FOLLOWUPS.",
+  "result_command": "sp result 49adda --json",
+  "inspect_command": "sp log 49adda --limit 200",
+  "action_command": null,
+  "correlation": {
+    "trace_id": "...",
+    "span_id": "..."
+  }
+}
+```
+
+For a waiting run:
+
+```json
+{
+  "schema_version": "xtrm.specialist.parent-notification.v1",
+  "kind": "job.waiting",
+  "job_id": "49adda",
+  "specialist": "debugger",
+  "status": "waiting",
+  "bead_id": "unitAI-123",
+  "summary": "A compatibility decision is required.",
+  "result_command": "sp result 49adda --json",
+  "inspect_command": "sp log 49adda --limit 200",
+  "action_command": "sp resume 49adda \"<answer>\""
+}
+```
+
+Rules:
+
+- `summary` is bounded.
+- Full output is never copied into the message.
+- `sp result --json` remains authoritative.
+- Commands are generated by Specialists, not inferred by the receiving LLM.
+- No raw prompt, terminal capture, secret, or unrestricted environment data enters the payload.
+- Missing optional correlation fields remain absent; values are never fabricated.
+
+The schema should live in the existing shared contracts package only if more than one repository parses it. xtmux may transport the body opaquely.
+
+### 7.5 Delivery semantics
+
+Message publication is best-effort relative to job completion:
+
+```text
+job succeeds + message delivery fails
+→ job remains successful
+→ message failure is recorded
+```
+
+Initial implementation should not add:
+
+- a notification outbox;
+- retry worker;
+- notification database;
+- delivery daemon;
+- `sp notifications` command group.
+
+Add durable retry only after measured evidence shows message loss is operationally significant.
+
+### 7.6 `xtrm.forensic.v1`
+
+The message is delivery. Forensics is evidence.
+
+Emit an existing-schema forensic event for:
+
+```text
+coordination.parent_notification.sent
+coordination.parent_notification.failed
+```
+
+Correlate, where available:
+
+- job ID;
+- parent job ID;
+- Bead ID;
+- chain ID and chain root;
+- node ID;
+- pane/session/agent instance;
+- trace/span;
+- branch and commit evidence;
+- returned xtmux message key.
+
+The event must record outcome and identifiers, not the full model output.
+
+### 7.7 Generic wake behavior
+
+No Specialists-specific wake extension is required.
+
+The existing xtmux message delivery path should wake Pi or Claude in the same way as any other coordination message. The receiving continuation should direct the agent to:
+
+```text
+xtmux message-get <message-key> --json
+sp result <job-id> --json
+```
+
+`message-get` should remain read-only. Receipt acknowledgement belongs after the runtime has successfully queued the continuation, preserving the distinction between:
+
+- message delivered;
+- message inspected;
+- receipt acknowledged;
+- reply obligation fulfilled.
+
+A Specialists completion notification is normally an FYI, not a reply obligation.
+
+---
+
+## 8. Completed output retrieval hierarchy
+
+The canonical guidance across Core and Specialists skills should be:
+
+```text
+Exact coordination message
+→ xtmux message-get <message-key> --json
+
+Latest completed generic agent turn
+→ xtmux agent-last <pane|session> --json
+
+Complete Specialist result
+→ sp result <job-id> --json
+
+Live terminal/UI/auth/interactive state
+→ pane capture
+```
+
+`capture-pane` must not be the standard mechanism for retrieving a completed conclusion or Specialist result.
+
+The Core `multiplexing` and `multiplexing-team` skills must be re-audited and updated wherever they still recommend capture for result discovery, model detection, or ordinary sibling inspection.
+
+---
+
+## 9. Monitors after direct notification
+
+Direct Specialist lifecycle notification reduces, but does not eliminate, monitors.
+
+### Do not create a redundant monitor when
+
+- Specialists already owns the lifecycle;
+- a verified parent target exists;
+- the required transition is `waiting` or terminal;
+- Specialists will publish that transition directly.
+
+### Keep or automatically create a monitor when
+
+- the target is a generic agent pane rather than a Specialist job;
+- the requester needs timeout semantics independent of agent completion;
+- the task is interactive and does not produce a Specialists result;
+- the parent target cannot receive direct lifecycle messages;
+- a workflow gate explicitly requires a bounded wait.
+
+Monitor creation must occur in the dispatch/launcher path, not as an instruction the agent must remember after dispatch.
+
+---
+
+## 10. Deterministic chain templates
+
+The chain template should move procedural decisions out of model memory.
+
+A mature template should declare:
+
+- nodes and Specialist roles;
+- dependencies;
+- allowed parallelism;
+- input and output schemas;
+- deterministic `when` conditions;
+- retry limits;
+- waiting behavior;
+- review gates;
+- integration authority and target branch;
+- operator approvals;
+- terminal cleanup behavior;
+- failure and cancellation behavior;
+- chain completion criteria.
+
+Example:
+
+```yaml
+nodes:
+  - id: implement
+    specialist: executor
+    output_type: implementation-result
+
+  - id: test
+    specialist: test-runner
+    depends_on: [implement]
+    when: "$implement.output.status == 'complete'"
+
+  - id: review
+    specialist: reviewer
+    depends_on: [test]
+    when: "$test.output.verdict == 'PASS'"
+
+  - id: integrate
+    action: integrate-specialist-branch
+    depends_on: [review]
+    when: "$review.output.verdict == 'PASS'"
+    approval: coordinator
+
+  - id: cleanup
+    action: cleanup-owned-runtime
+    depends_on: [integrate]
+```
+
+The coordinator remains responsible for:
+
+- semantic judgment that cannot be reduced to a deterministic rule;
+- exceptions and conflict resolution;
+- choosing among explicitly allowed transitions;
+- authorized integration;
+- operator escalation.
+
+The coordinator should not have to remember the standard happy-path procedure.
+
+> **Landing dependency — deterministic dispatch and chain templates**
+>
+> Precise, deterministic dispatch must land **alongside the canonical chain-template work**, not as an isolated launcher enhancement. The dispatch contract should be derived from the templates proposed in the Specialists roadmap and in **“Specialists Prompt, Chain Context, Interactive Coordination, Observability and Evaluation Modernization”**. Those documents define the broader chain model: node roles, dependencies, scrutiny levels, gates, context propagation, review behavior, and terminal conditions.
+>
+> The implementation should therefore ship one coherent contract:
+>
+> ```text
+> selected chain template
+> → resolved node graph
+> → exact Specialist role and dispatch parameters
+> → parent/coordinator assignment
+> → automatic monitor or direct lifecycle-notification expectation
+> → typed result contract
+> → deterministic eligible next transition
+> ```
+>
+> Dispatch logic must not invent a second, partial interpretation of a chain in Core, xtmux, or the coordinator prompt. One canonical template resolver should produce the dispatch plan consumed by the launcher and recorded in chain/job evidence. Until those proposed chain templates are implemented and versioned, any new deterministic dispatch behavior should remain narrowly scoped and explicitly transitional.
+
+---
+
+## 11. Archon evidence and its current status
+
+### 11.1 Status
+
+Archon remains an experiment.
+
+The QuestDB plan explicitly separates:
+
+1. `questdb-v2-maintenance-planning`
+   - read-only;
+   - evidence gathering;
+   - deterministic GO/NO-GO;
+   - plan generation;
+   - no production change.
+
+2. `questdb-v2-maintenance-execution`
+   - mutating;
+   - accepts only an approved plan;
+   - repeats live preflight;
+   - approval-gated;
+   - checkpointed;
+   - abortable;
+   - rollback-aware.
+
+The initial experiment must not replace Beads, xtmux, Specialists, or Core authority.
+
+### 11.2 Transferable patterns
+
+The useful Archon patterns are:
+
+- explicit DAGs;
+- parallel evidence gathering;
+- typed node outputs;
+- deterministic hard gates;
+- fail-closed behavior;
+- model synthesis that cannot override hard gates;
+- approval nodes;
+- dry-run by default;
+- independent post-action verification;
+- independent rollback workflows;
+- single worktree authority;
+- visible skipped/failed/cancelled state;
+- artifact passing instead of terminal scraping.
+
+### 11.3 Current experimental workflows
+
+The attached examples demonstrate two valuable patterns.
+
+#### Read-only hygiene
+
+```text
+deterministic worktree classification
+→ LLM operator summary
+→ approval records acceptance only
+→ no pruning
+```
+
+This is the correct initial posture for worktree hygiene.
+
+#### Gated merge FIFO
+
+```text
+deterministic eligible queue
++ independent Codex blocker gate
++ advisory LLM review
++ deterministic preflight
++ operator approval
+→ merge
+→ independent GitHub verification
+→ post-merge hygiene
+```
+
+The LLM does not decide the merge set.
+
+### 11.4 Archon/XTRM integration boundary
+
+For the current experiment:
+
+```text
+Archon bash/script node
+→ thin adapter
+→ existing XTRM CLI
+→ structured result
+```
+
+The first adapter should do only:
+
+```text
+start sp run
+capture job_id
+wait for a terminal result
+read sp result --json
+normalize exit/failure
+return JSON
+```
+
+It must never:
+
+- scrape a terminal pane;
+- infer completion from log prose;
+- create a second XTRM worktree;
+- become the Bead authority;
+- duplicate Specialists job state.
+
+### 11.5 Ponytail correction to the proposed adapter surface
+
+The QuestDB plan lists many potential `xtrm-archon` commands. Do not implement that surface up front.
+
+Initial implementation should contain only the commands required by the read-only planning experiment, preferably wrappers over existing tools. Add another command only when a real workflow node cannot be expressed safely with an existing CLI or a short deterministic script.
+
+### 11.6 Evaluation sequence
+
+Run:
+
+- **A:** native Archon nodes;
+- **B:** the same DAG with selected analysis nodes delegated to Specialists.
+
+Compare:
+
+- graph determinism;
+- routing correctness;
+- role fidelity;
+- structured-output reliability;
+- evidence traceability;
+- pause/resume;
+- failure semantics;
+- UI clarity;
+- adapter size;
+- preserved xtmux/Specialists identities;
+- cost and operator intervention.
+
+Do not build production execution until planning behavior is proven.
+
+---
+
+## 12. Merge and integration
+
+### 12.1 Current evidence
+
+The stack now contains:
+
+- coordinator-based Specialist branch ancestry;
+- a live Suite C integration test;
+- `xtrm.branch.integration.v1`;
+- `sp integration record`;
+- topology fields for branch/worktree/parent;
+- forensic lineage.
+
+Therefore the next work should not invent a merge database or custom branch graph.
+
+### 12.2 Minimal integration flow
+
+```text
+Specialist result accepted
+→ coordinator integrates Specialist branch into coordinator branch
+→ Git confirms resulting commit
+→ caller runs sp integration record
+→ xtrm.branch.integration.v1 records the observed result
+→ topology/forensics can reconstruct the relationship
+```
+
+Git remains authority. The event is evidence.
+
+### 12.3 Deterministic merge workflow candidate
+
+The Archon merge-FIFO experiment is a useful model for a future coordinator merge gate:
+
+1. Compute eligible branches or PRs deterministically.
+2. Check unresolved Codex or reviewer blockers independently.
+3. Run deterministic repository and ancestry preflight.
+4. Ask the model for advisory risk analysis only.
+5. Require coordinator or operator approval.
+6. Merge in the predetermined order.
+7. Record integration through `sp integration record`.
+8. Independently re-query Git/GitHub.
+9. Run post-merge hygiene.
+
+This remains experimental until tested against real XTRM chain output.
+
+---
+
+## 13. Specialists hygiene
+
+Process cleanup and worktree deletion must remain separate.
+
+### 13.1 Terminal job cleanup
+
+At terminal transition, Specialists should automatically release only resources owned by that job:
+
+- RPC/agent child;
+- process group;
+- owned legacy tmux session;
+- steer/resume FIFO;
+- temporary prompt/materialization files;
+- transient marker artifacts.
+
+It must preserve:
+
+- result;
+- observability rows;
+- Bead handoff;
+- branch;
+- worktree;
+- integration evidence.
+
+### 13.2 Waiting jobs
+
+Use the existing waiting lifecycle and configured `waiting_auto_close_ms`.
+
+Expected behavior:
+
+```text
+enter waiting
+→ publish one waiting notification
+→ suppress duplicate unchanged notifications
+→ resume, finalize, stop, or auto-close
+→ publish the resulting transition
+```
+
+### 13.3 Dead active jobs
+
+Reconciliation rule:
+
+```text
+status in starting/running/waiting
++ owned PID is dead
+→ mark canonical error/orphaned state
+→ release remaining owned resources
+→ notify parent
+```
+
+### 13.4 Worktree hygiene
+
+Worktree cleanup must remain read-only/proposal-first until integration evidence is reliable.
+
+Classify:
+
+- recent and behind;
+- dirty;
+- unlanded commits;
+- integrated and safe to prune;
+- stale with work;
+- orphan with no known PR/integration evidence.
+
+Never auto-prune a dirty or unlanded worktree.
+
+### 13.5 No new daemon initially
+
+Do not add a global reaper daemon yet.
+
+First:
+
+- fix terminal cleanup at the shared Supervisor seam;
+- retain `sp clean` for repair;
+- run read-only hygiene through the Archon experiment;
+- measure whether new orphan creation continues.
+
+Add periodic reconciliation only if the local cleanup fix is insufficient.
+
+---
+
+## 14. Core and skill changes
+
+Update only canonical skill sources, then re-vendor through the existing process.
+
+Priority skills:
+
+- `multiplexing`;
+- `multiplexing-team`;
+- `using-specialists`;
+- `chain-coordinator`;
+- `pr-reviewer`;
+- `deploy-monitor`.
+
+Required rules:
+
+```text
+Completed generic agent output → xtmux agent-last
+Exact coordination message → xtmux message-get
+Complete Specialist output → sp result --json
+Pane capture → live terminal-only diagnostics
+```
+
+Coordinator contract:
+
+```text
+- Consume typed Specialist transition messages.
+- Follow the chain template for eligible next steps.
+- Do not implement delegated work directly.
+- Integrate accepted Specialist branches into the coordinator branch.
+- Record integration evidence.
+- Do not merge the coordinator branch into main unless explicitly authorized.
+- Before final completion, account for every owned non-terminal job.
+- Report unresolved review threads, unintegrated branches, and preserved worktrees.
+```
+
+Review contract:
+
+```text
+PASS is forbidden while actionable unresolved review threads remain.
+```
+
+Deployment contract:
+
+```text
+PR merged is not deployment evidence.
+Topology discovers branch/PR/job.
+deploy-monitor verifies the deployed state.
+```
+
+---
+
+## 15. Remaining audit work
+
+### 15.1 Revalidate prior Codex findings
+
+Later merges may have superseded earlier findings. For every current PR or affected code path:
+
+```text
+list unresolved threads
+→ determine whether the finding still reproduces
+→ fix once in the shared seam or reply with evidence
+→ resolve the thread
+```
+
+Prioritize:
+
+1. security or data-loss risk;
+2. P1 correctness;
+3. P2 correctness;
+4. outdated findings.
+
+### 15.2 Specific areas to re-audit
+
+- Core topology source ledger completeness.
+- Cross-repository worktree discovery.
+- Pane routing for obligations and parent lineage.
+- PR state association with the correct job/coordinator branch.
+- xtmux Claude transcript extraction and `agent-last` availability.
+- Specialists terminal cleanup and orphan creation.
+- Stale skill copies after canonical updates.
+- Open Core PR #484 and global-skill migration durability.
+
+---
+
+## 16. Minimal implementation packages
+
+### Package A — shared notification contract
+
+**Repositories:** Core contracts, Specialists
+**Scope:**
+
+- add `xtrm.specialist.parent-notification.v1` only if cross-repo parsing requires it;
+- validate bounded fields and trust-boundary rules;
+- one focused schema test.
+
+**Skipped:** schema registry expansion, compatibility negotiation, notification database.
+
+### Package B — Specialists direct parent notification
+
+**Repository:** Specialists
+**Scope:**
+
+- call one notification helper from the shared lifecycle/handoff seam;
+- route only through verified runtime lineage;
+- send waiting/terminal messages through existing xtmux CLI;
+- emit forensic sent/failed evidence;
+- never fail the job because delivery failed;
+- one focused transition test plus one routing test.
+
+**Skipped:** outbox, daemon, retry worker, notification CLI.
+
+### Package C — terminal resource hygiene
+
+**Repository:** Specialists
+**Scope:**
+
+- audit every terminal exit through the shared Supervisor path;
+- release resources owned by the job;
+- preserve worktree/branch/result/evidence;
+- one orphan-regression test.
+
+**Skipped:** automatic worktree pruning.
+
+### Package D — canonical skill propagation
+
+**Repositories:** Specialists source skill, Core vendored/runtime distribution
+**Scope:**
+
+- update result retrieval hierarchy;
+- remove ordinary result-discovery capture guidance;
+- add coordinator notification and final-accounting rules;
+- re-vendor once.
+
+### Package E — live integration extension
+
+**Repository:** Core integration suite, with installed trio
+**Scope:**
+
+Extend the existing live Suite C scenario:
+
+```text
+launch coordinator
+→ commit coordinator-only change
+→ dispatch Specialist
+→ verify Specialist branch ancestry
+→ complete Specialist
+→ verify result appended to Bead
+→ verify typed xtmux message targets parent
+→ wake/read exact message
+→ retrieve sp result --json
+→ integrate branch
+→ record sp integration record
+→ verify topology and forensic lineage
+→ verify owned runtime cleanup
+```
+
+No new simulation framework.
+
+### Package F — Archon read-only experiment
+
+**Location:** experimental workflow repository/configuration
+**Scope:**
+
+- run QuestDB planning workflow only;
+- no worktree ownership in Archon;
+- deterministic NO-GO evaluator;
+- native run and Specialist-backed run;
+- complete scorecard;
+- preserve raw artifacts and run IDs.
+
+**Skipped:** production execution, automatic board writes by default, Archon→Substrate compilation.
+
+### Package G — deterministic merge/hygiene experiment
+
+**Status:** open design, separate from Packages A–E
+**Scope:**
+
+- use read-only hygiene first;
+- test deterministic merge queue and Codex gate;
+- require approval before mutation;
+- record integration;
+- independently verify;
+- no automatic pruning.
+
+---
+
+## 17. Acceptance criteria
+
+The follow-up is complete when all of the following are true.
+
+### Notification
+
+- A terminal or waiting Specialist transition sends exactly one typed message.
+- The message reaches the verified assigned parent.
+- The message contains the exact result/action commands.
+- Full output is not duplicated in the message.
+- Delivery failure does not alter the job verdict.
+- Sent/failed delivery is visible through `xtrm.forensic.v1`.
+
+### Retrieval
+
+- The parent does not use `sp feed` polling for ordinary completion.
+- The parent does not use pane capture for a completed result.
+- `sp result --json` returns the authoritative result.
+- `xtmux message-get` returns the exact coordination payload.
+
+### Integration
+
+- Specialist branch descends from the coordinator branch.
+- Accepted work integrates into the coordinator branch.
+- Integration is recorded through `sp integration record`.
+- Git remains the source of truth.
+- Review blockers are resolved or explicitly reported.
+
+### Hygiene
+
+- Terminal jobs release owned process/session/FIFO resources.
+- Worktrees containing unintegrated work are preserved.
+- No automatic prune occurs without deterministic safety evidence.
+- Every chain completion accounts for remaining active/waiting jobs.
+
+### Workflow determinism
+
+- The chain template determines standard next-node eligibility.
+- Deterministic gates cannot be overridden by LLM prose.
+- The coordinator handles judgment and exceptions, not procedural memory.
+- Archon remains experimental until scorecard evidence supports a narrower decision.
+
+---
+
+## 18. Non-goals
+
+The following are explicitly excluded from the immediate implementation:
+
+- replacing xtmux messages with a Specialists notification bus;
+- adding a Specialists-specific Pi extension or Claude hook;
+- copying full Specialist output into wake prompts;
+- building a notification outbox before message loss is observed;
+- introducing a global cleanup daemon before fixing local cleanup;
+- automatic worktree deletion;
+- making Archon the XTRM source of truth;
+- running both Archon and Core worktree ownership in one workflow;
+- compiling Archon YAML into Substrate templates before experiments;
+- automatic production QuestDB maintenance;
+- allowing an LLM to override deterministic operational gates;
+- creating many `xtrm-archon` commands speculatively.
+
+---
+
+## 19. Recommended order
+
+1. Merge or resolve Core PR #484.
+2. Revalidate current unresolved review findings against the new repository heads.
+3. Implement the shared Specialist parent-notification contract.
+4. Emit direct parent notifications from the existing lifecycle/handoff seam.
+5. Audit and fix terminal owned-resource cleanup.
+6. Land the canonical chain-template resolver and precise deterministic dispatch contract together, aligned with the Specialists roadmap and the modernization document.
+7. Update and re-vendor canonical orchestration skills.
+8. Extend live Suite C with template resolution, exact dispatch, notification, result, integration-record, and cleanup assertions.
+9. Run the Archon QuestDB planning experiment in native and Specialist-backed modes.
+10. Evaluate the merge/hygiene experiment separately.
+11. Produce a narrower architectural decision from measured results.
+
+---
+
+## 20. Evidence register
+
+### Repository PRs
+
+- Core #475 — live Suite C Specialist ancestry/integration lane
+  https://github.com/xtrm-dev/core/pull/475
+- Core #476 — runtime compatibility before worktree creation
+  https://github.com/xtrm-dev/core/pull/476
+- Core #477 — PR installer smoke
+  https://github.com/xtrm-dev/core/pull/477
+- Core #479 — topology agent contract widening
+  https://github.com/xtrm-dev/core/pull/479
+- Core #483 — retired skill-tier pruning
+  https://github.com/xtrm-dev/core/pull/483
+- Core #484 — scope-aware skill scaffolding, open at snapshot
+  https://github.com/xtrm-dev/core/pull/484
+- xtmux #56 — canonical Beads lifecycle stream
+  https://github.com/Jaggerxtrm/xtmux/pull/56
+- xtmux #57 — agent-last and message-get
+  https://github.com/Jaggerxtrm/xtmux/pull/57
+- xtmux #58 — hook installer idempotency
+  https://github.com/Jaggerxtrm/xtmux/pull/58
+- xtmux #60 — human event renderer and xtmux-events
+  https://github.com/Jaggerxtrm/xtmux/pull/60
+- xtmux #61 — topology role/worktree/branch/parent pane
+  https://github.com/Jaggerxtrm/xtmux/pull/61
+- Specialists #199 — branch-integration event primitive
+  https://github.com/xtrm-dev/specialists/pull/199
+- Specialists #200 — coordinator branch ancestry
+  https://github.com/xtrm-dev/specialists/pull/200
+- Specialists #201 — `sp integration record`
+  https://github.com/xtrm-dev/specialists/pull/201
+- Specialists #202 — `sp render-bead`
+  https://github.com/xtrm-dev/specialists/pull/202
+
+### Internal and experimental material
+
+- **Archon + XTRM — QuestDB Maintenance Workflow Plan**
+- Archon workflow examples:
+  - `orch-hygiene-readonly`
+  - `xtrm-merge-fifo`
+  - `sre-triage-live`
+- Existing Specialists modernization and open-issues audit context.
+- Prior Core/xtmux/Specialists cross-repository audit findings and Codex review threads.
+
+---
+
+## 21. Final architectural position
+
+The shortest path to a more deterministic system is not another orchestrator layer inside Specialists.
+
+It is:
+
+```text
+declarative chain
++ deterministic gates
++ Specialists-owned lifecycle
++ direct typed parent notification
++ xtmux-owned delivery and wake
++ authoritative structured result
++ Git-owned integration truth
++ forensic evidence
++ explicit cleanup
+```
+
+Archon is valuable as an experimental workflow engine and as evidence for better chain semantics. Its strongest patterns should influence XTRM only after they have been exercised in real read-only workflows and compared against the existing Specialists runtime.
+
+The immediate production improvement remains small: one lifecycle notification helper, one shared payload contract, one generic xtmux delivery path, one terminal cleanup audit, and one live end-to-end check.

--- a/docs/design/xtrm-orchestration-determinism-final-consolidated-report-2026-07-23.md
+++ b/docs/design/xtrm-orchestration-determinism-final-consolidated-report-2026-07-23.md
@@ -1,0 +1,2335 @@
+# XTRM Orchestration Determinism — Final Consolidated Audit and Architecture Conclusion
+
+**Status:** final consolidated report; implementation wave merged, audit closure conditional
+**Last verified:** 2026-07-23, Europe/Rome
+**Repositories:** `xtrm-dev/core`, `Jaggerxtrm/xtmux`, `xtrm-dev/specialists`
+**Experimental comparison:** Archon workflows
+**Primary objective:** consolidate the earlier cross-repository audit and the newest evidence, then make XTRM multiplexing and Specialists orchestration more deterministic without creating duplicate runtimes, state stores, notification systems, or workflow authorities.
+
+**Revision note:** this version supersedes all earlier audit drafts. The final conclusion below is authoritative; later sections retain the chronological evidence and intermediate snapshots for traceability.
+
+---
+
+## Final conclusion
+
+### 1. Overall verdict
+
+The completed work across Core, xtmux, and Specialists has produced a substantially stronger foundation:
+
+- runtime versions are compatible and released;
+- coordinator→Specialist branch ancestry is explicit and live-tested;
+- runtime origin and descendant lineage are reconstructable;
+- topology carries role, branch, worktree, and parent-pane context;
+- integration evidence has public write and read surfaces;
+- exact messages and completed agent turns have dedicated retrieval commands;
+- Specialists now emits a structured Pi-compatible NDJSON progress stream;
+- release, package, installer, and changelog machinery is materially more reliable.
+
+The implementation program should therefore be considered **successfully landed**.
+
+The audit itself is **not yet closed**. Several previously reproduced correctness and security findings remain current. The next work must be split into two deliberately separate tracks:
+
+```text
+Track A — close the existing audit
+Track B — build deterministic orchestration
+```
+
+Do not mix routine defect closure with the new workflow architecture into one large epic or PR series.
+
+### 2. Authoritative current state
+
+| Surface | Current state |
+|---|---|
+| Core | `xtrm-tools` 0.11.2 |
+| xtmux | `@jaggerxtrm/xtmux` 0.2.2 |
+| Specialists | `@jaggerxtrm/specialists` 3.21.1, with #206–#207 landed after that release |
+| Runtime compatibility | Core accepts Specialists `>=3.21.0 <4` and xtmux `>=0.1.0 <0.3` |
+| Latest open operational PR | Core #488, changelog freshness enforcement |
+| Historical review state | 15 current unresolved threads and 4 outdated unresolved threads |
+| Archon | experiment/reference workflow engine, not an adopted XTRM authority |
+
+Core #488 is not included in the landed baseline until merged. It is release-process hardening, not an orchestration dependency.
+
+### 3. What is now definitively landed
+
+#### Runtime and lineage
+
+```text
+Core coordinator
+→ published pane/session/role/branch/worktree identity
+→ Specialist job branch derived from coordinator branch
+→ descendant jobs inherit root runtime origin
+→ xtrm.forensic.v1 reconstructs the chain
+```
+
+The live Suite C lane proves:
+
+- a coordinator-only commit exists;
+- the Specialist branch descends from it;
+- the job records the coordinator runtime origin;
+- the accepted branch integrates back into the coordinator branch.
+
+This closes the earlier uncertainty around whether the contracts merely existed on paper or actually composed in a real run.
+
+#### Result and event retrieval
+
+The retrieval hierarchy is now:
+
+```text
+exact coordination message
+→ xtmux message-get <message-key> --json
+
+latest completed generic agent turn
+→ xtmux agent-last <pane|session> --json
+
+structured Specialist progress
+→ sp run --json / sp feed --json
+
+complete authoritative Specialist result
+→ sp result <job-id> --json
+
+live interactive terminal state
+→ pane capture
+```
+
+Pane capture is not the result protocol.
+
+#### Branch-integration evidence
+
+```text
+Git merge/cherry-pick/PR merge
+→ sp integration record
+→ xtrm.branch.integration.v1
+→ sp integration list
+```
+
+Git remains the merge authority. The event is evidence, not a second merge state machine.
+
+#### Release and packaging
+
+- Core 0.11.2 carries the corrected xtmux compatibility range.
+- xtmux 0.2.2 uses npm Trusted Publishing through OIDC and provenance.
+- Specialists 3.21.1 packages the audit wave through PR #203.
+- xtmux release ownership between the external release driver and tag workflow is no longer duplicated.
+- package bin paths and installed-artifact contracts are covered.
+
+### 4. New architectural evidence from Specialists NDJSON
+
+PRs #206–#207 change the practical integration boundary.
+
+The structured progress path is now:
+
+```text
+sp run --json
+→ session
+→ agent_start
+→ turn/message/tool events
+→ retry/compaction events
+→ agent_end
+→ agent_settled
+```
+
+Properties that matter:
+
+- events are projected from the persisted timeline;
+- internal forensic envelopes are not leaked as the public workflow stream;
+- replay uses the persisted job worktree as `cwd`;
+- SQLite is preferred, with file fallback;
+- fallback suppresses already emitted sequences;
+- per-job order is canonical by `seq`;
+- multiple jobs are merged through a stable k-way chronological merge.
+
+This is the correct stream for Archon and future workflow adapters.
+
+It does not replace `sp result --json`, which remains the complete terminal result surface.
+
+### 5. Authority model
+
+| Concern | Authority |
+|---|---|
+| Workflow graph, dependencies, deterministic transitions | canonical chain template; Archon only inside an Archon-owned experiment |
+| Interactive coordinator placement | Core |
+| Specialist execution, status, timeline, result | Specialists |
+| Pane/session identity, messages, obligations, monitors, wakes | xtmux |
+| Durable task contract and acceptance state | Beads |
+| Branch, commit, merge truth | Git |
+| Integration observation | `xtrm.branch.integration.v1` |
+| Runtime correlation and reconstruction | `xtrm.forensic.v1` |
+| Hard operational thresholds | deterministic code |
+| Semantic judgment and exceptions | coordinator/Specialist |
+| Production mutation authority | operator or explicitly authorized workflow gate |
+
+No new work should create a competing owner for any row in this table.
+
+---
+
+## Track A — Audit closure
+
+### A1. Current P1 and security closure
+
+The following items remain closure blockers.
+
+#### Complete topology source ledger
+
+`xtrm.topology.projection.v1.sources` must contain exactly one result for every expected source:
+
+```text
+xtmux
+tmux
+specialists
+beads
+git
+github
+```
+
+An empty, partial, or duplicate ledger must not validate.
+
+#### xtmux Beads cursor correctness
+
+Fix both problems together:
+
+1. retain the exact raw `created_at` representation, or normalize the SQL side and cursor identically;
+2. capture the initial repository cursor before dashboard and follower startup work.
+
+Acceptance must prove:
+
+- no duplicate event on repeated polling;
+- no event loss during startup;
+- stable `(created_at, id)` progression.
+
+#### Public operational export
+
+Remove `open-issues.json` from the public Specialists tree.
+
+The repository should not expose:
+
+- live runner identifiers and labels;
+- fork or runner policy;
+- operator email addresses;
+- known security backlog;
+- infrastructure findings intended for private operational triage.
+
+The separate immutable runner-denial P0 must be verified independently; removing the export is not remediation of the underlying runner policy.
+
+### A2. Current P2 correctness closure
+
+#### Core
+
+- avoid provisional worktree creation before `--reuse` resolves an existing session;
+- make topology worktree discovery correct across repositories;
+- route obligations to the pane selected from the snapshot;
+- join PR evidence against each Specialist job branch;
+- reconcile Serena installation/support with hook matchers and permissions;
+- preserve the caller’s staged index during Semgrep recovery;
+- restore or delegate a bounded Beads cache writer for Pi-only sessions.
+
+#### xtmux
+
+- use a positioned bounded tail read rather than full transcript `readFileSync`;
+- emit a fallback completed-turn row when Claude transcript extraction has no usable text;
+- resolve the `tmux_server_id` producer/contract discrepancy if still present in live validation.
+
+#### Specialists
+
+- record the real temporary publication branch as the integration target;
+- reject unknown flags, missing values, and flag-shaped values in `sp integration record`;
+- establish an intentional clean test baseline for the CLI suites.
+
+### A3. Review administration
+
+Every current thread must end in one of two states:
+
+```text
+reproduced → fixed → regression test → resolved
+
+superseded → evidence-backed reply naming commit/PR → resolved
+```
+
+Merge status is not thread resolution.
+
+### A4. Release closure
+
+Specialists #206–#207 landed after 3.21.1. Cut a patch release before claiming the installed package exposes the new NDJSON contract.
+
+A coordinated release verification should execute:
+
+```text
+xt version --json
+xtmux-obs version --json
+sp version --json
+runtime compatibility preflight
+packed install smoke
+live Suite C
+sp run --json replay smoke
+```
+
+---
+
+## Track B — Deterministic orchestration
+
+Track B is the next architecture program. It is not a continuation of the bug-fix audit disguised as feature closure.
+
+### B1. Canonical chain templates and deterministic dispatch must land together
+
+The source material is:
+
+- the Specialists roadmap;
+- **Specialists Prompt, Chain Context, Interactive Coordination, Observability and Evaluation Modernization**;
+- the chain-template proposals already discussed in this report.
+
+A chain template must define:
+
+```text
+nodes
+Specialist role per node
+dependencies
+parallelism
+scrutiny level
+input/output contracts
+when conditions
+review gates
+retry
+waiting behavior
+integration authority
+target branch
+cleanup
+completion criteria
+```
+
+One canonical resolver must produce:
+
+```text
+selected template
+→ resolved DAG
+→ exact Specialist and dispatch flags
+→ parent/coordinator assignment
+→ expected notification or monitor behavior
+→ typed result contract
+→ eligible next transitions
+```
+
+Do not implement separate partial resolvers in Core, xtmux, Specialists, prompts, and Archon adapters.
+
+### B2. Direct Specialists→parent notification
+
+At the same canonical lifecycle seam where Specialists persists the result and appends the Bead handoff:
+
+```text
+persist status/result
+→ append Bead handoff
+→ send typed xtmux message to verified parent
+→ generic xtmux wake
+```
+
+Initial actionable transitions:
+
+```text
+waiting
+done
+error
+cancelled
+stalled, only if already canonical
+```
+
+The notification should contain:
+
+- schema version;
+- transition kind;
+- job ID;
+- Specialist;
+- status;
+- Bead/chain/node identifiers when available;
+- verified parent;
+- bounded summary;
+- exact `sp result` / `sp resume` / inspection command;
+- trace/span correlation.
+
+It must not contain the complete result.
+
+Delivery is best-effort relative to job completion. Do not introduce an outbox, daemon, retry worker, notification database, or Specialist-specific Pi/Claude extension until measured delivery loss requires one.
+
+### B3. Generic xtmux delivery semantics
+
+The receiving path remains:
+
+```text
+message-get
+→ continuation successfully queued
+→ message-ack
+```
+
+Do not merge these concepts:
+
+```text
+delivered
+retrieved
+receipt acknowledged
+reply obligation fulfilled
+```
+
+A terminal Specialist notification is usually reply-free FYI. A waiting notification is normally fulfilled through `sp resume`, not a coordination reply.
+
+### B4. Merge and hygiene
+
+The deterministic merge pattern is:
+
+```text
+eligible integration set computed by code
++ unresolved review blockers checked independently
++ repository/ancestry preflight
++ advisory model risk summary
++ coordinator/operator approval
+→ merge in predetermined order
+→ sp integration record
+→ independent Git/GitHub verification
+→ post-merge hygiene
+```
+
+Worktree hygiene remains proposal-first:
+
+- preserve dirty worktrees;
+- preserve unlanded commits;
+- preserve worktrees without reliable integration evidence;
+- release only resources owned by terminal jobs automatically;
+- do not auto-prune merely because a job is terminal.
+
+---
+
+## Archon conclusion
+
+### Origin of the Archon discussion
+
+The Archon analysis began from the Confluence working PRD/workflow plan:
+
+**Archon + XTRM — QuestDB Maintenance Workflow Plan**
+
+The derivation was:
+
+```text
+QuestDB workflow plan
+→ concrete read-only Archon experiment
+→ extract reusable deterministic workflow patterns
+→ compare them with XTRM chains
+→ feed the conclusions into this audit
+```
+
+### Current role
+
+Archon is:
+
+- an experimental workflow engine;
+- a builder/viewer reference;
+- a source of DAG, typed-output, deterministic-gate, approval, and verification patterns.
+
+Archon is not currently:
+
+- the XTRM source of truth;
+- the owner of Specialists jobs;
+- the owner of xtmux messages or pane identity;
+- the owner of Beads;
+- the owner of Git integration truth;
+- the default owner of XTRM worktrees.
+
+### QuestDB experiment
+
+The PRD separates:
+
+```text
+questdb-v2-maintenance-planning
+→ read-only evidence
+→ deterministic GO/NO-GO
+→ proposed plan
+
+questdb-v2-maintenance-execution
+→ approved plan only
+→ fresh preflight
+→ explicit approval
+→ checkpointed mutation
+→ verification and rollback
+```
+
+Only the planning experiment should be used to evaluate the integration initially.
+
+### Thin adapter after #206–#207
+
+The adapter can now remain genuinely thin:
+
+```text
+Archon node
+→ sp run --json
+→ consume ordered NDJSON
+→ observe terminal settlement
+→ sp result --json
+→ return typed node output
+```
+
+It must not:
+
+- scrape a pane;
+- parse human logs;
+- read private Specialists SQLite schemas;
+- create another XTRM worktree;
+- duplicate job lifecycle;
+- reinterpret a deterministic NO-GO.
+
+### Comparative experiment
+
+Run the same planning DAG in two forms:
+
+```text
+A — Archon-native nodes
+B — selected nodes delegated to Specialists
+```
+
+Score:
+
+- graph determinism;
+- role fidelity;
+- routing correctness;
+- structured-output reliability;
+- pause/resume behavior;
+- failure semantics;
+- evidence traceability;
+- preserved XTRM identities;
+- adapter size;
+- operator intervention;
+- cost;
+- UI clarity.
+
+Do not design the production mutation workflow until the read-only comparison produces evidence.
+
+---
+
+## Final implementation sequence
+
+### Phase 1 — close P1/security
+
+1. Remove the public operational export and verify runner policy.
+2. Fix xtmux Beads cursor duplication and startup loss.
+3. Enforce the complete topology source ledger.
+
+### Phase 2 — close current P2 and review threads
+
+4. Resolve Core topology/routing/reuse/Serena/index/cache findings.
+5. Resolve xtmux Claude capture and topology identity findings.
+6. Resolve Specialists integration target and parser findings.
+7. Resolve all outdated threads with evidence.
+8. Establish a clean Specialists test baseline.
+9. Release Specialists with #206–#207.
+
+### Phase 3 — deterministic orchestration foundation
+
+10. Land canonical chain templates and their resolver.
+11. Land exact deterministic dispatch from that resolver.
+12. Land direct typed Specialists→parent notification.
+13. Update and re-vendor canonical orchestration skills.
+14. Extend live Suite C through notification, result retrieval, integration evidence, and terminal cleanup.
+
+### Phase 4 — experiments
+
+15. Run the QuestDB Archon planning workflow natively.
+16. Run the same DAG with selected Specialists-backed nodes.
+17. Complete the scorecard.
+18. Evaluate merge FIFO and worktree hygiene separately.
+
+### Phase 5 — architecture decision
+
+19. Decide whether Archon remains:
+    - an external workflow engine for selected workflows;
+    - a workflow builder/viewer that exports canonical XTRM templates;
+    - only a reference implementation whose patterns are absorbed into XTRM.
+
+No production execution engine or Archon→Substrate compiler should be built before this decision.
+
+---
+
+## Definition of done
+
+### Audit closed
+
+The audit may be marked closed only when:
+
+- all P1/security findings are fixed;
+- all current P2 findings are fixed or explicitly rejected with evidence;
+- all review threads are resolved;
+- the installed trio passes compatibility and packed-install checks;
+- Specialists has a published release containing its current public JSON contracts;
+- live Suite C passes on the released trio.
+
+### Deterministic orchestration foundation complete
+
+The next architecture milestone is complete only when:
+
+- a versioned canonical chain template resolves to one exact dispatch plan;
+- a real coordinator dispatches a Specialist from that plan;
+- waiting/terminal state generates a typed parent message;
+- the parent wakes and retrieves the exact message;
+- progress is available through ordered NDJSON;
+- the complete result is retrieved through `sp result --json`;
+- the accepted branch integrates into the coordinator branch;
+- integration evidence is recorded;
+- terminal owned resources are released;
+- unfinished jobs and preserved worktrees are explicitly accounted for.
+
+### Archon experiment complete
+
+The Archon investigation is complete only when:
+
+- the read-only QuestDB planning workflow has run in both variants;
+- deterministic gates cannot be overridden by model prose;
+- no duplicate authority or worktree ownership appears;
+- artifacts and XTRM identities remain traceable;
+- the comparison scorecard supports a concrete adoption decision.
+
+---
+
+## Final architectural position
+
+The system should converge on:
+
+```text
+canonical declarative chain
++ one deterministic resolver
++ exact dispatch
++ Specialists-owned execution and result
++ ordered structured progress events
++ direct typed parent notification
++ xtmux-owned delivery and wake
++ Beads-owned task contract
++ Git-owned integration truth
++ forensic correlation
++ explicit approval and cleanup
+```
+
+Archon strengthens this direction by demonstrating how DAGs, deterministic gates, typed artifacts, approvals, and independent verification can work. It should influence XTRM through measured experiments, not by taking ownership away from existing components.
+
+The previous implementation wave established the necessary substrate. The remaining audit fixes should now be closed cleanly, followed by a separate, narrowly scoped deterministic-orchestration program.
+
+---
+
+## Historical evidence and intermediate snapshots
+
+The sections below preserve the complete prior audit, delta analyses, finding matrix, and implementation rationale. Where an older section conflicts with the **Final conclusion**, the final conclusion is authoritative.
+
+## Hardening delta re-audit — later 2026-07-22
+
+### Revised verdict
+
+The latest work materially improves release safety and machine-consumable runtime behavior. It also closes two blockers identified by the preceding audit:
+
+- Core no longer rejects xtmux 0.2.x;
+- the three repositories now have coordinated release identities: Core 0.11.2, xtmux 0.2.2, Specialists 3.21.1.
+
+The system is nevertheless **not audit-closed**. The hardening work is mostly orthogonal to the unresolved topology, event-cursor, lifecycle-retrieval, public-export, integration-recording, and cleanup findings.
+
+This distinction matters:
+
+```text
+release and transport hardening improved
+≠
+all previously reproduced correctness findings fixed
+```
+
+### Latest repository state
+
+| Repository | Current source/package state | Latest material changes |
+|---|---|---|
+| Core | `xtrm-tools` 0.11.2 | xtmux compatibility widened to `<0.3`; coordinated release cut. |
+| xtmux | `@jaggerxtrm/xtmux` 0.2.2 | npm Trusted Publishing through OIDC; release workflow ownership corrected; changelog updater landed. |
+| Specialists | `@jaggerxtrm/specialists` 3.21.1 plus unreleased #206–#207 | Pi-compatible NDJSON for `sp run/feed --json`; SQLite-first replay; deterministic per-job ordering. |
+
+Core PR #488 remains open at this snapshot. Its changelog pre-push/CI enforcement is not yet landed and is not counted as completed hardening.
+
+### Closed since the previous audit
+
+#### Core↔xtmux compatibility
+
+Core now accepts:
+
+```json
+{
+  "specialists": ">=3.21.0 <4",
+  "xtmux": ">=0.1.0 <0.3",
+  "node": ">=24.0.0"
+}
+```
+
+This closes the previous blocker where Core 0.11.1 rejected xtmux 0.2.0 at launch.
+
+#### Release identity and publication pipeline
+
+- Core released 0.11.2.
+- Specialists released 3.21.1, covering the integration record/list and roleless Bead work through PR #203.
+- xtmux reached 0.2.2 and moved publication authentication from a long-lived npm token to Trusted Publishing through GitHub OIDC and provenance.
+- xtmux removed duplicate GitHub Release creation from the tag-triggered workflow because the external release driver already owns that operation.
+- xtmux gained an idempotent `[Unreleased]` updater.
+
+These are legitimate closure improvements even though they were not necessarily derived from this audit.
+
+### Specialists JSON transport: important new evidence
+
+PRs #206 and #207 substantially improve Specialists as a deterministic workflow component.
+
+`sp run --json` and `sp feed --json` now emit Pi-compatible NDJSON containing structured lifecycle records such as:
+
+```text
+session
+agent_start
+turn_start / turn_end
+message_start / message_update / message_end
+tool_execution_start / update / end
+compaction_start / end
+auto_retry_start / end
+agent_end
+agent_settled
+```
+
+The implementation projects the persisted Specialists timeline instead of exposing internal forensic envelopes or asking a consumer to parse human feed output.
+
+Review found and fixed three substantive defects before merge:
+
+1. replay/live session `cwd` used the caller checkout rather than the persisted job worktree;
+2. SQLite-success followed by file fallback could replay already emitted events;
+3. mixed timestamp/sequence sorting across jobs was non-transitive and could violate per-job ordering.
+
+The final implementation groups events by job, sorts each job stream by canonical `seq`, and performs a k-way chronological merge across queue heads.
+
+### Consequence for Archon and deterministic workflows
+
+This new NDJSON surface is now the preferred streaming boundary for a thin workflow adapter:
+
+```text
+start sp run --json
+→ consume structured Pi-compatible events
+→ correlate tools/messages/turns
+→ observe agent_end / agent_settled
+→ retrieve the authoritative final result with sp result --json
+```
+
+It removes the need to:
+
+- poll and parse the human `sp feed`;
+- scrape terminal panes;
+- infer completion from prose;
+- invent an Archon-specific Specialists event parser.
+
+The authority split remains:
+
+```text
+sp run/feed --json = structured progress stream
+sp result --json   = authoritative complete result
+Supervisor status  = authoritative job lifecycle
+```
+
+The new stream does **not** replace the proposed direct Specialists→parent xtmux message. An interactive coordinator still benefits from an automatic typed terminal/waiting notification rather than maintaining a live stream for every child.
+
+### Review and CI quality of the new hardening
+
+- Core 0.11.2 release head passed CI, Semgrep, Gitleaks, and OSV.
+- xtmux’s latest hardening head passed CI and CodeQL.
+- Specialists #207 passed Gitleaks, OSV, Semgrep, and package-payload.
+- Specialists #206 and #207 received actionable Codex review and resolved all findings raised on those PRs.
+- Several xtmux release-hardening PRs did not receive Codex review because the review quota was exhausted. Their green CI is evidence of tested behavior, not evidence of an independent semantic review.
+
+### Findings still current after the hardening delta
+
+The recent PR file scopes do not touch the following defects, and their review threads remain current and unresolved.
+
+#### Core
+
+- `xtrm.topology.projection.v1` still allows an empty, partial, or duplicated source ledger.
+- topology still collects Git worktrees from only the invocation repository while collecting panes server-wide.
+- the rendered obligations route still resolves the invoking pane rather than the selected pane.
+- the integration view still does not join PR state for each Specialist job branch.
+- Serena remains provisioned while relevant GitNexus/service-skill hook matchers omit Serena tools.
+- Semgrep recovery still uses `git reset --mixed`, which can unstage unrelated work.
+- the Pi-only footer still rereads but does not generate the Beads status cache.
+- `--subordinate --reuse` can still provision an unused worktree before session reuse is detected.
+
+#### xtmux
+
+- the Beads event follower still normalizes the stored cursor differently from the raw database timestamp, allowing repeated emission.
+- the startup Beads cursor is still captured after setup work, leaving a loss window.
+- Claude turn capture still reads the complete transcript before slicing its final 1 MiB.
+- Claude turn capture still emits no fallback completed-turn record when transcript extraction returns no text.
+
+#### Specialists
+
+- the public `open-issues.json` operational export remains tracked.
+- automatic branch-integration emission can still report the default branch instead of the temporary publication branch.
+- `sp integration record` still accepts another flag as a missing option value and can persist malformed attribution.
+- the direct typed Specialists→parent lifecycle notification has not landed.
+
+### Review-thread state
+
+The previous unresolved-thread count remains operationally relevant:
+
+| Repository | Current unresolved | Outdated unresolved | Total |
+|---|---:|---:|---:|
+| Core | 9 | 1 | 10 |
+| xtmux | 3 | 2 | 5 |
+| Specialists | 3 | 1 | 4 |
+| **Total** | **15** | **4** | **19** |
+
+Recent Specialists findings on #206 and #207 are not added to this count because they were fixed and resolved before merge.
+
+### Release caveat
+
+Specialists #206 and #207 landed **after** release 3.21.1. The source tree contains the new NDJSON and ordering fixes, but package version 3.21.1 does not identify those commits. A later patch release is needed before treating that behavior as installed-artifact evidence.
+
+Likewise, xtmux #68 and #69 landed after release 0.2.2; they harden the next release cycle rather than changing the already cut 0.2.2 package.
+
+### Updated closure priorities
+
+The compatibility and initial release-identity blockers can be removed from the closure list.
+
+The remaining minimum closure wave is:
+
+1. remove `open-issues.json` from the public repository and verify immutable runner protection;
+2. fix the xtmux Beads cursor duplication and startup loss window;
+3. enforce a complete, unique topology source ledger;
+4. close the remaining Core topology/routing/Serena/index/cache/reuse findings;
+5. fix Claude bounded-tail reading and completed-turn fallback;
+6. correct Specialists integration target and CLI argument validation;
+7. reply to and resolve all superseded review threads;
+8. establish and publish the intended Specialists test baseline;
+9. release Specialists with #206–#207 included;
+10. implement direct Specialists→parent notification and deterministic chain-template dispatch as the next architectural program.
+
+### Architectural conclusion after the new delta
+
+The latest work strengthens the planned architecture rather than replacing it.
+
+Most importantly, Specialists now has a credible structured streaming surface for workflow engines. The preferred future shape becomes:
+
+```text
+chain template resolves exact dispatch
+→ adapter starts sp run --json
+→ workflow consumes ordered structured events
+→ Supervisor persists authoritative result
+→ Specialists directly notifies the interactive parent through xtmux
+→ parent or workflow retrieves sp result --json
+→ deterministic gate selects the next node
+```
+
+This is a better foundation for the Archon comparison and for a canonical chain resolver. It does not reduce the need for direct parent notification, precise dispatch, or explicit hygiene ownership.
+
+---
+
+## Final delta re-audit — 2026-07-22
+
+### Verdict
+
+The implementation wave is **merged**, but the three-repository system is **not audit-closed**.
+
+Positive closure evidence:
+
+- the latest operator-authored PRs are merged;
+- Core’s latest PR head passed CI, Semgrep, Gitleaks, and OSV;
+- xtmux’s v0.2.0 release PR passed CI and CodeQL;
+- Specialists’ latest PR passed Gitleaks, OSV, Semgrep, and package-payload;
+- Core #484 made the global-skill migration durable;
+- Core #485 added final installed-artifact ownership checks;
+- xtmux #62 repaired npm bin packaging;
+- xtmux #63 tagged v0.2.0;
+- Specialists #203 completed the read/write surface for `xtrm.branch.integration.v1`.
+
+Audit-closure blockers:
+
+1. Core 0.11.1 still declares `xtmux >=0.1.0 <0.2`, while xtmux is now 0.2.0. Core’s launch preflight therefore rejects the final source trio.
+2. Nineteen GitHub review threads remain unresolved: fifteen non-outdated and four outdated. Code revalidation shows that one outdated xtmux finding remains substantively valid.
+3. Four P1/security findings remain live: incomplete topology source ledger, duplicate Beads event cursor, public operational issue export, and the runtime compatibility mismatch.
+4. Multiple P2 correctness findings still reproduce in current source.
+5. Specialists’ latest PR records approximately 68 pre-existing failures in `tests/unit/cli/`; the final workflow set does not provide a clean full-suite certification.
+6. The final Specialists changes remain under package version 3.21.0, whose release commit predates PRs #199–#203.
+7. The proposed direct Specialists→parent notification and canonical deterministic chain-template dispatch have not landed. They remain roadmap work, not missing implementation from the completed audit wave.
+
+### Actual final delta
+
+#### Core
+
+- #484 merged: repo-scoped skill state no longer recreates retired `default/` and `optional/` tiers.
+- #485 merged: Suite A verifies preservation of project-owned skills and flat global user packs; temporary suite sandboxes are cleaned correctly.
+- Current source head: `14ef17810d4addec0346c1a558673dae255649de`.
+- Current package version: `0.11.1`.
+
+#### xtmux
+
+- #62 merged: npm bin paths no longer use a leading `./`, preserving all seven commands during publication.
+- #63 merged and tagged: `v0.2.0`.
+- npm publication remains explicitly operator-authorized and was not performed by #63.
+- Current source head: `8eb24cb99d3d7bce71732ad5acc43fe6459926ba`.
+
+#### Specialists
+
+- #203 merged: `sp integration list` reads `xtrm.branch.integration.v1` records and composes with #201 `record`.
+- Current source head: `74b50b247c468ae4e449cf107c9b57fd24dde3c2`.
+- Current package version remains `3.21.0`; PRs #199–#203 are not represented by a new release identity.
+
+### New release blocker: Core rejects xtmux v0.2.0
+
+Current Core contract:
+
+```json
+{
+  "specialists": ">=3.21.0 <4",
+  "xtmux": ">=0.1.0 <0.2"
+}
+```
+
+Current xtmux package:
+
+```json
+{
+  "version": "0.2.0"
+}
+```
+
+Core #476 made this contract an enforced pre-worktree launch gate. Installing or linking xtmux 0.2.0 therefore causes `xt claude` / `xt pi` interactive launch to fail before worktree creation.
+
+Required disposition:
+
+- do not publish/install xtmux 0.2.0 across the fleet until Core’s compatibility contract and tests are updated;
+- validate the real trio with xtmux 0.2.0;
+- widen the range only after that live proof;
+- release/update Core and xtmux in coordinated order.
+
+### Review-thread accounting
+
+| Repository | Current unresolved | Outdated unresolved | Total |
+|---|---:|---:|---:|
+| Core | 9 | 1 | 10 |
+| xtmux | 3 | 2 | 5 |
+| Specialists | 3 | 1 | 4 |
+| **Total** | **15** | **4** | **19** |
+
+Outdated-thread disposition:
+
+- Core #485 user-pack location: fixed in later commits, thread not resolved.
+- Specialists #203 subcommand help: fixed, thread not resolved.
+- xtmux #57 temp-file permissions: fixed with a private temp directory and mode `0600`.
+- xtmux #57 bounded transcript-tail read: marked outdated by line movement, but **not fixed**; current code still calls `readFileSync(transcriptPath)` before taking the final 1 MiB.
+
+### Current P1 and security findings
+
+#### P1 — runtime compatibility mismatch
+
+Core’s enforced range rejects xtmux 0.2.0. This is a release blocker introduced by the final delta.
+
+#### P1 — topology source ledger remains incomplete by contract
+
+`xtrm.topology.projection.v1` still defines `sources` as an unconstrained array. It does not require exactly one entry for each of `xtmux`, `tmux`, `specialists`, `beads`, `git`, and `github`, nor uniqueness.
+
+#### P1 — xtmux Beads cursor still duplicates ISO rows
+
+Current `follow_beads()` still transforms the cursor:
+
+```bash
+.created_at | sub("T"; " ") | rtrimstr("Z")
+```
+
+but compares it against unchanged database `created_at`. ISO values containing `T` can remain greater than the normalized cursor containing a space, causing repeated emission.
+
+#### P1 / security — `open-issues.json` remains public
+
+The repository still tracks an operational export containing a known critical runner vulnerability, runner identity/labels, fork policy, operator email addresses, and internal security backlog.
+
+Required disposition:
+
+- remove it from the public tree;
+- keep future exports outside version control;
+- assess history cleanup and exposure;
+- independently verify whether immutable runner denial has been implemented externally.
+
+### Current P2 correctness findings
+
+#### Core #465 — reuse can orphan a provisional worktree
+
+`--subordinate --reuse` may create a worktree before session reuse is detected, leaving the extra branch and checkout behind.
+
+#### Core #468 — cross-repository worktree projection remains incomplete
+
+`collectProjection()` queries worktrees only from the invocation `cwd`, while pane collection spans the tmux server. Panes from another repository cannot resolve their worktrees correctly.
+
+#### Core #469 — obligations route uses the invoking pane
+
+The rendered command still resolves `#{pane_id}` at execution time rather than using the pane selected in the projection.
+
+#### Core #469 — integration view omits Specialist-job PR state
+
+The integration table shows Specialist job branches, but PR state is read only from `pane.pull_request`, which represents the coordinator/pane branch.
+
+#### Core #470 — Serena provisioning and hook policy disagree
+
+Core still installs Serena, while GitNexus and service-skill policies no longer match Serena navigation and mutation tools.
+
+#### Core #471 — semgrep recovery unstages unrelated work
+
+Recovery still runs `git reset --quiet --mixed`, preserving bytes but resetting the caller’s index.
+
+#### Core #473 — Pi-only footer has no Beads cache writer
+
+The Pi footer only reads and rereads `.xtrm/cache/beads-status.json`; it does not regenerate it.
+
+#### xtmux #56 — startup cursor can lose Beads events
+
+The Beads cursor is captured after dashboard/setup work and other followers, so mutations in that interval are excluded by the strict newer-than query.
+
+#### xtmux #57 — Claude `agent-last` fallback remains missing
+
+The Stop hook returns when transcript extraction yields no text; no fallback completed-turn enrichment is emitted.
+
+#### xtmux #57 — transcript tail remains unbounded I/O
+
+The hook reads the complete transcript, then slices the last 1 MiB.
+
+#### Cross-repo topology contract — `tmux_server_id`
+
+Core’s `xtrm.xtmux.topology.v1` requires `host.tmux_server_id`. Review evidence from xtmux #61 records that the producer emitted only `host_id`, and no later topology implementation PR followed #61.
+
+#### Specialists #199 — automatic merge event can record the wrong target branch
+
+The automatic emitter still falls back to the default branch, even when publication merges into a temporary PR branch.
+
+#### Specialists #201 — flag-shaped values can corrupt integration records
+
+The parser blindly consumes the next argv token as a value. A missing value can consume another flag and persist malformed attribution; the unique integration key may then prevent correction.
+
+#### Specialists test health
+
+The latest PR documents approximately 68 pre-existing `tests/unit/cli/` failures. Targeted and security/package checks pass, but no clean full-suite proof exists for the current head.
+
+### Landed and verified improvements
+
+The re-audit confirms these are complete:
+
+- runtime compatibility is enforced before worktree creation;
+- Specialist branches inherit coordinator ancestry;
+- live Suite C proves ancestry, runtime origin, and integration;
+- topology carries role/worktree/branch/parent-pane lineage;
+- external merges can write integration evidence;
+- integration evidence has a public read surface;
+- roleless Bead turn-1 rendering exists;
+- completed generic agent turns and exact messages have read surfaces;
+- xtmux Claude hook installation converges;
+- Core’s global-skill migration no longer recreates retired repo tiers;
+- latest available PR workflows are green.
+
+### Roadmap items not landed
+
+These are roadmap items, not regressions in the completed wave:
+
+- direct typed Specialists→parent lifecycle notification;
+- `xtrm.specialist.parent-notification.v1`;
+- canonical deterministic chain-template resolver;
+- precise dispatch derived from the roadmap and modernization templates;
+- Archon/XTRM production integration;
+- automatic worktree pruning;
+- production QuestDB execution workflow.
+
+### Minimum closure wave
+
+1. Repair Core↔xtmux 0.2 compatibility and run the real trio.
+2. Remove `open-issues.json` and verify external runner denial.
+3. Fix the xtmux Beads cursor P1.
+4. Fix the Core topology source-ledger P1.
+5. Fix or formally dispose every current review finding.
+6. Reply to and resolve all outdated threads.
+7. Establish a clean, intentional Specialists test baseline.
+8. Cut coordinated releases so package versions and installed artifacts identify the same code.
+
+Only then should the audit state move from **implementation merged** to **system closed**.
+
+---
+
+## 1. Executive decision
+
+The current XTRM stack already contains most of the primitives required for deterministic orchestration:
+
+- Core launches coordinators and subordinate runtimes, owns interactive worktree placement, and publishes agent branch/runtime metadata.
+- Specialists owns specialist job execution, lifecycle, result persistence, Bead handoff, runtime lineage, and subordinate worktrees.
+- xtmux owns pane/session identity, messages, reply obligations, monitors, wakes, topology, event transport, and completed-agent-turn retrieval.
+- Beads owns durable work contracts and task acceptance state.
+- Git owns branch, commit, merge, and integration truth.
+- `xtrm.forensic.v1` owns reconstructable runtime evidence and correlation.
+- Archon is being evaluated as an external declarative workflow engine, not adopted as an XTRM authority.
+
+The main remaining weakness is not missing observability. It is that orchestration still depends too often on an agent remembering procedural machinery:
+
+```text
+dispatch
+→ remember to poll sp ps / sp feed
+→ infer a transition
+→ remember to retrieve sp result
+→ remember to dispatch the next node
+→ remember to integrate the branch
+→ remember to stop or clean jobs
+```
+
+The immediate correction is narrower:
+
+```text
+Specialists persists a meaningful transition
+→ Specialists sends one typed xtmux message to the assigned parent
+→ xtmux performs its existing generic delivery and wake behavior
+→ the parent reads the message
+→ sp result --json remains the authoritative complete result
+→ the chain template determines the eligible next step
+```
+
+No Specialists-specific Pi extension, Claude hook pipeline, notification database, daemon, or result protocol should be added in the first implementation.
+
+---
+
+## 2. Evidence classification
+
+This document uses four evidence classes.
+
+| Class | Meaning |
+|---|---|
+| **Landed** | Merged and available in the repository snapshot. |
+| **Open** | Active PR or explicitly unresolved implementation work. |
+| **Needs revalidation** | Previously observed defect or review finding that may have been affected by later merges. |
+| **Experimental** | Archon workflow behavior being tested; not an adopted XTRM contract. |
+
+Claims about architecture must not silently promote experimental behavior into landed behavior.
+
+---
+
+
+## 3. Prior audit baseline and disposition
+
+This section preserves the findings and contract conclusions established before the Specialists notification and Archon discussion. It is intentionally explicit so the document does not depend on conversation history.
+
+### 3.1 Original audit scope
+
+The original audit covered `xtrm-dev/core`, `Jaggerxtrm/xtmux`, and `xtrm-dev/specialists` as one runtime system rather than as isolated repositories.
+
+The requested work included:
+
+- inspect recent merged and open PRs as the freshest implementation evidence;
+- inspect releases when they were newer than repository documentation;
+- reconcile the existing `open-issues.json` inventory against current code;
+- identify work that was completed, superseded, duplicated, mis-prioritized, or still active;
+- inspect unresolved Codex review findings rather than treating merge status as review completion;
+- verify runtime compatibility and packed-install behavior;
+- verify coordinator, subordinate, worktree, pane, session, branch, Bead, and Specialist lineage;
+- identify stale canonical and vendored skill guidance;
+- distinguish observability evidence from operational authority;
+- produce a later Jira/epic reorganization only after operator approval.
+
+The audit must continue to treat recent code and live contracts as stronger evidence than stale planning documents.
+
+### 3.2 Prior unresolved-review snapshot
+
+At the prior audit snapshot there were **16 unacknowledged Codex findings**:
+
+- **14 current unresolved findings**;
+- **2 unresolved findings considered outdated by later code**, but still requiring an evidence-backed reply and explicit thread resolution.
+
+This count is historical. It must be re-enumerated against the current PR heads before closure because later merges may have fixed, moved, or invalidated individual findings.
+
+A merge does not imply that review obligations are complete.
+
+### 3.3 Prior finding disposition matrix
+
+| Repository / reviewed PR | Severity | Original finding | Current disposition | Later evidence that may affect it | Remaining action |
+|---|---:|---|---|---|---|
+| Core #467 | P1 | The topology `sources` ledger could be empty, partial, or duplicate, making the projection unable to explain which source contributed each fact. | **Needs revalidation** | Core #479 and xtmux #61 widened and populated agent topology fields, but they do not by themselves prove source-ledger completeness or deduplication. | Reproduce against the current aggregation path; fix once in the shared projection ledger if still present. |
+| xtmux #56 | P1 | Timestamp cursor normalization could compare ISO and stored timestamp forms inconsistently and repeatedly select the same Beads rows. | **Needs revalidation; not known closed** | Later event rendering did not explicitly claim to change cursor semantics. | Test mixed timestamp forms and repeated polling against current main; preserve `(created_at, id)` monotonicity. |
+| Specialists #199 | P1 / security | A public `open-issues.json` artifact reportedly exposed runner, security, operator, or environment details inappropriate for a public repository. | **Needs immediate revalidation** | Later Specialists PRs did not explicitly claim removal or redaction. | Confirm whether the artifact remains public; remove, redact, or relocate sensitive operational content. |
+| Core #465 | P2 | `--subordinate --reuse` could provision or retain an orphan worktree when the reuse path did not complete cleanly. | **Needs revalidation** | Live Suite C proves normal ancestry/integration, not reuse failure cleanup. | Exercise reuse success, rejection, timeout, and launcher failure; assert no unowned worktree remains. |
+| Core #468 | P2 | Cross-repository worktrees could disappear from aggregation because discovery or projection remained repository-local. | **Needs revalidation** | xtmux #61 improves remote pane lineage; it does not prove cross-repository worktree inventory completeness. | Test a parent and Specialist spanning different repositories and verify one coherent topology view. |
+| Core #469 | P2 | Obligation routing could associate the wrong pane, and PR state could be derived from the coordinator/current branch rather than the job branch. | **Partially superseded; still needs separate checks** | xtmux #61 publishes `parent_pane_id`; Specialists #200 fixes branch ancestry; #201 records external integration. | Verify requester/target pane routing and job-branch PR lookup independently. Do not close one because the other improved. |
+| Core #470 | P2 | Serena matcher/configuration was removed from one surface while Serena was still provisioned or referenced elsewhere. | **Needs revalidation** | Global-skill migration work changed provisioning paths but did not explicitly close this contract mismatch. | Trace every Serena provisioner, matcher, skill reference, and runtime registration; delete or restore one canonical path. |
+| Core #471 | P2 | A mixed/reset operation could unstage unrelated operator work rather than only the files owned by the workflow. | **Needs revalidation** | No later PR reviewed in this audit explicitly claims this ownership-bound reset fix. | Reproduce with unrelated staged changes; replace broad reset with path-scoped ownership-safe behavior. |
+| Core #473 | P2 | The footer could retain stale agent/runtime state in Pi-only sessions. | **Needs revalidation** | Core #473 substantially simplified the footer into a cache reader, which may supersede the original symptom but does not automatically resolve the review thread. | Run the original stale-state reproduction against current main; reply with evidence and resolve or fix. |
+| xtmux #56 | P2 | Startup cursor capture could race with rows written during initialization and skip or duplicate events. | **Needs revalidation; not known closed** | Later human rendering is unrelated. | Add a deterministic startup-concurrency test around cursor establishment and first poll. |
+| xtmux #57 | P2 | Claude transcript extraction failure could suppress full turn enrichment, causing `agent-last` to report not found despite a completed turn. | **Needs revalidation; high operational relevance** | No later PR explicitly claims a fallback that persists the completed turn when transcript parsing fails. | Simulate malformed/missing transcript; persist bounded fallback output or explicit unavailable reason without suppressing the turn row. |
+| Specialists #199 | P2 | Reported integration target branch could be incorrect. | **Partially superseded** | Specialists #200 establishes coordinator branch ancestry; #201 publishes integration recording with explicit target fields. | Verify actual result/status output, forensic events, and integration rows all report the same target branch. |
+| Two prior review threads | Outdated | Later commits appeared to invalidate the comments, but the threads remained unresolved. | **Administrative closure still required** | Exact identities must be re-enumerated from GitHub. | Reply with the superseding commit/PR and resolve explicitly; do not silently ignore them. |
+
+The matrix records the original defect class, not a claim that each problem still reproduces. The closure rule is evidence, not age.
+
+### 3.4 Prior requirements that have since landed
+
+Several requirements identified during the earlier audit now have direct implementation evidence.
+
+| Requirement | Evidence | Disposition |
+|---|---|---|
+| Publish build identity through machine-readable CLI output | Core and Specialists audit PRs; xtmux build identity work | Landed |
+| Reject incompatible runtime combinations before creating an interactive worktree | Core #476 | Landed |
+| Run packed installer/update smoke earlier on relevant PRs | Core #477 | Landed |
+| Publish coordinator role, branch, worktree, and parent-pane lineage through topology | Core #479 + xtmux #61 | Landed |
+| Make Specialist job branches descend from the coordinator branch | Specialists #200 | Landed |
+| Prove ancestry, runtime origin, and integration in a real opt-in lane | Core #475 | Landed |
+| Record integration performed outside `sp merge` | Specialists #201 | Landed |
+| Render a Bead turn-1 body for roleless launches | Specialists #202 | Landed |
+| Retrieve full completed generic agent turns without pane capture | xtmux #57 `agent-last` | Landed, with transcript-fallback caveat |
+| Retrieve exact coordination message bodies | xtmux #57 `message-get` | Landed |
+| Converge duplicate Claude hook registrations | xtmux #58 | Landed |
+| Stream canonical Beads lifecycle events rather than duplicate hook facts | xtmux #56 | Landed, with cursor caveats pending revalidation |
+
+### 3.5 Completed-turn and message semantics established by the earlier audit
+
+The earlier audit established three distinct retrieval planes.
+
+| Need | Canonical surface | Semantics |
+|---|---|---|
+| Exact coordination body | `xtmux message-get <message-key|id> --json` | Reads the durable message body. It does not mean the message was processed and does not retrieve a generic agent's full turn. |
+| Latest completed generic agent response | `xtmux agent-last <pane|session> --json` | Reads the bounded full completed turn stored in `agent_turns.last_message_text`, subject to the Claude transcript caveat. |
+| Live terminal state | pane capture | Used for streaming output, prompts, menus, authentication, or other state not represented by a completed result. |
+
+The Pi child-to-parent completion path added with xtmux #57 stores the full response separately but sends only a compact one-line FYI summary to the parent. Therefore:
+
+```text
+automatic parent FYI
+≠ full completed response
+```
+
+The parent must use `agent-last` when the full generic-agent conclusion is required.
+
+For Specialists, the authoritative complete output remains:
+
+```text
+sp result <job-id> --json
+```
+
+### 3.6 Pane-capture conclusion
+
+No hard technical prohibition against `tmux capture-pane` was landed.
+
+The intended policy is semantic:
+
+```text
+completed coordination message → message-get
+completed generic agent turn    → agent-last
+completed Specialist job        → sp result --json
+live terminal interaction       → pane capture
+```
+
+At the earlier snapshot, Core's canonical `multiplexing` skill still recommended capture for several ordinary result-discovery and preflight paths. Those instructions must be re-audited and corrected in the canonical source, then re-vendored.
+
+### 3.7 Message acknowledgement conclusion
+
+`message-get` should remain a pure read operation because it is also useful to:
+
+- consoles and viewers;
+- forensic tooling;
+- an orchestrator inspecting another participant;
+- retries and previews.
+
+The receiving runtime should use:
+
+```text
+message-get
+→ successfully queue the continuation
+→ message-ack
+```
+
+This preserves at-least-once delivery and avoids acknowledging a message before its content reaches the model.
+
+Do not conflate:
+
+- wake delivered;
+- message retrieved;
+- receipt acknowledged;
+- correlated reply obligation fulfilled.
+
+A Specialist completion notification is normally reply-free FYI. A Specialist waiting transition normally requires `sp resume`, not `xtmux message-reply`.
+
+### 3.8 Pi wake behavior observed during the earlier audit
+
+The existing Pi coordination extension already:
+
+- polls durable messages expecting replies and durable reply obligations;
+- acknowledges receipts through the coordination path;
+- renders bounded widget/system metadata;
+- consumes terminal wakes with `wait-agent --consume`;
+- sends one follow-up wake;
+- intentionally avoids injecting untrusted inbound message summaries as executable instructions.
+
+The missing bridge at that snapshot was precision. The continuation text was generic and did not reliably carry:
+
+- the exact message key;
+- the exact `message-get` command;
+- the source pane/session for `agent-last`;
+- a typed distinction between a coordination message and a completed-agent notification.
+
+The proposed Specialists direct-message design reduces the need for a Specialists-specific extension. It does not remove the requirement that the generic Pi message wake preserve the stable message key and exact retrieval instruction.
+
+### 3.9 Claude wake behavior observed during the earlier audit
+
+The existing Claude hook path already:
+
+- emits the native `Monitor(... wait-agent ... --consume)` continuation;
+- consumes terminal wakes idempotently;
+- uses xtmux monitor/wake state rather than a new Specialists state store.
+
+The earlier gap was similar:
+
+- no typed Specialists transition payload;
+- no direct instruction to retrieve a Specialist result;
+- no guarantee of Pi/Claude wording parity;
+- no automatic child-to-parent completion FYI parity proven for every Claude path.
+
+The current plan should therefore send one ordinary typed xtmux message from Specialists. Claude should receive it through the generic xtmux coordination path, not through a new Specialists completion hook.
+
+### 3.10 Why typed completion metadata was considered
+
+The compact Pi FYI was originally free-form text. Free-form text makes it difficult to select reliably between:
+
+```text
+message-get <message-key>
+agent-last <source-pane>
+sp result <job-id>
+```
+
+A typed Specialists parent notification is justified because it provides stable fields such as:
+
+- transition kind;
+- job ID;
+- parent job ID;
+- Specialist role;
+- Bead and chain IDs;
+- exact result/action command;
+- correlation IDs.
+
+For generic agent-turn FYIs, a later improvement may add typed source pane/session or turn ID metadata. That is separate from the Specialists notification package and should not be bundled without a concrete consumer.
+
+### 3.11 Prior audit closure requirements
+
+The consolidated audit is not complete until:
+
+1. every previously unresolved review thread is re-enumerated;
+2. every current finding has a reproduction or supersession proof;
+3. every outdated finding receives an explicit evidence-backed response;
+4. open-issue inventory is reconciled against landed PRs and current defects;
+5. canonical skills are updated and vendored copies are regenerated;
+6. packed-install and runtime compatibility checks pass;
+7. the live cross-repository lane proves ancestry, routing, result retrieval, integration evidence, and cleanup;
+8. remaining work is grouped into implementation packages or epics only after the technical disposition is known.
+
+---
+
+## 4. Updated repository evidence
+
+### 4.1 Core
+
+Recent work materially closes several earlier audit gaps.
+
+| Evidence | Status | Consequence |
+|---|---:|---|
+| Core PR #475 — opt-in live Suite C lane | Landed | A real coordinator dispatches a real Specialist, verifies coordinator-branch ancestry, runtime origin, and integration back into the coordinator branch. |
+| Core PR #476 — runtime compatibility preflight | Landed | Incompatible Core/xtmux/Specialists combinations are rejected before worktree creation. |
+| Core PR #477 — PR installer smoke | Landed | Installer/runtime surface changes receive an earlier packed-install smoke. |
+| Core PR #479 — topology contract widening | Landed | `role`, `worktree`, `branch`, and `parent_pane_id` are accepted in `xtrm.xtmux.topology.v1`. |
+| Core PR #483 — prune retired empty skill tiers | Landed | Global-skill migration residue is reduced. |
+| Core PR #484 — stop repo scope from recreating retired tiers | **Open** | The migration is not fully durable until this merges. |
+
+Implication: branch ancestry, runtime compatibility, and topology contract gaps are no longer speculative design work. Follow-up work should reuse these landed contracts.
+
+### 4.2 xtmux
+
+| Evidence | Status | Consequence |
+|---|---:|---|
+| xtmux PR #56 — canonical Beads lifecycle event streaming | Landed | xtmux can observe canonical Beads mutations without duplicating lifecycle authority. |
+| xtmux PR #57 — full completed turns, `agent-last`, `message-get` | Landed | Completed agent conclusions and exact coordination messages are retrievable without pane capture. |
+| xtmux PR #58 — idempotent Claude hook installation | Landed | Duplicate lifecycle hook execution self-heals on install. |
+| xtmux PR #60 — human event rendering and `xtmux-events` | Landed | The event journal is more usable without changing its machine format. |
+| xtmux PR #61 — topology publishes role/worktree/branch/parent pane | Landed | Remote topology no longer needs a second local tmux read to reconstruct agent lineage. |
+
+Implication: xtmux already has the delivery, identity, wake, topology, and retrieval primitives needed by Specialists. A new notification runtime would duplicate existing functionality.
+
+### 4.3 Specialists
+
+| Evidence | Status | Consequence |
+|---|---:|---|
+| Specialists PR #199 — `xtrm.branch.integration.v1` primitive | Landed | Integration can be recorded as evidence without replacing Git as authority. |
+| Specialists PR #200 — job branches derive from coordinator branch | Landed | Specialists see coordinator work and can return changes to the correct branch lineage. |
+| Specialists PR #201 — `sp integration record` | Landed | Manual, `xt`, or GitHub-driven merges can record the integration result through a public Specialists CLI. |
+| Specialists PR #202 — `sp render-bead` | Landed | Bare Bead launches can receive a deterministic turn-1 task body without inventing a Specialist role. |
+| Direct Specialists→parent lifecycle notification | **Not landed** | The parent still lacks a Supervisor-originated typed completion/waiting/failure message. |
+| Automatic terminal resource cleanup audit | **Open** | Existing `sp clean` capabilities do not prove every owned runtime resource is released at the terminal transition. |
+
+Implication: the correct notification seam is now easier to identify. Specialists already performs result persistence and Bead handoff at completion; message publication belongs beside that existing operation.
+
+---
+
+## 5. Architectural ownership
+
+The system must preserve one authority per concept.
+
+| Concept | Authority |
+|---|---|
+| Workflow graph and workflow-local node state | Chain template or experimental Archon workflow |
+| Interactive worktree and coordinator placement | Core |
+| Specialist job lifecycle and complete result | Specialists |
+| Pane/session identity and live runtime routing | xtmux |
+| Message delivery, reply obligations, monitors, and wakes | xtmux |
+| Durable task contract and acceptance state | Beads |
+| Branch, commit, and merge truth | Git |
+| Branch-integration observation | `xtrm.branch.integration.v1` |
+| Runtime evidence and correlation | `xtrm.forensic.v1` |
+| Operational GO/NO-GO thresholds | Versioned deterministic code |
+| Semantic judgment and exception handling | Coordinator or Specialist |
+| Final production authority | Operator |
+
+A component may reference another component’s record. It must not silently become the canonical owner of that state.
+
+---
+
+## 6. Design rule: push transitions, do not poll lifecycle
+
+`sp ps` and `sp feed` remain valuable operator and recovery surfaces. They should not be the normal orchestration protocol.
+
+### Current weak path
+
+```text
+parent dispatches Specialist
+→ parent polls sp ps or sp feed
+→ parent detects done/waiting/error
+→ parent executes sp result
+→ parent reconstructs chain context
+```
+
+Weaknesses:
+
+- repeated process and database reads;
+- agent attention consumed by supervision;
+- missed transitions when the agent forgets to poll;
+- no automatic wake;
+- duplicated result-discovery instructions;
+- follow-up dispatch depends on memory rather than the chain contract;
+- orphaned jobs and sessions are easy to overlook.
+
+### Target path
+
+```text
+Supervisor changes authoritative state
+→ result and handoff are persisted
+→ typed xtmux message is sent to the assigned parent
+→ xtmux uses the existing generic wake path
+→ parent retrieves the complete result with sp result --json
+→ workflow template exposes the next eligible transition
+```
+
+Polling remains available for:
+
+- live diagnostics;
+- recovery after unavailable routing;
+- human dashboards;
+- forensic investigation;
+- old runs without runtime origin.
+
+---
+
+## 7. Specialists direct parent notification
+
+### 7.1 Correct implementation seam
+
+Specialists already has a shared handoff path that:
+
+- formats a unified handoff;
+- appends it to the input Bead;
+- records append failures without failing the run;
+- optionally writes an output artifact.
+
+The parent notification must be emitted from the same completion/waiting lifecycle seam, after authoritative state and result persistence.
+
+Conceptually:
+
+```ts
+persistStatusAndResult();
+appendResultToInputBead();
+notifyAssignedParent();
+```
+
+Do not add notification behavior to:
+
+- `sp feed`;
+- `sp ps`;
+- the CLI result reader;
+- a new Pi extension;
+- a new Claude-specific hook;
+- the legacy ready-marker scanner.
+
+### 7.2 Notification states
+
+Initial implementation should publish only transitions requiring orchestration attention:
+
+- `waiting`;
+- `done`;
+- `error`;
+- `cancelled`;
+- `stalled`, only if this is already a canonical Supervisor transition.
+
+Do not publish:
+
+- streaming text;
+- thinking;
+- every tool call;
+- heartbeats;
+- repeated unchanged status snapshots.
+
+### 7.3 Routing precedence
+
+The target must be derived from verified lineage, never guessed.
+
+1. Explicit assigned parent target, if the dispatch contract already provides one.
+2. Immediate verified parent runtime origin.
+3. For a child Specialist job, resolve the parent job and use its verified runtime target.
+4. Verified root runtime origin.
+5. No target: do not send; retain result, Bead handoff, forensic evidence, and legacy fallback behavior.
+
+A root pane must not receive a duplicate when the immediate parent is already the correct coordinator.
+
+### 7.4 Minimal shared schema
+
+A schema is justified here because the payload crosses Specialists, xtmux, and an agent runtime.
+
+Recommended schema name:
+
+```text
+xtrm.specialist.parent-notification.v1
+```
+
+Minimum envelope:
+
+```json
+{
+  "schema_version": "xtrm.specialist.parent-notification.v1",
+  "kind": "job.completed",
+  "job_id": "49adda",
+  "specialist": "reviewer",
+  "status": "done",
+  "bead_id": "unitAI-123",
+  "parent_job_id": null,
+  "chain_id": "chain-abc",
+  "node_id": "review",
+  "summary": "Review completed with PASS_WITH_FOLLOWUPS.",
+  "result_command": "sp result 49adda --json",
+  "inspect_command": "sp log 49adda --limit 200",
+  "action_command": null,
+  "correlation": {
+    "trace_id": "...",
+    "span_id": "..."
+  }
+}
+```
+
+For a waiting run:
+
+```json
+{
+  "schema_version": "xtrm.specialist.parent-notification.v1",
+  "kind": "job.waiting",
+  "job_id": "49adda",
+  "specialist": "debugger",
+  "status": "waiting",
+  "bead_id": "unitAI-123",
+  "summary": "A compatibility decision is required.",
+  "result_command": "sp result 49adda --json",
+  "inspect_command": "sp log 49adda --limit 200",
+  "action_command": "sp resume 49adda \"<answer>\""
+}
+```
+
+Rules:
+
+- `summary` is bounded.
+- Full output is never copied into the message.
+- `sp result --json` remains authoritative.
+- Commands are generated by Specialists, not inferred by the receiving LLM.
+- No raw prompt, terminal capture, secret, or unrestricted environment data enters the payload.
+- Missing optional correlation fields remain absent; values are never fabricated.
+
+The schema should live in the existing shared contracts package only if more than one repository parses it. xtmux may transport the body opaquely.
+
+### 7.5 Delivery semantics
+
+Message publication is best-effort relative to job completion:
+
+```text
+job succeeds + message delivery fails
+→ job remains successful
+→ message failure is recorded
+```
+
+Initial implementation should not add:
+
+- a notification outbox;
+- retry worker;
+- notification database;
+- delivery daemon;
+- `sp notifications` command group.
+
+Add durable retry only after measured evidence shows message loss is operationally significant.
+
+### 7.6 `xtrm.forensic.v1`
+
+The message is delivery. Forensics is evidence.
+
+Emit an existing-schema forensic event for:
+
+```text
+coordination.parent_notification.sent
+coordination.parent_notification.failed
+```
+
+Correlate, where available:
+
+- job ID;
+- parent job ID;
+- Bead ID;
+- chain ID and chain root;
+- node ID;
+- pane/session/agent instance;
+- trace/span;
+- branch and commit evidence;
+- returned xtmux message key.
+
+The event must record outcome and identifiers, not the full model output.
+
+### 7.7 Generic wake behavior
+
+No Specialists-specific wake extension is required.
+
+The existing xtmux message delivery path should wake Pi or Claude in the same way as any other coordination message. The receiving continuation should direct the agent to:
+
+```text
+xtmux message-get <message-key> --json
+sp result <job-id> --json
+```
+
+`message-get` should remain read-only. Receipt acknowledgement belongs after the runtime has successfully queued the continuation, preserving the distinction between:
+
+- message delivered;
+- message inspected;
+- receipt acknowledged;
+- reply obligation fulfilled.
+
+A Specialists completion notification is normally an FYI, not a reply obligation.
+
+---
+
+## 8. Completed output retrieval hierarchy
+
+The canonical guidance across Core and Specialists skills should be:
+
+```text
+Exact coordination message
+→ xtmux message-get <message-key> --json
+
+Latest completed generic agent turn
+→ xtmux agent-last <pane|session> --json
+
+Complete Specialist result
+→ sp result <job-id> --json
+
+Live terminal/UI/auth/interactive state
+→ pane capture
+```
+
+`capture-pane` must not be the standard mechanism for retrieving a completed conclusion or Specialist result.
+
+The Core `multiplexing` and `multiplexing-team` skills must be re-audited and updated wherever they still recommend capture for result discovery, model detection, or ordinary sibling inspection.
+
+---
+
+## 9. Monitors after direct notification
+
+Direct Specialist lifecycle notification reduces, but does not eliminate, monitors.
+
+### Do not create a redundant monitor when
+
+- Specialists already owns the lifecycle;
+- a verified parent target exists;
+- the required transition is `waiting` or terminal;
+- Specialists will publish that transition directly.
+
+### Keep or automatically create a monitor when
+
+- the target is a generic agent pane rather than a Specialist job;
+- the requester needs timeout semantics independent of agent completion;
+- the task is interactive and does not produce a Specialists result;
+- the parent target cannot receive direct lifecycle messages;
+- a workflow gate explicitly requires a bounded wait.
+
+Monitor creation must occur in the dispatch/launcher path, not as an instruction the agent must remember after dispatch.
+
+---
+
+## 10. Deterministic chain templates
+
+The chain template should move procedural decisions out of model memory.
+
+A mature template should declare:
+
+- nodes and Specialist roles;
+- dependencies;
+- allowed parallelism;
+- input and output schemas;
+- deterministic `when` conditions;
+- retry limits;
+- waiting behavior;
+- review gates;
+- integration authority and target branch;
+- operator approvals;
+- terminal cleanup behavior;
+- failure and cancellation behavior;
+- chain completion criteria.
+
+Example:
+
+```yaml
+nodes:
+  - id: implement
+    specialist: executor
+    output_type: implementation-result
+
+  - id: test
+    specialist: test-runner
+    depends_on: [implement]
+    when: "$implement.output.status == 'complete'"
+
+  - id: review
+    specialist: reviewer
+    depends_on: [test]
+    when: "$test.output.verdict == 'PASS'"
+
+  - id: integrate
+    action: integrate-specialist-branch
+    depends_on: [review]
+    when: "$review.output.verdict == 'PASS'"
+    approval: coordinator
+
+  - id: cleanup
+    action: cleanup-owned-runtime
+    depends_on: [integrate]
+```
+
+The coordinator remains responsible for:
+
+- semantic judgment that cannot be reduced to a deterministic rule;
+- exceptions and conflict resolution;
+- choosing among explicitly allowed transitions;
+- authorized integration;
+- operator escalation.
+
+The coordinator should not have to remember the standard happy-path procedure.
+
+> **Landing dependency — deterministic dispatch and chain templates**
+>
+> Precise, deterministic dispatch must land **alongside the canonical chain-template work**, not as an isolated launcher enhancement. The dispatch contract should be derived from the templates proposed in the Specialists roadmap and in **“Specialists Prompt, Chain Context, Interactive Coordination, Observability and Evaluation Modernization”**. Those documents define the broader chain model: node roles, dependencies, scrutiny levels, gates, context propagation, review behavior, and terminal conditions.
+>
+> The implementation should therefore ship one coherent contract:
+>
+> ```text
+> selected chain template
+> → resolved node graph
+> → exact Specialist role and dispatch parameters
+> → parent/coordinator assignment
+> → automatic monitor or direct lifecycle-notification expectation
+> → typed result contract
+> → deterministic eligible next transition
+> ```
+>
+> Dispatch logic must not invent a second, partial interpretation of a chain in Core, xtmux, or the coordinator prompt. One canonical template resolver should produce the dispatch plan consumed by the launcher and recorded in chain/job evidence. Until those proposed chain templates are implemented and versioned, any new deterministic dispatch behavior should remain narrowly scoped and explicitly transitional.
+
+---
+
+## 11. Archon evidence and its current status
+
+### 11.1 Status
+
+Archon remains an experiment.
+
+The QuestDB plan explicitly separates:
+
+1. `questdb-v2-maintenance-planning`
+   - read-only;
+   - evidence gathering;
+   - deterministic GO/NO-GO;
+   - plan generation;
+   - no production change.
+
+2. `questdb-v2-maintenance-execution`
+   - mutating;
+   - accepts only an approved plan;
+   - repeats live preflight;
+   - approval-gated;
+   - checkpointed;
+   - abortable;
+   - rollback-aware.
+
+The initial experiment must not replace Beads, xtmux, Specialists, or Core authority.
+
+### 11.2 Transferable patterns
+
+The useful Archon patterns are:
+
+- explicit DAGs;
+- parallel evidence gathering;
+- typed node outputs;
+- deterministic hard gates;
+- fail-closed behavior;
+- model synthesis that cannot override hard gates;
+- approval nodes;
+- dry-run by default;
+- independent post-action verification;
+- independent rollback workflows;
+- single worktree authority;
+- visible skipped/failed/cancelled state;
+- artifact passing instead of terminal scraping.
+
+### 11.3 Current experimental workflows
+
+The attached examples demonstrate two valuable patterns.
+
+#### Read-only hygiene
+
+```text
+deterministic worktree classification
+→ LLM operator summary
+→ approval records acceptance only
+→ no pruning
+```
+
+This is the correct initial posture for worktree hygiene.
+
+#### Gated merge FIFO
+
+```text
+deterministic eligible queue
++ independent Codex blocker gate
++ advisory LLM review
++ deterministic preflight
++ operator approval
+→ merge
+→ independent GitHub verification
+→ post-merge hygiene
+```
+
+The LLM does not decide the merge set.
+
+### 11.4 Archon/XTRM integration boundary
+
+For the current experiment:
+
+```text
+Archon bash/script node
+→ thin adapter
+→ existing XTRM CLI
+→ structured result
+```
+
+The first adapter should do only:
+
+```text
+start sp run
+capture job_id
+wait for a terminal result
+read sp result --json
+normalize exit/failure
+return JSON
+```
+
+It must never:
+
+- scrape a terminal pane;
+- infer completion from log prose;
+- create a second XTRM worktree;
+- become the Bead authority;
+- duplicate Specialists job state.
+
+### 11.5 Ponytail correction to the proposed adapter surface
+
+The QuestDB plan lists many potential `xtrm-archon` commands. Do not implement that surface up front.
+
+Initial implementation should contain only the commands required by the read-only planning experiment, preferably wrappers over existing tools. Add another command only when a real workflow node cannot be expressed safely with an existing CLI or a short deterministic script.
+
+### 11.6 Evaluation sequence
+
+Run:
+
+- **A:** native Archon nodes;
+- **B:** the same DAG with selected analysis nodes delegated to Specialists.
+
+Compare:
+
+- graph determinism;
+- routing correctness;
+- role fidelity;
+- structured-output reliability;
+- evidence traceability;
+- pause/resume;
+- failure semantics;
+- UI clarity;
+- adapter size;
+- preserved xtmux/Specialists identities;
+- cost and operator intervention.
+
+Do not build production execution until planning behavior is proven.
+
+---
+
+## 12. Merge and integration
+
+### 12.1 Current evidence
+
+The stack now contains:
+
+- coordinator-based Specialist branch ancestry;
+- a live Suite C integration test;
+- `xtrm.branch.integration.v1`;
+- `sp integration record`;
+- topology fields for branch/worktree/parent;
+- forensic lineage.
+
+Therefore the next work should not invent a merge database or custom branch graph.
+
+### 12.2 Minimal integration flow
+
+```text
+Specialist result accepted
+→ coordinator integrates Specialist branch into coordinator branch
+→ Git confirms resulting commit
+→ caller runs sp integration record
+→ xtrm.branch.integration.v1 records the observed result
+→ topology/forensics can reconstruct the relationship
+```
+
+Git remains authority. The event is evidence.
+
+### 12.3 Deterministic merge workflow candidate
+
+The Archon merge-FIFO experiment is a useful model for a future coordinator merge gate:
+
+1. Compute eligible branches or PRs deterministically.
+2. Check unresolved Codex or reviewer blockers independently.
+3. Run deterministic repository and ancestry preflight.
+4. Ask the model for advisory risk analysis only.
+5. Require coordinator or operator approval.
+6. Merge in the predetermined order.
+7. Record integration through `sp integration record`.
+8. Independently re-query Git/GitHub.
+9. Run post-merge hygiene.
+
+This remains experimental until tested against real XTRM chain output.
+
+---
+
+## 13. Specialists hygiene
+
+Process cleanup and worktree deletion must remain separate.
+
+### 13.1 Terminal job cleanup
+
+At terminal transition, Specialists should automatically release only resources owned by that job:
+
+- RPC/agent child;
+- process group;
+- owned legacy tmux session;
+- steer/resume FIFO;
+- temporary prompt/materialization files;
+- transient marker artifacts.
+
+It must preserve:
+
+- result;
+- observability rows;
+- Bead handoff;
+- branch;
+- worktree;
+- integration evidence.
+
+### 13.2 Waiting jobs
+
+Use the existing waiting lifecycle and configured `waiting_auto_close_ms`.
+
+Expected behavior:
+
+```text
+enter waiting
+→ publish one waiting notification
+→ suppress duplicate unchanged notifications
+→ resume, finalize, stop, or auto-close
+→ publish the resulting transition
+```
+
+### 13.3 Dead active jobs
+
+Reconciliation rule:
+
+```text
+status in starting/running/waiting
++ owned PID is dead
+→ mark canonical error/orphaned state
+→ release remaining owned resources
+→ notify parent
+```
+
+### 13.4 Worktree hygiene
+
+Worktree cleanup must remain read-only/proposal-first until integration evidence is reliable.
+
+Classify:
+
+- recent and behind;
+- dirty;
+- unlanded commits;
+- integrated and safe to prune;
+- stale with work;
+- orphan with no known PR/integration evidence.
+
+Never auto-prune a dirty or unlanded worktree.
+
+### 13.5 No new daemon initially
+
+Do not add a global reaper daemon yet.
+
+First:
+
+- fix terminal cleanup at the shared Supervisor seam;
+- retain `sp clean` for repair;
+- run read-only hygiene through the Archon experiment;
+- measure whether new orphan creation continues.
+
+Add periodic reconciliation only if the local cleanup fix is insufficient.
+
+---
+
+## 14. Core and skill changes
+
+Update only canonical skill sources, then re-vendor through the existing process.
+
+Priority skills:
+
+- `multiplexing`;
+- `multiplexing-team`;
+- `using-specialists`;
+- `chain-coordinator`;
+- `pr-reviewer`;
+- `deploy-monitor`.
+
+Required rules:
+
+```text
+Completed generic agent output → xtmux agent-last
+Exact coordination message → xtmux message-get
+Complete Specialist output → sp result --json
+Pane capture → live terminal-only diagnostics
+```
+
+Coordinator contract:
+
+```text
+- Consume typed Specialist transition messages.
+- Follow the chain template for eligible next steps.
+- Do not implement delegated work directly.
+- Integrate accepted Specialist branches into the coordinator branch.
+- Record integration evidence.
+- Do not merge the coordinator branch into main unless explicitly authorized.
+- Before final completion, account for every owned non-terminal job.
+- Report unresolved review threads, unintegrated branches, and preserved worktrees.
+```
+
+Review contract:
+
+```text
+PASS is forbidden while actionable unresolved review threads remain.
+```
+
+Deployment contract:
+
+```text
+PR merged is not deployment evidence.
+Topology discovers branch/PR/job.
+deploy-monitor verifies the deployed state.
+```
+
+---
+
+## 15. Remaining audit work
+
+### 15.1 Revalidate prior Codex findings
+
+Later merges may have superseded earlier findings. For every current PR or affected code path:
+
+```text
+list unresolved threads
+→ determine whether the finding still reproduces
+→ fix once in the shared seam or reply with evidence
+→ resolve the thread
+```
+
+Prioritize:
+
+1. security or data-loss risk;
+2. P1 correctness;
+3. P2 correctness;
+4. outdated findings.
+
+### 15.2 Specific areas to re-audit
+
+- Core topology source ledger completeness.
+- Cross-repository worktree discovery.
+- Pane routing for obligations and parent lineage.
+- PR state association with the correct job/coordinator branch.
+- xtmux Claude transcript extraction and `agent-last` availability.
+- Specialists terminal cleanup and orphan creation.
+- Stale skill copies after canonical updates.
+- Open Core PR #484 and global-skill migration durability.
+
+---
+
+## 16. Minimal implementation packages
+
+### Package A — shared notification contract
+
+**Repositories:** Core contracts, Specialists
+**Scope:**
+
+- add `xtrm.specialist.parent-notification.v1` only if cross-repo parsing requires it;
+- validate bounded fields and trust-boundary rules;
+- one focused schema test.
+
+**Skipped:** schema registry expansion, compatibility negotiation, notification database.
+
+### Package B — Specialists direct parent notification
+
+**Repository:** Specialists
+**Scope:**
+
+- call one notification helper from the shared lifecycle/handoff seam;
+- route only through verified runtime lineage;
+- send waiting/terminal messages through existing xtmux CLI;
+- emit forensic sent/failed evidence;
+- never fail the job because delivery failed;
+- one focused transition test plus one routing test.
+
+**Skipped:** outbox, daemon, retry worker, notification CLI.
+
+### Package C — terminal resource hygiene
+
+**Repository:** Specialists
+**Scope:**
+
+- audit every terminal exit through the shared Supervisor path;
+- release resources owned by the job;
+- preserve worktree/branch/result/evidence;
+- one orphan-regression test.
+
+**Skipped:** automatic worktree pruning.
+
+### Package D — canonical skill propagation
+
+**Repositories:** Specialists source skill, Core vendored/runtime distribution
+**Scope:**
+
+- update result retrieval hierarchy;
+- remove ordinary result-discovery capture guidance;
+- add coordinator notification and final-accounting rules;
+- re-vendor once.
+
+### Package E — live integration extension
+
+**Repository:** Core integration suite, with installed trio
+**Scope:**
+
+Extend the existing live Suite C scenario:
+
+```text
+launch coordinator
+→ commit coordinator-only change
+→ dispatch Specialist
+→ verify Specialist branch ancestry
+→ complete Specialist
+→ verify result appended to Bead
+→ verify typed xtmux message targets parent
+→ wake/read exact message
+→ retrieve sp result --json
+→ integrate branch
+→ record sp integration record
+→ verify topology and forensic lineage
+→ verify owned runtime cleanup
+```
+
+No new simulation framework.
+
+### Package F — Archon read-only experiment
+
+**Location:** experimental workflow repository/configuration
+**Scope:**
+
+- run QuestDB planning workflow only;
+- no worktree ownership in Archon;
+- deterministic NO-GO evaluator;
+- native run and Specialist-backed run;
+- complete scorecard;
+- preserve raw artifacts and run IDs.
+
+**Skipped:** production execution, automatic board writes by default, Archon→Substrate compilation.
+
+### Package G — deterministic merge/hygiene experiment
+
+**Status:** open design, separate from Packages A–E
+**Scope:**
+
+- use read-only hygiene first;
+- test deterministic merge queue and Codex gate;
+- require approval before mutation;
+- record integration;
+- independently verify;
+- no automatic pruning.
+
+---
+
+## 17. Acceptance criteria
+
+The follow-up is complete when all of the following are true.
+
+### Notification
+
+- A terminal or waiting Specialist transition sends exactly one typed message.
+- The message reaches the verified assigned parent.
+- The message contains the exact result/action commands.
+- Full output is not duplicated in the message.
+- Delivery failure does not alter the job verdict.
+- Sent/failed delivery is visible through `xtrm.forensic.v1`.
+
+### Retrieval
+
+- The parent does not use `sp feed` polling for ordinary completion.
+- The parent does not use pane capture for a completed result.
+- `sp result --json` returns the authoritative result.
+- `xtmux message-get` returns the exact coordination payload.
+
+### Integration
+
+- Specialist branch descends from the coordinator branch.
+- Accepted work integrates into the coordinator branch.
+- Integration is recorded through `sp integration record`.
+- Git remains the source of truth.
+- Review blockers are resolved or explicitly reported.
+
+### Hygiene
+
+- Terminal jobs release owned process/session/FIFO resources.
+- Worktrees containing unintegrated work are preserved.
+- No automatic prune occurs without deterministic safety evidence.
+- Every chain completion accounts for remaining active/waiting jobs.
+
+### Workflow determinism
+
+- The chain template determines standard next-node eligibility.
+- Deterministic gates cannot be overridden by LLM prose.
+- The coordinator handles judgment and exceptions, not procedural memory.
+- Archon remains experimental until scorecard evidence supports a narrower decision.
+
+---
+
+## 18. Non-goals
+
+The following are explicitly excluded from the immediate implementation:
+
+- replacing xtmux messages with a Specialists notification bus;
+- adding a Specialists-specific Pi extension or Claude hook;
+- copying full Specialist output into wake prompts;
+- building a notification outbox before message loss is observed;
+- introducing a global cleanup daemon before fixing local cleanup;
+- automatic worktree deletion;
+- making Archon the XTRM source of truth;
+- running both Archon and Core worktree ownership in one workflow;
+- compiling Archon YAML into Substrate templates before experiments;
+- automatic production QuestDB maintenance;
+- allowing an LLM to override deterministic operational gates;
+- creating many `xtrm-archon` commands speculatively.
+
+---
+
+## 19. Recommended order
+
+1. Merge or resolve Core PR #484.
+2. Revalidate current unresolved review findings against the new repository heads.
+3. Implement the shared Specialist parent-notification contract.
+4. Emit direct parent notifications from the existing lifecycle/handoff seam.
+5. Audit and fix terminal owned-resource cleanup.
+6. Land the canonical chain-template resolver and precise deterministic dispatch contract together, aligned with the Specialists roadmap and the modernization document.
+7. Update and re-vendor canonical orchestration skills.
+8. Extend live Suite C with template resolution, exact dispatch, notification, result, integration-record, and cleanup assertions.
+9. Run the Archon QuestDB planning experiment in native and Specialist-backed modes.
+10. Evaluate the merge/hygiene experiment separately.
+11. Produce a narrower architectural decision from measured results.
+
+---
+
+## 20. Evidence register
+
+### Repository PRs
+
+- Core #475 — live Suite C Specialist ancestry/integration lane
+  https://github.com/xtrm-dev/core/pull/475
+- Core #476 — runtime compatibility before worktree creation
+  https://github.com/xtrm-dev/core/pull/476
+- Core #477 — PR installer smoke
+  https://github.com/xtrm-dev/core/pull/477
+- Core #479 — topology agent contract widening
+  https://github.com/xtrm-dev/core/pull/479
+- Core #483 — retired skill-tier pruning
+  https://github.com/xtrm-dev/core/pull/483
+- Core #484 — scope-aware skill scaffolding, open at snapshot
+  https://github.com/xtrm-dev/core/pull/484
+- xtmux #56 — canonical Beads lifecycle stream
+  https://github.com/Jaggerxtrm/xtmux/pull/56
+- xtmux #57 — agent-last and message-get
+  https://github.com/Jaggerxtrm/xtmux/pull/57
+- xtmux #58 — hook installer idempotency
+  https://github.com/Jaggerxtrm/xtmux/pull/58
+- xtmux #60 — human event renderer and xtmux-events
+  https://github.com/Jaggerxtrm/xtmux/pull/60
+- xtmux #61 — topology role/worktree/branch/parent pane
+  https://github.com/Jaggerxtrm/xtmux/pull/61
+- Specialists #199 — branch-integration event primitive
+  https://github.com/xtrm-dev/specialists/pull/199
+- Specialists #200 — coordinator branch ancestry
+  https://github.com/xtrm-dev/specialists/pull/200
+- Specialists #201 — `sp integration record`
+  https://github.com/xtrm-dev/specialists/pull/201
+- Specialists #202 — `sp render-bead`
+  https://github.com/xtrm-dev/specialists/pull/202
+
+### Internal and experimental material
+
+- **Archon + XTRM — QuestDB Maintenance Workflow Plan**
+- Archon workflow examples:
+  - `orch-hygiene-readonly`
+  - `xtrm-merge-fifo`
+  - `sre-triage-live`
+- Existing Specialists modernization and open-issues audit context.
+- Prior Core/xtmux/Specialists cross-repository audit findings and Codex review threads.
+
+---
+
+## 21. Final architectural position
+
+The shortest path to a more deterministic system is not another orchestrator layer inside Specialists.
+
+It is:
+
+```text
+declarative chain
++ deterministic gates
++ Specialists-owned lifecycle
++ direct typed parent notification
++ xtmux-owned delivery and wake
++ authoritative structured result
++ Git-owned integration truth
++ forensic evidence
++ explicit cleanup
+```
+
+Archon is valuable as an experimental workflow engine and as evidence for better chain semantics. Its strongest patterns should influence XTRM only after they have been exercised in real read-only workflows and compared against the existing Specialists runtime.
+
+The immediate production improvement remains small: one lifecycle notification helper, one shared payload contract, one generic xtmux delivery path, one terminal cleanup audit, and one live end-to-end check.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-review-gate.yml`: blocks merges while any LLM-bot-authored review thread is unresolved, or any allowlisted bot has active `CHANGES_REQUESTED`.
- Bot detection defaults to `(?i)codex|coderabbit|claude`; overridable via repo variable `PR_REVIEW_GATE_BOT_RE`.
- Fails closed on GraphQL errors. Codex-shaped reviews (state=COMMENTED, submittedAt=null) route through the unresolved-thread path.
- Triggers on `pull_request`, `pull_request_review`, `pull_request_review_thread`, `issue_comment` so status auto-refreshes on bot posts / thread resolution.
- `actions/github-script` pinned to SHA per repo semgrep policy.

## Context
Part of epic `xtrm-54zwl` — moving the Codex/LLM-bot review gate out of the client-side Archon `xtrm-merge-fifo` workflow (which only fires when the operator drives merges through Archon) into a canonical CI required status check that also enforces on plain `gh pr merge`.

Follow-ups already scoped:
- `xtrm-54zwl.6` — manual branch-protection toggle + live demo verification (post-merge)
- `xtrm-54zwl.2` — canonicalize as a `security-pipeline` template
- `xtrm-54zwl.3` — simplify Archon `xtrm-merge-fifo` to consume this check
- `xtrm-54zwl.4` — fix stale `openai-codex[bot]` references in review skills
- `xtrm-54zwl.5` — propagate to other xtrm-managed repos

Mirror PR in `specialists` (also touched by this epic) follows separately.

## Test plan
- [ ] CI runs and the `pr-review-gate / gate` check appears on this PR
- [ ] After merge: Settings → Branches → main → require `pr-review-gate / gate`
- [ ] Demo cycle: bot-authored review thread unresolved → red; resolved → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)