### PR TITLE
ci(pr-review-gate): explicit job name for readable required-check context

### DIFF
--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted, dismissed]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
   issue_comment:
     types: [created, edited, deleted]
 

--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -1,5 +1,12 @@
 name: pr-review-gate
 
+# Limitation: GitHub Actions rejects `pull_request_review_thread` even though
+# the docs list it, so resolving a thread emits no event this workflow listens
+# on. Refresh options after resolving a bot thread:
+#   - re-request the failed check-suite from the PR checks tab (one click)
+#   - `gh workflow run pr-review-gate.yml -F pr=<n>` (workflow_dispatch)
+#   - push any commit (or an empty one) to the PR branch
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -7,11 +14,17 @@ on:
     types: [submitted, dismissed]
   issue_comment:
     types: [created, edited, deleted]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to re-check
+        required: true
+        type: string
 
 jobs:
   gate:
     name: pr-review-gate
-    if: github.event.pull_request || github.event.issue.pull_request
+    if: github.event.pull_request || github.event.issue.pull_request || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -23,7 +36,8 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request?.number
-                    ?? context.payload.issue?.number;
+                    ?? context.payload.issue?.number
+                    ?? Number(context.payload.inputs?.pr);
             if (!pr) { core.info('no PR context; skipping'); return; }
             const { owner, repo } = context.repo;
             // Strip Python/Perl-style inline flag if present; JS regex doesn't support it.

--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   gate:
+    name: pr-review-gate
     if: github.event.pull_request || github.event.issue.pull_request
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -19,14 +19,16 @@ jobs:
       - name: Check unresolved LLM-bot threads and bot verdict
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
-          BOT_RE: ${{ vars.PR_REVIEW_GATE_BOT_RE || '(?i)codex|coderabbit|claude' }}
+          BOT_RE: ${{ vars.PR_REVIEW_GATE_BOT_RE || 'codex|coderabbit|claude' }}
         with:
           script: |
             const pr = context.payload.pull_request?.number
                     ?? context.payload.issue?.number;
             if (!pr) { core.info('no PR context; skipping'); return; }
             const { owner, repo } = context.repo;
-            const botRe = new RegExp(process.env.BOT_RE);
+            // Strip Python/Perl-style inline flag if present; JS regex doesn't support it.
+            const rawPattern = process.env.BOT_RE.replace(/^\(\?[imsux]+\)/, '');
+            const botRe = new RegExp(rawPattern, 'i');
 
             let data;
             try {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Use JS-native regex flag ('i') instead of Perl-style (?i)** ([f6be0d4](https://github.com/xtrm-dev/core/commit/f6be0d4543c1d80c314d46ce329d13426092dfe0)) — 2026-07-24 12:41
 
+- **Restore pull_request_review_thread trigger to verify GH parses it** ([8301732](https://github.com/xtrm-dev/core/commit/83017322a42f7e06798b4f5878cefe4ccd426c38)) — 2026-07-24 12:44
+
 ## [v0.11.2] — 2026-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Set explicit job name + drop unsupported pull_request_review_thread trigger** ([feb3bf3](https://github.com/xtrm-dev/core/commit/feb3bf3a748a11a882be06aeb648267e4c14694f)) — 2026-07-24 12:29
 
+- **Use JS-native regex flag ('i') instead of Perl-style (?i)** ([62a2e6f](https://github.com/xtrm-dev/core/commit/62a2e6f674e72677d28a1f702bbf083797f88da0)) — 2026-07-24 12:41
+
 ## [v0.11.2] — 2026-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Set explicit job name + drop unsupported pull_request_review_thread trigger** ([feb3bf3](https://github.com/xtrm-dev/core/commit/feb3bf3a748a11a882be06aeb648267e4c14694f)) — 2026-07-24 12:29
 
-- **Use JS-native regex flag ('i') instead of Perl-style (?i)** ([62a2e6f](https://github.com/xtrm-dev/core/commit/62a2e6f674e72677d28a1f702bbf083797f88da0)) — 2026-07-24 12:41
+- **Use JS-native regex flag ('i') instead of Perl-style (?i)** ([f6be0d4](https://github.com/xtrm-dev/core/commit/f6be0d4543c1d80c314d46ce329d13426092dfe0)) — 2026-07-24 12:41
 
 ## [v0.11.2] — 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Set explicit job name for readable required-check context** ([6dfb7ea](https://github.com/xtrm-dev/core/commit/6dfb7eaae4b189bc01f7084783bcf8fec0312bd3)) — 2026-07-24 12:29
 
-- **Set explicit job name + drop unsupported pull_request_review_thread trigger** ([4bf642e](https://github.com/xtrm-dev/core/commit/4bf642e0321ccd2c405e920ef6112a6c00c675fc)) — 2026-07-24 12:29
+- **Set explicit job name + drop unsupported pull_request_review_thread trigger** ([feb3bf3](https://github.com/xtrm-dev/core/commit/feb3bf3a748a11a882be06aeb648267e4c14694f)) — 2026-07-24 12:29
 
 ## [v0.11.2] — 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **/prd-to-plan skill for spec → runnable bd board** ([695006e](https://github.com/xtrm-dev/core/commit/695006e2041315c876ebac142a7bc9d9f266a2dd)) — 2026-07-24 05:32
+- **/prd-to-plan skill for spec → runnable bd board** ([7e8c105](https://github.com/xtrm-dev/core/commit/7e8c10589b6d93bc32f29c9ce2c2da119cf891a9)) — 2026-07-24 05:32
 
 ### Other changes
 
@@ -21,9 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Auto-refresh CHANGELOG.md — pre-push hook + PR CI check (xtrm-reyem.12) (#488)** ([6e7040d](https://github.com/xtrm-dev/core/commit/6e7040df7ecb9dafd0fc6a732f98e4a9897b3be1)) — 2026-07-23 05:18
 
-- **Audit-reconcile v0724 program plan + consolidated determinism report** ([be2acc8](https://github.com/xtrm-dev/core/commit/be2acc8d4cc287c3d26486f195a0cde198da9427)) — 2026-07-24 05:31
+- **Audit-reconcile v0724 program plan + consolidated determinism report** ([48f6e7c](https://github.com/xtrm-dev/core/commit/48f6e7c8443eb8b2654ecd9415ce60d5ee6647fc)) — 2026-07-24 05:31
 
-- **Add pr-review-gate required-status-check workflow (xtrm-54zwl.1)** ([1693029](https://github.com/xtrm-dev/core/commit/169302900448648bc557be23a7d3cd8b28a00eb8)) — 2026-07-24 07:50
+- **Add pr-review-gate required-status-check workflow (xtrm-54zwl.1)** ([6a6c19e](https://github.com/xtrm-dev/core/commit/6a6c19ec230c48590bfa289bff6ba57711c7d510)) — 2026-07-24 07:50
+
+- **Set explicit job name for readable required-check context** ([6dfb7ea](https://github.com/xtrm-dev/core/commit/6dfb7eaae4b189bc01f7084783bcf8fec0312bd3)) — 2026-07-24 12:29
+
+- **Set explicit job name + drop unsupported pull_request_review_thread trigger** ([4bf642e](https://github.com/xtrm-dev/core/commit/4bf642e0321ccd2c405e920ef6112a6c00c675fc)) — 2026-07-24 12:29
 
 ## [v0.11.2] — 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Use JS-native regex flag ('i') instead of Perl-style (?i)** ([f6be0d4](https://github.com/xtrm-dev/core/commit/f6be0d4543c1d80c314d46ce329d13426092dfe0)) — 2026-07-24 12:41
 
-- **Restore pull_request_review_thread trigger to verify GH parses it** ([8301732](https://github.com/xtrm-dev/core/commit/83017322a42f7e06798b4f5878cefe4ccd426c38)) — 2026-07-24 12:44
+- **Add workflow_dispatch for post-resolve manual refresh** ([4f3cab4](https://github.com/xtrm-dev/core/commit/4f3cab48ed4dd98a3d4b155706e66e331f1f791b)) — 2026-07-24 12:46
 
 ## [v0.11.2] — 2026-07-22
 


### PR DESCRIPTION
One-line follow-up to make the required-status-check context descriptive (`pr-review-gate` instead of `gate`). Same for xtrm-dev/specialists#211 and mercuryintelligence/infra#246.