### PR TITLE
skills(security-pipeline): canonicalize pr-review-gate template + refresh review-skill docs (xtrm-54zwl)

### DIFF
--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -44,42 +44,70 @@ jobs:
             const rawPattern = process.env.BOT_RE.replace(/^\(\?[imsux]+\)/, '');
             const botRe = new RegExp(rawPattern, 'i');
 
-            let data;
+            // Bot detection: MUST be a Bot account (GraphQL __typename) AND
+            // login matches the pattern. Prevents human logins containing
+            // "codex"/"claude" from tripping the gate.
+            const isBot = (author) =>
+              !!author && author.__typename === 'Bot' &&
+              botRe.test(author.login ?? '');
+
+            // Paginate reviewThreads — a PR with >100 threads could hide an
+            // unresolved bot thread behind the first page. Same for reviews.
+            const threads = [];
+            let reviewsPage = [];
+            let cursor = null;
+            let reviewCursor = null;
             try {
-              data = await github.graphql(`
-                query($o:String!,$r:String!,$n:Int!){
-                  repository(owner:$o,name:$r){
-                    pullRequest(number:$n){
-                      reviewThreads(first:100){
-                        nodes{
-                          isResolved
-                          isOutdated
-                          comments(first:1){nodes{author{login}}}
+              for (let page = 0; page < 20; page++) {  // hard cap: 20 pages = 2000 threads
+                const data = await github.graphql(`
+                  query($o:String!,$r:String!,$n:Int!,$tc:String,$rc:String){
+                    repository(owner:$o,name:$r){
+                      pullRequest(number:$n){
+                        reviewThreads(first:100, after:$tc){
+                          pageInfo{ hasNextPage endCursor }
+                          nodes{
+                            isResolved
+                            isOutdated
+                            comments(first:1){nodes{author{login __typename}}}
+                          }
+                        }
+                        reviews(first:100, after:$rc){
+                          pageInfo{ hasNextPage endCursor }
+                          nodes{ state submittedAt author{login __typename} }
                         }
                       }
-                      reviews(first:100){
-                        nodes{ state author{login} submittedAt }
-                      }
                     }
-                  }
-                }`, { o: owner, r: repo, n: pr });
+                  }`, { o: owner, r: repo, n: pr, tc: cursor, rc: reviewCursor });
+                const rt = data.repository.pullRequest.reviewThreads;
+                const rv = data.repository.pullRequest.reviews;
+                threads.push(...rt.nodes);
+                if (page === 0) reviewsPage = rv.nodes.slice();
+                else reviewsPage.push(...rv.nodes);
+                const nextT = rt.pageInfo.hasNextPage ? rt.pageInfo.endCursor : null;
+                const nextR = rv.pageInfo.hasNextPage ? rv.pageInfo.endCursor : null;
+                if (!nextT && !nextR) break;
+                cursor = nextT ?? cursor;
+                reviewCursor = nextR ?? reviewCursor;
+                if (page === 19 && (nextT || nextR)) {
+                  core.setFailed('BLOCKED — PR has >2000 threads/reviews; gate cannot verify all pages (fail closed)');
+                  return;
+                }
+              }
             } catch (e) {
               core.setFailed(`GraphQL failed (fail closed): ${e.message}`);
               return;
             }
 
-            const threads = data.repository.pullRequest.reviewThreads.nodes;
             const unresolvedBot = threads.filter(t =>
               !t.isResolved && !t.isOutdated &&
-              t.comments.nodes.some(c => botRe.test(c.author?.login ?? ''))
+              t.comments.nodes.some(c => isBot(c.author))
             );
 
-            const reviews = data.repository.pullRequest.reviews.nodes;
             const latest = {};
-            for (const r of reviews) {
-              const login = r.author?.login;
-              if (!login || !botRe.test(login)) continue;
+            for (const r of reviewsPage) {
+              if (!isBot(r.author)) continue;
               if (!r.submittedAt) continue; // Codex-shaped: null timestamp; threads-only path
+              const login = r.author.login;
               const prev = latest[login];
               if (!prev || new Date(prev.submittedAt) < new Date(r.submittedAt)) {
                 latest[login] = r;

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -154,7 +154,7 @@
           "version": "0.11.2"
         },
         "code-review/SKILL.md": {
-          "hash": "dbb5bcd6d3e37a3d18a8ee5c2be41c274c382c4e0c8bf8c7c9c9eb135e641f61",
+          "hash": "e6ebc4c4d7f123dda215f18ce3fa111b21dbe2bf211ce9b7fc976a3b9e742196",
           "version": "0.11.2"
         },
         "deepwiki/SKILL.md": {
@@ -646,11 +646,7 @@
           "version": "0.11.2"
         },
         "pr-reviewer/SKILL.md": {
-          "hash": "7ef3fba0d998d09122e19478d428a1537940fe91f1b5eb683428d57c4d431641",
-          "version": "0.11.2"
-        },
-        "prd-to-plan/SKILL.md": {
-          "hash": "b5891dc0b9e4ee198eb5c0270c386d7c220d6f608550b92b4c7954548afcc1b5",
+          "hash": "4a56d9bb089ac7fb05cbf60e9b526550bbfa1dfb074d72d2f1f84cb9dfcc0f8b",
           "version": "0.11.2"
         },
         "premortem/SKILL.md": {
@@ -763,106 +759,6 @@
         },
         "security-pipeline/templates/scripts/semgrep-diff.sh": {
           "hash": "e4efc20d218e6f6689725a4a9aca37958384216ba080bf89ba2307cd529d6dc2",
-          "version": "0.11.2"
-        },
-        "service-skills/install/git-hooks/doc_reminder.py": {
-          "hash": "90d33305dcc8fcc73bae2f9ad7390be118617743dbb38808d61710dc1662879b",
-          "version": "0.11.2"
-        },
-        "service-skills/install/git-hooks/post_merge_drift_sweep.py": {
-          "hash": "39d6f4e0afe7946636e47b2877cfc71afe6589b7ab045f86f0f739a8ccc886b9",
-          "version": "0.11.2"
-        },
-        "service-skills/install/git-hooks/skill_staleness.py": {
-          "hash": "39d1ac16dee329bab34a646216e2d851856a07d53f6c0f909709fe217f2ba22f",
-          "version": "0.11.2"
-        },
-        "service-skills/install/install-service-skills.py": {
-          "hash": "e89bc2fd5fe9cb463f9e56360fcd5f8994479e5fc665044af76404b1ddc3eb29",
-          "version": "0.11.2"
-        },
-        "service-skills/install/service-skills-readme.md": {
-          "hash": "95d31a8ae4241255c988d0aa35009070b63ac08fbf31e2cb8025e05f9a8ed585",
-          "version": "0.11.2"
-        },
-        "service-skills/install/settings.json": {
-          "hash": "dd832d6f054bda8e82b389b257d923944761f4c28d09ba8b28c7e7196784a657",
-          "version": "0.11.2"
-        },
-        "service-skills/references/creating.md": {
-          "hash": "6952c0d0f98f91fa7f3619d6db0925f4d628c583fb84997bb2c87aa05d777441",
-          "version": "0.11.2"
-        },
-        "service-skills/references/routing.md": {
-          "hash": "69e5d873bb35bf680cdd568c65963fcb72ee1acc7cb9d86f395c37d8edb8e515",
-          "version": "0.11.2"
-        },
-        "service-skills/references/script_quality_standards.md": {
-          "hash": "964476a17aea08505edddae1616899ebcc9f6f1f990e060cf37c1676a7f54b7c",
-          "version": "0.11.2"
-        },
-        "service-skills/references/service_skill_contract.json": {
-          "hash": "8df02e365d539651f4cff1f8999407c1be2c5a2f895a9f14c9efc65af87855d5",
-          "version": "0.11.2"
-        },
-        "service-skills/references/system-guide.md": {
-          "hash": "3f07f08f740ea5d3261c1d39f0942064a84a0e40a67a1ccf130cad96f8cbf6da",
-          "version": "0.11.2"
-        },
-        "service-skills/references/updating.md": {
-          "hash": "a6db70b6e91e405827e9c31718032a68571d3b38f8932605d7fd1ef089bc7e50",
-          "version": "0.11.2"
-        },
-        "service-skills/references/using.md": {
-          "hash": "b6876929a55c7c326d0214b6f06afe2967373e01826bef370bd1d97c19cc5662",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/bootstrap.py": {
-          "hash": "0fb9b2dc142c54bf62abaeb80d92aa61491745ab77ba2bd0576950a603ef7016",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/cataloger.py": {
-          "hash": "764e7e2684b31ad674ad3d2b0f2b430bbd8e2eef0d513949d963d82e3c508af1",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/deep_dive.py": {
-          "hash": "fb28936c7c690566960b63bab419a54588fe55495f009da00b5b153e77f42597",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/drift_detector.py": {
-          "hash": "23e805110571cc7c9527259044d5d1c2728aae225110ff1d83ffd50bdf464aec",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/layout_migrator.py": {
-          "hash": "c14712c262ba5c5b6bc33fbce759a33a8b0e61632d2382d31107d5a18cf287c8",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/reconcile.py": {
-          "hash": "735416ab8c1198ea2ed9941732b4c1b23de02de9883e1bd7ca0511edd30a3da0",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/scaffolder.py": {
-          "hash": "07071c8a14b5dd493e095dbba3db70e93a4aa73ff9180811f91480d33c47a384",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/scope.py": {
-          "hash": "2f0f5a4d6f4af4a93e3a4fa5db18e32f5aba87743bafc0105905cccbb2f41cf6",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/skill_activator.py": {
-          "hash": "b76f7861dacf302f9d958202e8dd60bf54ad1265d098e5f3072423beac0a25a2",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/skill_migrator.py": {
-          "hash": "d874fbc829e4da6c4f47526f9d2f914aad9d3e5e1c1a51347b2b38c0211e3c29",
-          "version": "0.11.2"
-        },
-        "service-skills/scripts/umbrella_generator.py": {
-          "hash": "842890132fbb5f69c33bf2f5b5f51291ca8f931afce034426724959b15ad71fd",
-          "version": "0.11.2"
-        },
-        "service-skills/SKILL.md": {
-          "hash": "ca9d1e2ce74b69f2cda6d71995674bcd5f0454e16fc1d6c20311a419fd6e5d30",
           "version": "0.11.2"
         },
         "session-close-report/SKILL.md": {

--- a/.xtrm/skills/default/code-review/SKILL.md
+++ b/.xtrm/skills/default/code-review/SKILL.md
@@ -13,7 +13,7 @@ If you are on Claude Code and the plugin slash-command resolves, prefer it — i
 
 - The Judge in a multiplexed sprint (`/judge-with-codex`) needs to run a review on a PR from a pi/Codex pane.
 - Any pane needs a structured PR review and the Claude Code plugin is not resolvable.
-- Any operator wants a review that specifically weighs `openai-codex[bot]` comments and threads.
+- Any operator wants a review that specifically weighs Codex bot comments and threads (login matches `/codex/i` — currently `chatgpt-codex-connector[bot]`).
 
 ## When NOT to use
 
@@ -99,7 +99,7 @@ gh api repos/<owner>/<repo>/pulls/<N>/reviews \
   --jq '.[] | {user:.user.login, state, body}'
 ```
 
-Filter for Codex (`openai-codex[bot]` / `openai/codex`) — those are the highest-signal, non-authoritative findings. Human reviewer comments matter too but you already know how to weigh those.
+Filter for Codex (login matches `/codex/i` — currently `chatgpt-codex-connector[bot]`, historically `openai-codex[bot]`) — those are the highest-signal, non-authoritative findings. Human reviewer comments matter too but you already know how to weigh those.
 
 ### 5. Cross-check Codex against the diff
 

--- a/.xtrm/skills/default/pr-reviewer/SKILL.md
+++ b/.xtrm/skills/default/pr-reviewer/SKILL.md
@@ -44,7 +44,9 @@ Ambiguity resolution: when torn between `PASS_WITH_NOTES` and `NEEDS_CHANGES`, a
 
 ## Codex integration — mandatory read on every PR
 
-Codex (`openai-codex[bot]` / `openai/codex`) leaves inline review comments on PRs automatically. Treat these as **high-signal, non-authoritative**: you verify every claim against the diff, and you never merge on Codex's word alone. The 82wh regression sat in production for over a month; the standard of review is now higher.
+Codex (login matches `/codex/i` — currently `chatgpt-codex-connector[bot]`, historically `openai-codex[bot]`) leaves inline review comments on PRs automatically. Treat these as **high-signal, non-authoritative**: you verify every claim against the diff, and you never merge on Codex's word alone. The 82wh regression sat in production for over a month; the standard of review is now higher.
+
+**Merge blocking now lives in CI.** The `pr-review-gate` GitHub Actions workflow (installed by the `security-pipeline` skill) is a required status check on `main`/`master` across xtrm-managed repos. It blocks merge while any LLM-bot-authored review thread is unresolved. This skill writes the human/agent-side verdict — per-finding rationale, AGREED/REJECTED/OWN sets, disagreement justification. The CI check is what actually blocks the merge.
 
 ### Fetching what Codex left
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Rename /prd-to-plan → /spec-dispatch (#494)** ([fa6e2be](https://github.com/xtrm-dev/core/commit/fa6e2be25fa6fa8e7f76bbe9016fd3fc1c0ce7f3)) — 2026-07-24 17:33
 
+- **Tighten to Bot __typename + paginate threads/reviews (per Codex P2s on #495)** ([69d5dbe](https://github.com/xtrm-dev/core/commit/69d5dbe38e33e8a9455d4bd5cf1c41e71f7e8b48)) — 2026-07-24 17:53
+
 ## [v0.11.2] — 2026-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Dump CI changelog:check diagnostics (#489)** ([428a27b](https://github.com/xtrm-dev/core/commit/428a27bfa1dcf3ae6d2e819db92533823ca0aa58)) — 2026-07-23 13:40
 
+- **Canonicalize pr-review-gate template + refresh review-skill docs (xtrm-54zwl.2 + .4)** ([0681860](https://github.com/xtrm-dev/core/commit/0681860caaf452b9b110b5be4666dd749c522199)) — 2026-07-24 17:38
+
 ### Project maintenance
 
 - **Auto-refresh CHANGELOG.md — pre-push hook + PR CI check (xtrm-reyem.12) (#488)** ([6e7040d](https://github.com/xtrm-dev/core/commit/6e7040df7ecb9dafd0fc6a732f98e4a9897b3be1)) — 2026-07-23 05:18
@@ -35,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Retire vendored service-skills from core [xtrm-56flm.6] (#493)** ([c2c7edc](https://github.com/xtrm-dev/core/commit/c2c7edca6034c98599b06419b0bcc269c4d8f9a3)) — 2026-07-24 15:03
 
-- **Rename /prd-to-plan → /spec-dispatch** ([44260ce](https://github.com/xtrm-dev/core/commit/44260cee6dde751e20d49ec19e55ae0b7c657edb)) — 2026-07-24 12:20
+- **Rename /prd-to-plan → /spec-dispatch (#494)** ([fa6e2be](https://github.com/xtrm-dev/core/commit/fa6e2be25fa6fa8e7f76bbe9016fd3fc1c0ce7f3)) — 2026-07-24 17:33
 
 ## [v0.11.2] — 2026-07-22
 

--- a/skills/judge-with-codex/SKILL.md
+++ b/skills/judge-with-codex/SKILL.md
@@ -36,7 +36,9 @@ Ambiguity resolution: when torn between `PASS_WITH_NOTES` and `NEEDS_CHANGES`, a
 
 ## Codex integration — mandatory read on every PR
 
-Codex (`openai-codex[bot]` / `openai/codex`) leaves inline review comments on PRs automatically. Treat these as **high-signal, non-authoritative**: you verify every claim against the diff, and you never merge on Codex's word alone. The 82wh regression sat in production for over a month; the standard of review is now higher.
+Codex (login matches `/codex/i` — currently `chatgpt-codex-connector[bot]`, historically `openai-codex[bot]`) leaves inline review comments on PRs automatically. Treat these as **high-signal, non-authoritative**: you verify every claim against the diff, and you never merge on Codex's word alone. The 82wh regression sat in production for over a month; the standard of review is now higher.
+
+**Merge blocking now lives in CI.** The `pr-review-gate` GitHub Actions workflow (installed by the `security-pipeline` skill) is a required status check on `main`/`master` across xtrm-managed repos. It blocks merge while any LLM-bot-authored review thread is unresolved. This skill writes the human/agent-side verdict — per-finding rationale, AGREED/REJECTED/OWN sets, disagreement justification. The CI check is what actually blocks the merge.
 
 ### Fetching what Codex left
 

--- a/skills/security-pipeline/SKILL.md
+++ b/skills/security-pipeline/SKILL.md
@@ -18,14 +18,15 @@ project-agnostic — adapt the allowlists and dependabot ecosystems per repo.
 Do NOT use this skill if the repo already has a working `dependabot.yml` AND
 all three workflows (`osv-scanner.yml`, `semgrep.yml`, `gitleaks.yml`).
 
-## Architecture (4 layers)
+## Architecture (5 layers)
 
 ```
-git commit  ──► pre-commit  (gitleaks staged, ruff, hygiene)        ~1s
-git push    ──► pre-push    (semgrep diff-only, osv, anti-main)     ~30s
-PR opened   ──► CI          (osv-scanner, semgrep, gitleaks)        ~1m
-PR review   ──► Codex       (semantic AI review, optional)          ~2m
-PR merged   ──► Dependabot  (continuous vuln + version PRs)         async
+git commit  ──► pre-commit    (gitleaks staged, ruff, hygiene)          ~1s
+git push    ──► pre-push      (semgrep diff-only, osv, anti-main)       ~30s
+PR opened   ──► CI            (osv-scanner, semgrep, gitleaks)          ~1m
+PR review   ──► Codex         (semantic AI review, optional)            ~2m
+PR merge    ──► pr-review-gate (blocks while any LLM-bot thread unresolved)  ~5s
+PR merged   ──► Dependabot    (continuous vuln + version PRs)           async
 ```
 
 Pre-existing debt is NEVER blocked by the push gate — only NEW findings vs
@@ -67,9 +68,42 @@ The script CAN'T do these — operator walks them per target repo:
 
 1. **Codex Connector** (optional) — install at https://chatgpt.com/codex/cloud/settings/general
 2. **Branch protection rule** — Settings → Branches → classic rule for `main`
-   - Required checks: `OSV scan`, `Semgrep scan`, `Gitleaks scan`
+   - Required checks: `OSV scan`, `Semgrep scan`, `Gitleaks scan`, `pr-review-gate`
    - On free private repos rules don't enforce server-side; the pre-push hook fills the gap
+   - If the repo uses the newer **rulesets** API instead of classic protection, add
+     the same contexts as a `required_status_checks` rule on the default-branch ruleset.
+     One `gh api` PUT does it — see the "Enabling the gate (one-time, per repo)" section.
 3. **`make install-hooks`** in the target clone (or run `git config core.hooksPath .githooks`)
+
+## Enabling the gate (one-time, per repo)
+
+`pr-review-gate.yml` runs on every PR after bootstrap, but the check does NOT
+block merges until it's added to the required-checks list. Two paths depending
+on which protection model the repo uses:
+
+**Classic branch protection** (Settings → Branches → main → Require status checks):
+add context `pr-review-gate`. Or via API:
+
+```bash
+gh api -X POST /repos/OWNER/REPO/branches/main/protection/required_status_checks/contexts \
+  -f 'contexts[]=pr-review-gate'
+```
+
+**Rulesets** (Settings → Rules → Rulesets → the ruleset that targets your
+default branch): edit and add a `required_status_checks` rule with context
+`pr-review-gate`. Or via API — fetch the ruleset, append the rule, PUT it
+back (see xtrm-54zwl.6 bead notes for a scripted example).
+
+Bot detection defaults to `codex|coderabbit|claude` (case-insensitive) and is
+overridable via the `PR_REVIEW_GATE_BOT_RE` repo variable. To manually refresh
+the gate after resolving a thread (`pull_request_review_thread` isn't accepted
+by GitHub Actions despite the docs listing it):
+
+```bash
+gh workflow run pr-review-gate.yml -F pr=<n>
+```
+
+or click "re-request check-suite" in the PR checks tab, or push any commit.
 
 ## Files in `templates/`
 
@@ -78,6 +112,7 @@ The script CAN'T do these — operator walks them per target repo:
 | `.github/workflows/osv-scanner.yml` | same path | Vuln scan via OSV.dev |
 | `.github/workflows/semgrep.yml` | same path | SAST (replaces CodeQL) |
 | `.github/workflows/gitleaks.yml` | same path | Secret scan |
+| `.github/workflows/pr-review-gate.yml` | same path | Blocks merge on unresolved LLM-bot review threads |
 | `.gitleaks.toml` | same path | **Allowlist — adapt per project** (see below) |
 | `.semgrepignore` | same path | **Excludes — adapt per project** (see below) |
 | `.pre-commit-config.yaml` | same path | Two-stage local gate |

--- a/skills/security-pipeline/scripts/security-bootstrap.sh
+++ b/skills/security-pipeline/scripts/security-bootstrap.sh
@@ -86,6 +86,7 @@ echo "── Copying baseline files ──"
 copy_file .github/workflows/osv-scanner.yml
 copy_file .github/workflows/semgrep.yml
 copy_file .github/workflows/gitleaks.yml
+copy_file .github/workflows/pr-review-gate.yml
 copy_file .gitleaks.toml
 copy_file .semgrepignore
 copy_file .pre-commit-config.yaml

--- a/skills/security-pipeline/templates/.github/workflows/pr-review-gate.yml
+++ b/skills/security-pipeline/templates/.github/workflows/pr-review-gate.yml
@@ -44,42 +44,70 @@ jobs:
             const rawPattern = process.env.BOT_RE.replace(/^\(\?[imsux]+\)/, '');
             const botRe = new RegExp(rawPattern, 'i');
 
-            let data;
+            // Bot detection: MUST be a Bot account (GraphQL __typename) AND
+            // login matches the pattern. Prevents human logins containing
+            // "codex"/"claude" from tripping the gate.
+            const isBot = (author) =>
+              !!author && author.__typename === 'Bot' &&
+              botRe.test(author.login ?? '');
+
+            // Paginate reviewThreads — a PR with >100 threads could hide an
+            // unresolved bot thread behind the first page. Same for reviews.
+            const threads = [];
+            let reviewsPage = [];
+            let cursor = null;
+            let reviewCursor = null;
             try {
-              data = await github.graphql(`
-                query($o:String!,$r:String!,$n:Int!){
-                  repository(owner:$o,name:$r){
-                    pullRequest(number:$n){
-                      reviewThreads(first:100){
-                        nodes{
-                          isResolved
-                          isOutdated
-                          comments(first:1){nodes{author{login}}}
+              for (let page = 0; page < 20; page++) {  // hard cap: 20 pages = 2000 threads
+                const data = await github.graphql(`
+                  query($o:String!,$r:String!,$n:Int!,$tc:String,$rc:String){
+                    repository(owner:$o,name:$r){
+                      pullRequest(number:$n){
+                        reviewThreads(first:100, after:$tc){
+                          pageInfo{ hasNextPage endCursor }
+                          nodes{
+                            isResolved
+                            isOutdated
+                            comments(first:1){nodes{author{login __typename}}}
+                          }
+                        }
+                        reviews(first:100, after:$rc){
+                          pageInfo{ hasNextPage endCursor }
+                          nodes{ state submittedAt author{login __typename} }
                         }
                       }
-                      reviews(first:100){
-                        nodes{ state author{login} submittedAt }
-                      }
                     }
-                  }
-                }`, { o: owner, r: repo, n: pr });
+                  }`, { o: owner, r: repo, n: pr, tc: cursor, rc: reviewCursor });
+                const rt = data.repository.pullRequest.reviewThreads;
+                const rv = data.repository.pullRequest.reviews;
+                threads.push(...rt.nodes);
+                if (page === 0) reviewsPage = rv.nodes.slice();
+                else reviewsPage.push(...rv.nodes);
+                const nextT = rt.pageInfo.hasNextPage ? rt.pageInfo.endCursor : null;
+                const nextR = rv.pageInfo.hasNextPage ? rv.pageInfo.endCursor : null;
+                if (!nextT && !nextR) break;
+                cursor = nextT ?? cursor;
+                reviewCursor = nextR ?? reviewCursor;
+                if (page === 19 && (nextT || nextR)) {
+                  core.setFailed('BLOCKED — PR has >2000 threads/reviews; gate cannot verify all pages (fail closed)');
+                  return;
+                }
+              }
             } catch (e) {
               core.setFailed(`GraphQL failed (fail closed): ${e.message}`);
               return;
             }
 
-            const threads = data.repository.pullRequest.reviewThreads.nodes;
             const unresolvedBot = threads.filter(t =>
               !t.isResolved && !t.isOutdated &&
-              t.comments.nodes.some(c => botRe.test(c.author?.login ?? ''))
+              t.comments.nodes.some(c => isBot(c.author))
             );
 
-            const reviews = data.repository.pullRequest.reviews.nodes;
             const latest = {};
-            for (const r of reviews) {
-              const login = r.author?.login;
-              if (!login || !botRe.test(login)) continue;
+            for (const r of reviewsPage) {
+              if (!isBot(r.author)) continue;
               if (!r.submittedAt) continue; // Codex-shaped: null timestamp; threads-only path
+              const login = r.author.login;
               const prev = latest[login];
               if (!prev || new Date(prev.submittedAt) < new Date(r.submittedAt)) {
                 latest[login] = r;

--- a/skills/security-pipeline/templates/.github/workflows/pr-review-gate.yml
+++ b/skills/security-pipeline/templates/.github/workflows/pr-review-gate.yml
@@ -1,0 +1,106 @@
+name: pr-review-gate
+
+# Limitation: GitHub Actions rejects `pull_request_review_thread` even though
+# the docs list it, so resolving a thread emits no event this workflow listens
+# on. Refresh options after resolving a bot thread:
+#   - re-request the failed check-suite from the PR checks tab (one click)
+#   - `gh workflow run pr-review-gate.yml -F pr=<n>` (workflow_dispatch)
+#   - push any commit (or an empty one) to the PR branch
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, dismissed]
+  issue_comment:
+    types: [created, edited, deleted]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to re-check
+        required: true
+        type: string
+
+jobs:
+  gate:
+    name: pr-review-gate
+    if: github.event.pull_request || github.event.issue.pull_request || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check unresolved LLM-bot threads and bot verdict
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          BOT_RE: ${{ vars.PR_REVIEW_GATE_BOT_RE || 'codex|coderabbit|claude' }}
+        with:
+          script: |
+            const pr = context.payload.pull_request?.number
+                    ?? context.payload.issue?.number
+                    ?? Number(context.payload.inputs?.pr);
+            if (!pr) { core.info('no PR context; skipping'); return; }
+            const { owner, repo } = context.repo;
+            // Strip Python/Perl-style inline flag if present; JS regex doesn't support it.
+            const rawPattern = process.env.BOT_RE.replace(/^\(\?[imsux]+\)/, '');
+            const botRe = new RegExp(rawPattern, 'i');
+
+            let data;
+            try {
+              data = await github.graphql(`
+                query($o:String!,$r:String!,$n:Int!){
+                  repository(owner:$o,name:$r){
+                    pullRequest(number:$n){
+                      reviewThreads(first:100){
+                        nodes{
+                          isResolved
+                          isOutdated
+                          comments(first:1){nodes{author{login}}}
+                        }
+                      }
+                      reviews(first:100){
+                        nodes{ state author{login} submittedAt }
+                      }
+                    }
+                  }
+                }`, { o: owner, r: repo, n: pr });
+            } catch (e) {
+              core.setFailed(`GraphQL failed (fail closed): ${e.message}`);
+              return;
+            }
+
+            const threads = data.repository.pullRequest.reviewThreads.nodes;
+            const unresolvedBot = threads.filter(t =>
+              !t.isResolved && !t.isOutdated &&
+              t.comments.nodes.some(c => botRe.test(c.author?.login ?? ''))
+            );
+
+            const reviews = data.repository.pullRequest.reviews.nodes;
+            const latest = {};
+            for (const r of reviews) {
+              const login = r.author?.login;
+              if (!login || !botRe.test(login)) continue;
+              if (!r.submittedAt) continue; // Codex-shaped: null timestamp; threads-only path
+              const prev = latest[login];
+              if (!prev || new Date(prev.submittedAt) < new Date(r.submittedAt)) {
+                latest[login] = r;
+              }
+            }
+            const blockingBots = Object.entries(latest)
+              .filter(([, r]) => r.state === 'CHANGES_REQUESTED')
+              .map(([login]) => login);
+
+            const problems = [];
+            if (unresolvedBot.length) {
+              const authors = [...new Set(unresolvedBot.flatMap(t =>
+                t.comments.nodes.map(c => c.author?.login).filter(Boolean)))];
+              problems.push(`${unresolvedBot.length} unresolved bot review thread(s) from: ${authors.join(', ')}`);
+            }
+            if (blockingBots.length) {
+              problems.push(`CHANGES_REQUESTED from: ${blockingBots.join(', ')}`);
+            }
+
+            if (problems.length) {
+              core.setFailed('BLOCKED — ' + problems.join(' | '));
+            } else {
+              core.info('OK — no unresolved bot threads, no bot CHANGES_REQUESTED');
+            }

--- a/skills/xt-merge/SKILL.md
+++ b/skills/xt-merge/SKILL.md
@@ -136,6 +136,12 @@ If they differ, the green result is from before the rebase — wait for the new 
 Wait for all checks to pass. If CI is still running, tell the user and pause — don't
 merge a PR with pending or failing checks.
 
+**`pr-review-gate` specifically** must be `success`, not just present — it fails when
+any LLM-bot review thread is unresolved. If it's failing, address or resolve the
+Codex/CodeRabbit threads before merging (or manually re-trigger via
+`gh workflow run pr-review-gate.yml -F pr=<n>` after resolution — a resolved
+thread emits no event that would auto-refresh the gate).
+
 If CI is failing:
 - Show the failing check names and link to the run
 - Do NOT proceed with the merge


### PR DESCRIPTION
## Summary
Closes Phases 2 and 4 of epic `xtrm-54zwl` (pr-review-gate) in a single PR.

**Phase 2 — canonicalize in security-pipeline:**
- `skills/security-pipeline/templates/.github/workflows/pr-review-gate.yml` (byte-identical to the live workflow already on main)
- `security-bootstrap.sh` copies it
- `SKILL.md` architecture bumped 4→5 layers, files-table row added, new **Enabling the gate (one-time, per repo)** section documenting both classic branch protection and rulesets (mercuryintelligence/infra + mercuryintelligence/market-data use rulesets, hence the two paths)

**Phase 4 — review-skill docs:**
- `judge-with-codex`, `pr-reviewer`, `code-review`: replace hardcoded `openai-codex[bot]` with regex-tolerant language matching `/codex/i` (current bot is `chatgpt-codex-connector[bot]`)
- `judge-with-codex` + `pr-reviewer`: explicit note that merge blocking now lives in the `pr-review-gate` CI check — these skills only write the human/agent-side verdict
- `xt-merge` Stage 2: pr-review-gate must be success not just present; how to manually refresh (`gh workflow run pr-review-gate.yml -F pr=<n>` since `pull_request_review_thread` is not accepted by GitHub Actions)

## Byproduct
`.xtrm/registry.json` refreshed via `npm run gen-registry` — drops stale entries for `prd-to-plan/*` and `service-skills/install/*` that no longer exist on disk. Registry↔pack parity check passes after regen.

## Not in scope
Discovered mid-work: `.claude/skills/service-skills/scripts/{skill_activator,drift_detector}.py` are missing but wired in hooks — session-blocking. Filed as P0 xtrm-igx6a (root-cause in #493, discovered via #494). Local symlinks used as a stopgap this session; not part of this PR.

## Test plan
- [x] `npm run gen-registry` clean
- [x] `npm run check:payload-hygiene` clean
- [x] `npm run check:registry-pack-parity` clean
- [ ] Fresh test repo: `bash security-bootstrap.sh <target>` copies the workflow to `.github/workflows/pr-review-gate.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)