### PR TITLE
ci(pr-review-gate): wave-2 — pull_request_review_comment trigger + preserve CR verdicts (xtrm-54zwl.7)

### DIFF
--- a/.github/workflows/pr-review-gate.yml
+++ b/.github/workflows/pr-review-gate.yml
@@ -12,6 +12,8 @@ on:
     types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
   issue_comment:
     types: [created, edited, deleted]
   workflow_dispatch:
@@ -39,6 +41,9 @@ jobs:
                     ?? context.payload.issue?.number
                     ?? Number(context.payload.inputs?.pr);
             if (!pr) { core.info('no PR context; skipping'); return; }
+            // issue_comment fires on PR conversation comments only; inline diff
+            // comments fire pull_request_review_comment. Both listed so an
+            // out-of-review inline bot comment still re-runs the gate.
             const { owner, repo } = context.repo;
             // Strip Python/Perl-style inline flag if present; JS regex doesn't support it.
             const rawPattern = process.env.BOT_RE.replace(/^\(\?[imsux]+\)/, '');
@@ -103,17 +108,24 @@ jobs:
               t.comments.nodes.some(c => isBot(c.author))
             );
 
-            const latest = {};
+            // Preserve active CHANGES_REQUESTED like GitHub's native branch
+            // protection does: a CR verdict stays active until the same bot
+            // submits APPROVED or DISMISSED. Later COMMENTED reviews do NOT
+            // clear it. Track the latest *verdict-carrying* review per bot
+            // (APPROVED/CHANGES_REQUESTED/DISMISSED); COMMENTED is ignored.
+            const VERDICT_STATES = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
+            const latestVerdict = {};
             for (const r of reviewsPage) {
               if (!isBot(r.author)) continue;
               if (!r.submittedAt) continue; // Codex-shaped: null timestamp; threads-only path
+              if (!VERDICT_STATES.has(r.state)) continue;
               const login = r.author.login;
-              const prev = latest[login];
+              const prev = latestVerdict[login];
               if (!prev || new Date(prev.submittedAt) < new Date(r.submittedAt)) {
-                latest[login] = r;
+                latestVerdict[login] = r;
               }
             }
-            const blockingBots = Object.entries(latest)
+            const blockingBots = Object.entries(latestVerdict)
               .filter(([, r]) => r.state === 'CHANGES_REQUESTED')
               .map(([login]) => login);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Summary lines double-print epic id (xtrm-5swny) (#499)** ([87fc6b8](https://github.com/xtrm-dev/core/commit/87fc6b80b1acae51d431507104e6566071b94e32)) — 2026-07-24 21:34
 
-- **Remove stale service-skills wiring** ([417e6c4](https://github.com/xtrm-dev/core/commit/417e6c4f9395fe0ce18c2884d63618dda34c9a16)) — 2026-07-24 22:26
-
-- **Preserve unowned registry rows** ([3e5e918](https://github.com/xtrm-dev/core/commit/3e5e918ef641287014a4cf2f2e07c78f2705f37f)) — 2026-07-24 22:34
+- **Remove stale service-skills wiring (#500)** ([efa5f11](https://github.com/xtrm-dev/core/commit/efa5f11ab80df85296e3dc86bebcbcbe91db8584)) — 2026-07-24 22:37
 
 ### Other changes
 
@@ -55,9 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Recommend symlink install over cp (xtrm-81c64) (#497)** ([e642412](https://github.com/xtrm-dev/core/commit/e64241266a01e0d19e2a363f30a8c597135fa5ac)) — 2026-07-24 20:53
 
-- **Document validated registry path** ([48dfc27](https://github.com/xtrm-dev/core/commit/48dfc270d9aba6350f83a763f8ede552f2cd3965)) — 2026-07-24 22:28
-
-- **Refresh generated bundle** ([534dd92](https://github.com/xtrm-dev/core/commit/534dd927b84817fb2fc598a27e281d0918febc20)) — 2026-07-24 22:31
+- **Wave-2 — pull_request_review_comment trigger + preserve CR verdicts (xtrm-54zwl.7)** ([987bda5](https://github.com/xtrm-dev/core/commit/987bda5f0fc4c040031ef2e6d657e420b5a37b1b)) — 2026-07-25 09:57
 
 ## [v0.11.2] — 2026-07-22
 

--- a/skills/security-pipeline/templates/.github/workflows/pr-review-gate.yml
+++ b/skills/security-pipeline/templates/.github/workflows/pr-review-gate.yml
@@ -12,6 +12,8 @@ on:
     types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
   issue_comment:
     types: [created, edited, deleted]
   workflow_dispatch:
@@ -39,6 +41,9 @@ jobs:
                     ?? context.payload.issue?.number
                     ?? Number(context.payload.inputs?.pr);
             if (!pr) { core.info('no PR context; skipping'); return; }
+            // issue_comment fires on PR conversation comments only; inline diff
+            // comments fire pull_request_review_comment. Both listed so an
+            // out-of-review inline bot comment still re-runs the gate.
             const { owner, repo } = context.repo;
             // Strip Python/Perl-style inline flag if present; JS regex doesn't support it.
             const rawPattern = process.env.BOT_RE.replace(/^\(\?[imsux]+\)/, '');
@@ -103,17 +108,24 @@ jobs:
               t.comments.nodes.some(c => isBot(c.author))
             );
 
-            const latest = {};
+            // Preserve active CHANGES_REQUESTED like GitHub's native branch
+            // protection does: a CR verdict stays active until the same bot
+            // submits APPROVED or DISMISSED. Later COMMENTED reviews do NOT
+            // clear it. Track the latest *verdict-carrying* review per bot
+            // (APPROVED/CHANGES_REQUESTED/DISMISSED); COMMENTED is ignored.
+            const VERDICT_STATES = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
+            const latestVerdict = {};
             for (const r of reviewsPage) {
               if (!isBot(r.author)) continue;
               if (!r.submittedAt) continue; // Codex-shaped: null timestamp; threads-only path
+              if (!VERDICT_STATES.has(r.state)) continue;
               const login = r.author.login;
-              const prev = latest[login];
+              const prev = latestVerdict[login];
               if (!prev || new Date(prev.submittedAt) < new Date(r.submittedAt)) {
-                latest[login] = r;
+                latestVerdict[login] = r;
               }
             }
-            const blockingBots = Object.entries(latest)
+            const blockingBots = Object.entries(latestVerdict)
               .filter(([, r]) => r.state === 'CHANGES_REQUESTED')
               .map(([login]) => login);
 


### PR DESCRIPTION
## Summary
Two P2 correctness fixes Codex flagged during the wave-1 fanout across 8 mercuryintelligence repos:

1. **Add `pull_request_review_comment` trigger.** `issue_comment` fires on top-level PR conversation comments only; inline diff comments fire the separate `pull_request_review_comment` event. Without it, a bot posting/editing an inline comment outside a review submission would not re-run the gate.

2. **Preserve active `CHANGES_REQUESTED`.** Previous logic took the latest `submittedAt` review per bot, so a bot that submitted CR then later added `COMMENTED` would silently drop its blocking verdict. Now the check tracks the latest verdict-carrying review (`APPROVED`, `CHANGES_REQUESTED`, or `DISMISSED`); `COMMENTED` reviews no longer overwrite. Mirrors GitHub's own branch-protection semantics.

Byte-identical between `.github/workflows/` (live) and `skills/security-pipeline/templates/.github/workflows/` (canonical).

Neither manifests in Codex's current pattern (Codex bundles inline comments with review submissions; Codex state is always COMMENTED, never CR), but both are real gaps for CodeRabbit-shaped bots and future adopters.

## Fanout plan
This lands in core first, then the same byte-identical change goes to the other 15 already-live repos (specialists, infra, market-data, darth-feedor, economic-data, terminalbeta, platform, sierra-vps, quant, terminal, treasury-cb, barchart-scraper, website, beads_viewer, xtmux).