### PR TITLE
docs(security-pipeline): reconcile SKILL.md + CLAUDE.md with pr-review-gate wave-2 reality (xtrm-54zwl.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Recommend symlink install over cp (xtrm-81c64) (#497)** ([e642412](https://github.com/xtrm-dev/core/commit/e64241266a01e0d19e2a363f30a8c597135fa5ac)) — 2026-07-24 20:53
 
-- **Wave-2 — pull_request_review_comment trigger + preserve CR verdicts (xtrm-54zwl.7)** ([987bda5](https://github.com/xtrm-dev/core/commit/987bda5f0fc4c040031ef2e6d657e420b5a37b1b)) — 2026-07-25 09:57
+- **Wave-2 — pull_request_review_comment trigger + preserve CR verdicts (xtrm-54zwl.7)** ([6651be3](https://github.com/xtrm-dev/core/commit/6651be380872f333a4c388e097cf1c9436d874ed)) — 2026-07-25 09:57
+
+- **Reconcile SKILL.md + CLAUDE.md with pr-review-gate wave-2 reality (xtrm-54zwl.8)** ([7c52937](https://github.com/xtrm-dev/core/commit/7c52937c8c43e5f4120ed2984b1438f0347347fc)) — 2026-07-25 11:25
 
 ## [v0.11.2] — 2026-07-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,7 @@ This project is indexed by GitNexus as **xtrm-tools**. Use the GitNexus MCP tool
 - Worktrees do not carry ignored dependencies (`node_modules`, `.venv`); run the repo bootstrap inside the worktree when needed.
 - `.xtrm/reports/` is gitignored; use `git add -f` only when a report should be committed.
 - Per-repo `default/` and `optional/` are deprecated; migrate with `xt migrate skills --apply`.
+- `pr-review-gate` GitHub Actions workflow is a required check on `main`/`master` across the 16 xtrm/mercuryintelligence/Jaggerxtrm-managed repos with real PR flow. Canonical template lives at `skills/security-pipeline/templates/.github/workflows/pr-review-gate.yml`; installed per-repo via `security-bootstrap.sh` and NOT auto-synced by `xt update --apply` — template changes require a manual fanout (see wave-1 `xtrm-7cjkv` + wave-2 `xtrm-54zwl.7` bead notes for the batch pattern).
 
 ## Quality gates
 

--- a/skills/security-pipeline/SKILL.md
+++ b/skills/security-pipeline/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: security-pipeline
-description: Bootstrap a complete security pipeline (Dependabot + OSV + Semgrep + gitleaks + pre-commit hooks + Codex review) on any GitHub repo. Designed for free user-private repos where GitHub Advanced Security is unavailable. Reusable across Python/TypeScript/Go/Rust stacks.
+description: Bootstrap a complete security pipeline (Dependabot + OSV + Semgrep + gitleaks + pre-commit hooks + Codex review + pr-review-gate) on any GitHub repo. Designed for free user-private repos where GitHub Advanced Security is unavailable. Reusable across Python/TypeScript/Go/Rust stacks.
 ---
 
 # Security Pipeline
 
-Wires a 4-layer security baseline onto any GitHub repo. Originally proven on
+Wires a 5-layer security baseline onto any GitHub repo. Originally proven on
 the Mercury infra stack but the templates and bootstrap script are
 project-agnostic — adapt the allowlists and dependabot ecosystems per repo.
 
@@ -95,15 +95,34 @@ default branch): edit and add a `required_status_checks` rule with context
 back (see xtrm-54zwl.6 bead notes for a scripted example).
 
 Bot detection defaults to `codex|coderabbit|claude` (case-insensitive) and is
-overridable via the `PR_REVIEW_GATE_BOT_RE` repo variable. To manually refresh
-the gate after resolving a thread (`pull_request_review_thread` isn't accepted
-by GitHub Actions despite the docs listing it):
+overridable via the `PR_REVIEW_GATE_BOT_RE` repo variable. Matches only accounts
+whose GraphQL `__typename == 'Bot'` AND login matches the regex, so a human
+reviewer whose login happens to contain "claude" or "codex" can't trip the gate.
+Paginates `reviewThreads` and `reviews` up to 2000 entries each (fails closed
+beyond that). Preserves an active `CHANGES_REQUESTED` verdict per bot until the
+same bot submits `APPROVED` or `DISMISSED` — later `COMMENTED` reviews do NOT
+clear a CR, matching GitHub's native branch-protection semantics.
+
+To manually refresh the gate after resolving a thread (`pull_request_review_thread`
+isn't accepted by GitHub Actions despite the docs listing it):
 
 ```bash
 gh workflow run pr-review-gate.yml -F pr=<n>
 ```
 
 or click "re-request check-suite" in the PR checks tab, or push any commit.
+
+### Keeping consumer copies in sync
+
+The workflow file is COPIED into each consumer repo by `security-bootstrap.sh`
+at install time — there is no auto-sync. When the canonical template in this
+repo changes, every consumer needs a manual re-fanout PR. The wave-1 (`xtrm-7cjkv`)
+and wave-2 (`xtrm-54zwl.7`) beads document the batch scripts under
+`~/.claude/…/scratchpad/` that handle this: worktree per repo, `SKIP=osv-scanner
+git push` (osv-scanner chokes on `.git` being a file in worktrees),
+`gh pr create --head <branch>` (never rely on cwd inference across repos),
+`--admin` merge for ruleset-protected repos with `required_approving_review_count>=1`.
+Budget ~30 min operator-driven wall time per fanout wave across ~16 repos.
 
 ## Files in `templates/`
 


### PR DESCRIPTION
## Summary
Doc-only reconciliation with pr-review-gate wave-2 (xtrm-54zwl.7 landed the code, this catches the docs up).

- `skills/security-pipeline/SKILL.md`:
  - Front-matter `description:` now lists pr-review-gate alongside the other four layers.
  - Body intro: **4-layer** → **5-layer** (matches the Architecture heading I already bumped in xtrm-54zwl.2).
  - Enabling section: describe wave-2 behavior — Bot `__typename` filter + login regex, pagination up to 2000 with fail-closed beyond, `CHANGES_REQUESTED` preservation semantics matching GitHub native.
  - New subsection **"Keeping consumer copies in sync"**: the workflow is COPIED at install time and NOT auto-synced by `xt update --apply`. Template updates require a manual fanout; points at the wave-1 (`xtrm-7cjkv`) and wave-2 (`xtrm-54zwl.7`) bead notes for the batch scripts + the three portable gotchas (SKIP=osv-scanner, --head, --admin for ruleset repos).

- `CLAUDE.md`: one-line gotcha under **Current gotchas** — pr-review-gate status + template location + fanout-required-on-update note, pointing at the same beads.

Nothing behavioral changes. Registry regen clean; pack parity clean.