### PR TITLE
sre-triage: nudge to use service-knowledge on ambiguous incidents

### DIFF
--- a/.xtrm/skills/default/sre-triage/SKILL.md
+++ b/.xtrm/skills/default/sre-triage/SKILL.md
@@ -259,7 +259,31 @@ Read: .claude/skills/<service-id>/SKILL.md
 **Do not proceed to diagnosis until all affected skills are loaded.**
 Adopt the failure modes table, diagnostic scripts, and runbook from each skill.
 
-If the affected service has no registered skill:
+**When the symptom → service mapping is ambiguous** — the alert names a
+container that doesn't match a registered service directly, a stack trace
+points at a file whose owner is unclear, or two services are plausible
+candidates — reach for **service-knowledge** before falling back to grep:
+
+```bash
+# Route by touched paths (what the activator does internally).
+service-knowledge index query "<symptom text or metric name>"
+```
+
+Or from an MCP host:
+
+- `knowledge_evidence_for_files` with the paths the incident touches — returns
+  the service(s) whose territory covers them, plus a ranked evidence bundle
+  from the shipped SKILLs.
+- `knowledge_search` with a free-text query (alert name, error string, metric,
+  concept) — returns the same evidence-bundle shape ranked across every
+  registered service.
+
+Both surfaces read the per-repo FTS5 evidence index (`.xtrm/cache/service-knowledge.sqlite`,
+built by `service-knowledge install`) so latency is sub-10ms. They return
+evidence, never conclusions — use the ranked hits to pick which skill(s) to
+`Read` in this step, then proceed to Step 5 with the expert context loaded.
+
+If the affected service has no registered skill even after the search:
 1. Report: `"No registered skill for <service-id>."`
 2. Continue with general expert mode using docker logs and AGENT_MONITORING.md guidance.
 3. Offer: `"I can create a skill — use /creating-service-skills."`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Wave-2 — pull_request_review_comment trigger + preserve CR verdicts (xtrm-54zwl.7)** ([6651be3](https://github.com/xtrm-dev/core/commit/6651be380872f333a4c388e097cf1c9436d874ed)) — 2026-07-25 09:57
 
-- **Reconcile SKILL.md + CLAUDE.md with pr-review-gate wave-2 reality (xtrm-54zwl.8)** ([7c52937](https://github.com/xtrm-dev/core/commit/7c52937c8c43e5f4120ed2984b1438f0347347fc)) — 2026-07-25 11:25
+- **Reconcile SKILL.md + CLAUDE.md with pr-review-gate wave-2 reality (xtrm-54zwl.8)** ([2ff4e42](https://github.com/xtrm-dev/core/commit/2ff4e42aa49001fe7a40918d09636e594c79ca78)) — 2026-07-25 11:25
 
 ## [v0.11.2] — 2026-07-22
 


### PR DESCRIPTION
## Summary

Adds a callout in Step 4 (Load Skills for Affected Services) of the \`/sre-triage\` skill explaining how to use \`service-knowledge index query\` (CLI) or the MCP tools \`knowledge_evidence_for_files\` / \`knowledge_search\` when the symptom → service mapping is ambiguous — before falling back to grep.

Mirrors the same edit in \`~/.xtrm/skills/default/sre-triage/SKILL.md\` (user-global, not versioned; must stay in sync).

## Test plan
- [x] Diff between this repo's copy and the user-global copy is clean after landing
- [x] Skill still parses — single-block insertion, no reflow