### PR TITLE
feat(scripts): Alpine smoke-test container for the xtrm trio (xtrm-wiy5n.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Drift-lint gates for forbidden phrases and vendored specialists parity (xtrm-wiy5n.4.3) (#514)** ([a89f55d](https://github.com/xtrm-dev/core/commit/a89f55db0b7da94bebd3fa3c10ae78f987157863)) — 2026-07-26 16:25
 
+- **Add Alpine smoke-test container for the xtrm trio** ([05d89f0](https://github.com/xtrm-dev/core/commit/05d89f06cf090da3263cf229cebe13b086f60dbd)) — 2026-07-26 15:39
+
 ### Fixed
 
 - **Summary lines double-print epic id (xtrm-5swny) (#499)** ([87fc6b8](https://github.com/xtrm-dev/core/commit/87fc6b80b1acae51d431507104e6566071b94e32)) — 2026-07-24 21:34
@@ -33,9 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Assign beads from the runtime readiness handshake (xtrm-wiy5n.4.18) (#510)** ([359af43](https://github.com/xtrm-dev/core/commit/359af431f8c90d33044002525039cb39579dc388)) — 2026-07-26 16:06
 
-- **Stop xt claude --role forwarding non-Claude models (xtrm-wiy5n.4.19)** ([56a1210](https://github.com/xtrm-dev/core/commit/56a1210425deec7edf6a0f2934b7b2c9de31ad51)) — 2026-07-26 16:20
+- **Stop xt claude --role forwarding non-Claude models (xtrm-wiy5n.4.19) (#511)** ([50b1987](https://github.com/xtrm-dev/core/commit/50b19878aad623b4ff9c4dcd81fb3dc21cae30e7)) — 2026-07-26 18:58
 
-- **Validate only the effective --model, not every occurrence** ([cdfc755](https://github.com/xtrm-dev/core/commit/cdfc755edb73f7e7575f6321b46492be5294e75f)) — 2026-07-26 16:54
+- **Propagate smoke-stage failures and close SCOPE gaps** ([e6dfbe7](https://github.com/xtrm-dev/core/commit/e6dfbe7443191f6a3a14045a60a40a9514eff44f)) — 2026-07-26 16:19
+
+- **Honour --tag past stage 1 and select smoke artifacts by arch** ([d390fc8](https://github.com/xtrm-dev/core/commit/d390fc847ea280d0326a3157998f64901a871b90)) — 2026-07-26 16:40
 
 ### Other changes
 

--- a/scripts/smoke-container/Dockerfile
+++ b/scripts/smoke-container/Dockerfile
@@ -1,0 +1,61 @@
+# Pre/post-release smoke-test container for the xtrm trio (xt / sp / xtmux).
+# Build:  docker build -t xtrm-smoke scripts/smoke-container/
+# Run:    docker run --rm xtrm-smoke ./verify.sh
+FROM node:24-alpine
+
+# bash      — verify.sh is bash (arrays, [[ ]]).
+# git       — clones the three xtrm repos.
+# sqlite    — xtmux observability db lives in SQLite.
+# tmux      — the stage-5 live xtmux scenario needs a real server.
+# jq        — snapshot assertions over registry.json / hooks.json.
+# curl+unzip+tar — fetch the musl bun and beads binaries below.
+# gcompat   — beads ships a glibc-linked binary; this is the musl shim for it.
+# libstdc++ — bun runtime dependency.
+RUN apk add --no-cache \
+      bash git curl unzip jq sqlite tmux util-linux-misc \
+      gcompat libstdc++ ca-certificates
+
+# @jaggerxtrm/xtmux and @jaggerxtrm/specialists both run on Bun. The `bun` npm
+# package ships a glibc binary that is ENOEXEC on musl, so install the official
+# musl build. Pinned to xtmux's declared bun dependency.
+#
+# It lives in /opt, NOT /usr/local/bin: xtmux depends on the `bun` npm package,
+# whose own `bun` bin link would otherwise overwrite this binary on every
+# `npm i -g @jaggerxtrm/xtmux`. /opt/bun/bin goes first in PATH so the musl
+# build always wins for `sp` (#!/usr/bin/env bun) and for verify.sh.
+ARG BUN_VERSION=1.3.14
+RUN curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64-musl.zip" -o /tmp/bun.zip \
+ && unzip -q /tmp/bun.zip -d /tmp/bun \
+ && install -D -m 0755 /tmp/bun/*/bun /opt/bun/bin/bun \
+ && rm -rf /tmp/bun /tmp/bun.zip \
+ && /opt/bun/bin/bun --version
+ENV PATH="/opt/bun/bin:${PATH}" \
+    XTMUX_BUN="/opt/bun/bin/bun" \
+    XTRM_SMOKE_BUN="/opt/bun/bin/bun"
+
+# beads (`bd`) is the xtrm issue tracker and a hard dependency of xtmux-events.
+# @beads/bd's postinstall download does not resolve on musl, so take the
+# release binary directly (works via gcompat, verified at build time).
+ARG BEADS_VERSION=1.1.0
+RUN curl -fsSL "https://github.com/gastownhall/beads/releases/download/v${BEADS_VERSION}/beads_${BEADS_VERSION}_linux_amd64.tar.gz" -o /tmp/beads.tgz \
+ && tar -xzf /tmp/beads.tgz -C /tmp bd \
+ && install -m 0755 /tmp/bd /usr/local/bin/bd \
+ && rm -f /tmp/beads.tgz /tmp/bd \
+ && bd version
+
+# git needs an identity for the stage-4 drift commits.
+RUN git config --global user.email smoke@xtrm.local \
+ && git config --global user.name  "xtrm smoke" \
+ && git config --global init.defaultBranch main \
+ && git config --global advice.detachedHead false
+
+WORKDIR /smoke
+COPY verify.sh ./
+RUN chmod 0755 verify.sh
+
+# Root is deliberate: the harness exists to exercise the documented
+# `npm i -g` global-install path into /usr/local, plus `xt init` writing to
+# $HOME. The image is an ephemeral local test subject — it serves nothing,
+# exposes no port, and is discarded with `docker run --rm`.
+# nosemgrep: dockerfile.security.missing-user.missing-user
+CMD ["./verify.sh"]

--- a/scripts/smoke-container/Dockerfile
+++ b/scripts/smoke-container/Dockerfile
@@ -24,7 +24,13 @@ RUN apk add --no-cache \
 # `npm i -g @jaggerxtrm/xtmux`. /opt/bun/bin goes first in PATH so the musl
 # build always wins for `sp` (#!/usr/bin/env bun) and for verify.sh.
 ARG BUN_VERSION=1.3.14
-RUN curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64-musl.zip" -o /tmp/bun.zip \
+ARG TARGETARCH
+RUN case "${TARGETARCH:-amd64}" in \
+      amd64) bun_arch=x64 ;; \
+      arm64) bun_arch=aarch64 ;; \
+      *) echo "unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${bun_arch}-musl.zip" -o /tmp/bun.zip \
  && unzip -q /tmp/bun.zip -d /tmp/bun \
  && install -D -m 0755 /tmp/bun/*/bun /opt/bun/bin/bun \
  && rm -rf /tmp/bun /tmp/bun.zip \
@@ -37,7 +43,7 @@ ENV PATH="/opt/bun/bin:${PATH}" \
 # @beads/bd's postinstall download does not resolve on musl, so take the
 # release binary directly (works via gcompat, verified at build time).
 ARG BEADS_VERSION=1.1.0
-RUN curl -fsSL "https://github.com/gastownhall/beads/releases/download/v${BEADS_VERSION}/beads_${BEADS_VERSION}_linux_amd64.tar.gz" -o /tmp/beads.tgz \
+RUN curl -fsSL "https://github.com/gastownhall/beads/releases/download/v${BEADS_VERSION}/beads_${BEADS_VERSION}_linux_${TARGETARCH:-amd64}.tar.gz" -o /tmp/beads.tgz \
  && tar -xzf /tmp/beads.tgz -C /tmp bd \
  && install -m 0755 /tmp/bd /usr/local/bin/bd \
  && rm -f /tmp/beads.tgz /tmp/bd \

--- a/scripts/smoke-container/README.md
+++ b/scripts/smoke-container/README.md
@@ -13,7 +13,7 @@ re-runs `xt update --apply`, and verifies the before/after state.
 ```bash
 docker build -t xtrm-smoke scripts/smoke-container/
 docker run --rm xtrm-smoke ./verify.sh                 # currently-released packages
-docker run --rm xtrm-smoke ./verify.sh --tag next      # a different npm dist-tag
+docker run --rm xtrm-smoke ./verify.sh --tag next      # a release candidate, in every stage
 docker run --rm xtrm-smoke ./verify.sh --branch xt/foo # unreleased branch, all repos
 docker run --rm xtrm-smoke ./verify.sh --branch core=xt/foo --branch xtmux=fix/bar
 docker run --rm xtrm-smoke ./verify.sh --skip-live     # no tmux/sp scenario
@@ -106,6 +106,14 @@ correctly but renders nothing, because it joins the journal's `session_id`
 (`$0`) against `xtmux dashboard`'s composite `sessionId`
 (`$0_name_%0_path_ts`). `xtmux log follow` delivering the same event is the
 hard assertion; the render gap is reported and named.
+
+## Architecture
+
+Bun and beads binaries are selected from `TARGETARCH` (`amd64` → bun `x64` /
+beads `linux_amd64`, `arm64` → bun `aarch64` / beads `linux_arm64`). Only the
+amd64 path has been run end to end; the arm64 mapping is mechanical and
+untested. Any other `TARGETARCH` fails the build with a named error rather than
+installing an incompatible binary.
 
 ## Non-goals
 

--- a/scripts/smoke-container/README.md
+++ b/scripts/smoke-container/README.md
@@ -39,27 +39,41 @@ branch's code, not just its files. Repos without the ref are reported `[SKIP]`.
 | `4-apply-edits-and-update` | apply `--branch` (if given), delete a hook payload to induce drift, `xt update --apply`, snapshot | — |
 | `5-verify` | compare snapshots and assert invariants | see below |
 
-Snapshots record: trio versions, `.xtrm/registry.json` asset count + hash,
-hook command count in `.xtrm/config/hooks.json`, hook payload file count,
-skill-root counts (repo and global `~/.xtrm/skills/default`), and symlink count
-under `.xtrm`.
+Snapshots record: trio versions, `.xtrm/registry.json` asset-group count,
+registry parity (`declared/missing/mismatch`), hook command count in
+`.xtrm/config/hooks.json`, hook payload file count, skill-root counts (repo and
+global `~/.xtrm/skills/default`), and symlink count under `.xtrm`.
 
 Stage 5 asserts, per repo: at least one wired hook command, hook payload count
-not regressed against the pre snapshot, a non-empty registry, a populated global
-skill mirror, zero symlinks under `.xtrm`, and that `xt update --apply` restored
-the hook payload stage 4 deleted. Globally it asserts the three
-specialists-owned skills (`using-specialists`, `update-specialists`,
-`using-specialists-auto`) landed in `~/.xtrm/skills/default`, and that the
-`Source and destination must not be the same` fresh-machine regression did not
-reappear anywhere in the run.
+not regressed against the pre snapshot, a non-empty registry, every file the
+registry declares present on disk under its group's `source_dir`, a populated
+global skill mirror, zero symlinks under `.xtrm`, and that `xt update --apply`
+restored the hook payload stage 4 deleted. Registry *hash* mismatches are
+reported as `[WARN]`, not failures — a clone of a repo's default branch
+legitimately sits ahead of the released registry's hashes.
+
+Globally it asserts the three specialists-owned skills (`using-specialists`,
+`update-specialists`, `using-specialists-auto`) landed in
+`~/.xtrm/skills/default`, runs the core clone's own
+`scripts/check-skill-root-budget.mjs` (so the budgets live in one place, not
+duplicated here), and asserts that the `Source and destination must not be the
+same` fresh-machine regression did not reappear anywhere in the run.
+
+Budget overruns are `[WARN]`. The clone's `.xtrm/skills/default` holds whatever
+the *installed* package shipped, so a pre-release run legitimately reports roots
+that the release being gated is about to slim — a red gate there would block the
+fix. Compare the pre and post runs: overruns present in both are a real
+regression.
 
 The live scenario migrates the observability DB, asserts `xtmux-obs health`,
 starts a tmux session, runs `xtmux log follow` and `xtmux-events --json` against
 it, and sends a beaded `xtmux message-send`. The follower must deliver that
 exact message key live, and `xtmux-events` must start and report the session it
-is following. `sp run` only runs when model credentials are in the environment;
-otherwise it is `[SKIP]`, which does not affect PASS/FAIL. Use `--skip-live`
-where tmux is unavailable.
+is following. `sp run` only runs when model credentials are in the environment —
+and when it does run, it gates; without credentials it is `[SKIP]`, which does
+not affect PASS/FAIL. Terminal-notification delivery is always `[SKIP]`: there
+is no terminal in a headless container to receive one. Use `--skip-live` where
+tmux is unavailable.
 
 Failures print the tail of the command log. `--keep` retains the work directory
 (snapshots + full command log) instead of deleting it on exit.

--- a/scripts/smoke-container/README.md
+++ b/scripts/smoke-container/README.md
@@ -1,0 +1,99 @@
+# xtrm smoke-test container
+
+Pre/post-release gate for the xtrm trio — `xtrm-tools` (`xt`),
+`@jaggerxtrm/specialists` (`sp`), `@jaggerxtrm/xtmux` (`xtmux`). One Alpine
+container installs the three packages from npm, exercises the update
+mechanisms, clones the three xtrm repos as test subjects, induces drift,
+re-runs `xt update --apply`, and verifies the before/after state.
+
+`exit 0` = PASS. Nonzero = FAIL, with the failing stage named in the summary.
+
+## Usage
+
+```bash
+docker build -t xtrm-smoke scripts/smoke-container/
+docker run --rm xtrm-smoke ./verify.sh                 # currently-released packages
+docker run --rm xtrm-smoke ./verify.sh --tag next      # a different npm dist-tag
+docker run --rm xtrm-smoke ./verify.sh --branch xt/foo # unreleased branch, all repos
+docker run --rm xtrm-smoke ./verify.sh --branch core=xt/foo --branch xtmux=fix/bar
+docker run --rm xtrm-smoke ./verify.sh --skip-live     # no tmux/sp scenario
+docker run --rm -e ANTHROPIC_API_KEY=... xtrm-smoke ./verify.sh   # enables `sp run`
+```
+
+Run it twice around a coordinated release: once before publishing (against the
+current `latest`) and once after (still `latest`, now the new versions). Both
+must be PASS.
+
+`--branch <repo>=<ref>` takes `core`, `specialists`, or `xtmux`. For every repo
+that has the ref, the clone is moved to it and that package is packed
+(`npm pack --ignore-scripts`) and installed globally — so the run tests the
+branch's code, not just its files. Repos without the ref are reported `[SKIP]`.
+
+## Stages
+
+| Stage | What it does | Hard failure when |
+|---|---|---|
+| `1-install` | `npm i -g` the trio at `--tag` | a binary is missing or does not run |
+| `2-update-mechanisms` | re-install at `@latest`; `xt init -y` + `xt update --apply` in a fresh git repo | update leaves no `.xtrm/registry.json` |
+| `3-clone-and-init` | clone the 3 repos, `xt init -y`, snapshot | clone fails |
+| `4-apply-edits-and-update` | apply `--branch` (if given), delete a hook payload to induce drift, `xt update --apply`, snapshot | — |
+| `5-verify` | compare snapshots and assert invariants | see below |
+
+Snapshots record: trio versions, `.xtrm/registry.json` asset count + hash,
+hook command count in `.xtrm/config/hooks.json`, hook payload file count,
+skill-root counts (repo and global `~/.xtrm/skills/default`), and symlink count
+under `.xtrm`.
+
+Stage 5 asserts, per repo: at least one wired hook command, hook payload count
+not regressed against the pre snapshot, a non-empty registry, a populated global
+skill mirror, zero symlinks under `.xtrm`, and that `xt update --apply` restored
+the hook payload stage 4 deleted. Globally it asserts the three
+specialists-owned skills (`using-specialists`, `update-specialists`,
+`using-specialists-auto`) landed in `~/.xtrm/skills/default`, and that the
+`Source and destination must not be the same` fresh-machine regression did not
+reappear anywhere in the run.
+
+The live scenario migrates the observability DB, asserts `xtmux-obs health`,
+starts a tmux session, runs `xtmux log follow` and `xtmux-events --json` against
+it, and sends a beaded `xtmux message-send`. The follower must deliver that
+exact message key live, and `xtmux-events` must start and report the session it
+is following. `sp run` only runs when model credentials are in the environment;
+otherwise it is `[SKIP]`, which does not affect PASS/FAIL. Use `--skip-live`
+where tmux is unavailable.
+
+Failures print the tail of the command log. `--keep` retains the work directory
+(snapshots + full command log) instead of deleting it on exit.
+
+Expect roughly 12–15 minutes end to end. `xt init -y` runs `gitnexus analyze`
+per repo with a 120 s internal timeout, which dominates the runtime.
+
+## Alpine/musl caveats this container works around
+
+These are upstream defects, not harness bugs. They are reported as `[WARN]`
+rather than `[FAIL]` so the gate stays usable, but they are real:
+
+- **`bun` on musl.** `@jaggerxtrm/xtmux` depends on the `bun` npm package, whose
+  binary is glibc-only (`ENOEXEC` on Alpine), so `npm i -g @jaggerxtrm/xtmux`
+  fails in its postinstall. The container installs the official
+  `bun-linux-x64-musl` build to `/opt/bun/bin` (first on `PATH`) and, on
+  install failure, retries with `--ignore-scripts` and drops the musl binary
+  over the bundled `bun.exe`. `XTMUX_BUN` alone does **not** fix this:
+  `scripts/xtmux-obs.mjs` resolves the bundled path unconditionally and
+  overwrites the env var.
+- **`install(1)` shadowing.** `@jaggerxtrm/specialists` declares a bin named
+  `install`, so after `npm i -g` it shadows coreutils `install` for any shell
+  with the npm global bin dir ahead of `/usr/bin`. Stage 5 names every global
+  npm bin that shadows a system command.
+- **`bd` on musl.** `@beads/bd`'s postinstall download does not resolve on
+  Alpine; the image takes the `linux_amd64` release binary and adds `gcompat`.
+
+One more `[WARN]`, not Alpine-specific: `xtmux-events` follows the journal
+correctly but renders nothing, because it joins the journal's `session_id`
+(`$0`) against `xtmux dashboard`'s composite `sessionId`
+(`$0_name_%0_path_ts`). `xtmux log follow` delivering the same event is the
+hard assertion; the render gap is reported and named.
+
+## Non-goals
+
+No compose, no k8s, no CI wiring, no multi-stage build. One Dockerfile, one
+bash script, host `docker` is the only dependency.

--- a/scripts/smoke-container/verify.sh
+++ b/scripts/smoke-container/verify.sh
@@ -23,7 +23,7 @@ usage: ./verify.sh [options]
 
   --branch <ref>            test <ref> in every repo that has it (checkout + install from source)
   --branch <repo>=<ref>     test <ref> in one repo only (repo: core|specialists|xtmux); repeatable
-  --tag <dist-tag>          npm dist-tag to install in stages 1-2 (default: latest)
+  --tag <dist-tag>          npm dist-tag installed and updated to in every stage (default: latest)
   --skip-live               skip the stage-5 tmux/sp live scenario
   --keep                    keep the work directory on exit
   -h, --help                this text
@@ -223,9 +223,12 @@ printf '  versions: xt=%s sp=%s xtmux=%s bd=%s\n' \
 # ===========================================================================
 stage "2-update-mechanisms"
 # ===========================================================================
-run "npm i -g xtrm-tools@latest" npm i -g xtrm-tools@latest
-run "npm i -g @jaggerxtrm/specialists@latest" npm i -g @jaggerxtrm/specialists@latest
-install_xtmux "@jaggerxtrm/xtmux@latest"
+# Re-install at the same dist-tag under test. Hardcoding @latest here would
+# silently replace a `--tag next` candidate, so stages 2-5 would exercise
+# latest and could report PASS on a broken candidate.
+run "npm i -g xtrm-tools@$TAG (update)" npm i -g "xtrm-tools@$TAG"
+run "npm i -g @jaggerxtrm/specialists@$TAG (update)" npm i -g "@jaggerxtrm/specialists@$TAG"
+install_xtmux "@jaggerxtrm/xtmux@$TAG"
 
 SCRATCH="$WORK/scratch"
 mkdir -p "$SCRATCH"

--- a/scripts/smoke-container/verify.sh
+++ b/scripts/smoke-container/verify.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+# xtrm trio pre/post-release smoke test. Exit 0 = PASS, nonzero = FAIL.
+# See README.md. Runs inside the container built from ./Dockerfile.
+set -uo pipefail
+
+# --- repos under test -------------------------------------------------------
+# name|clone url|npm package (package is what --branch installs from source)
+REPOS=(
+  "core|https://github.com/xtrm-dev/core.git|xtrm-tools"
+  "specialists|https://github.com/xtrm-dev/specialists.git|@jaggerxtrm/specialists"
+  "xtmux|https://github.com/Jaggerxtrm/xtmux.git|@jaggerxtrm/xtmux"
+)
+
+BRANCH_ALL=""
+declare -A BRANCH_FOR=()
+KEEP=0
+SKIP_LIVE=0
+TAG=latest
+
+usage() {
+  cat <<'EOF'
+usage: ./verify.sh [options]
+
+  --branch <ref>            test <ref> in every repo that has it (checkout + install from source)
+  --branch <repo>=<ref>     test <ref> in one repo only (repo: core|specialists|xtmux); repeatable
+  --tag <dist-tag>          npm dist-tag to install in stages 1-2 (default: latest)
+  --skip-live               skip the stage-5 tmux/sp live scenario
+  --keep                    keep the work directory on exit
+  -h, --help                this text
+
+exit 0 = PASS; nonzero = FAIL, and the failing stage is named in the summary.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --branch)
+      [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+      if [[ "$2" == *=* ]]; then BRANCH_FOR["${2%%=*}"]="${2#*=}"; else BRANCH_ALL="$2"; fi
+      shift 2 ;;
+    --tag) [ "$#" -ge 2 ] || { usage >&2; exit 2; }; TAG="$2"; shift 2 ;;
+    --skip-live) SKIP_LIVE=1; shift ;;
+    --keep) KEEP=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'unknown argument: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+WORK="$(mktemp -d /tmp/xtrm-smoke.XXXXXX)"
+LOG="$WORK/commands.log"
+: > "$LOG"
+cleanup() { [ "$KEEP" -eq 1 ] && printf '\nwork dir kept: %s\n' "$WORK" || rm -rf "$WORK"; }
+trap cleanup EXIT
+
+FAILED=0 WARNED=0 SKIPPED=0 STAGE="0-init" FIRST_FAIL=""
+
+stage() { STAGE="$1"; printf '\n=== STAGE %s ===\n' "$1"; printf '\n##### stage %s\n' "$1" >>"$LOG"; }
+ok()    { printf '  [OK]   %s\n' "$1"; }
+warn()  { WARNED=$((WARNED + 1)); printf '  [WARN] %s\n' "$1"; }
+skip()  { SKIPPED=$((SKIPPED + 1)); printf '  [SKIP] %s\n' "$1"; }
+fail()  {
+  FAILED=$((FAILED + 1))
+  [ -n "$FIRST_FAIL" ] || FIRST_FAIL="$STAGE: $1"
+  printf '  [FAIL] %s\n' "$1"
+}
+
+# run <desc> <cmd...> — command output goes to the log, not the report.
+run() {
+  local desc="$1"; shift
+  printf '\n$ %s\n' "$*" >>"$LOG"
+  if "$@" >>"$LOG" 2>&1; then ok "$desc"; return 0; fi
+  fail "$desc (tail of $LOG below)"
+  tail -20 "$LOG" | sed 's/^/         /'
+  return 1
+}
+
+field() { grep "^$1=" "$2" 2>/dev/null | cut -d= -f2-; }
+
+# expect_ge <label> <actual> <floor>
+expect_ge() {
+  if [ "${2:-x}" != "x" ] && [ "$2" -ge "$3" ] 2>/dev/null; then
+    ok "$1 = $2 (>= $3)"
+  else
+    fail "$1 = ${2:-<missing>}, expected >= $3"
+  fi
+}
+
+expect_eq() {
+  if [ "${2:-x}" = "$3" ]; then ok "$1 = $2"; else fail "$1 = ${2:-<missing>}, expected $3"; fi
+}
+
+# --- xtmux install needs a musl-capable bun --------------------------------
+xtmux_root() { printf '%s/@jaggerxtrm/xtmux' "$(npm root -g)"; }
+
+# Not `command -v bun`: npm relinks /usr/local/bin/bun to the glibc placeholder
+# from xtmux's own `bun` dependency, so PATH lookup can point at the broken one.
+MUSL_BUN="${XTRM_SMOKE_BUN:-/opt/bun/bin/bun}"
+
+# The bun npm package that xtmux depends on ships a glibc bun.exe. On musl it is
+# ENOEXEC, which fails xtmux's postinstall (and xtmux-obs at runtime). Overwrite
+# it with the container's musl bun. Must run AFTER any npm install that would
+# restore the package's node_modules.
+# cp, not install(1): @jaggerxtrm/specialists ships a global `install` bin that
+# shadows coreutils on PATH once it is installed globally (see the shadowing
+# check in stage 5).
+patch_bundled_bun() {
+  local target; target="$(xtmux_root)/node_modules/bun/bin/bun.exe"
+  [ -d "$(dirname "$target")" ] || return 1
+  cp -f "$MUSL_BUN" "$target" && chmod 0755 "$target"
+}
+
+install_xtmux() {
+  local spec="$1"
+  printf '\n$ npm i -g %s\n' "$spec" >>"$LOG"
+  if npm i -g "$spec" >>"$LOG" 2>&1 && xtmux-obs --help >>"$LOG" 2>&1; then
+    ok "npm i -g $spec"
+    return 0
+  fi
+  warn "npm i -g $spec needed the musl bun shim (bundled bun.exe is a glibc binary — Alpine/musl install path is not clean upstream)"
+  npm i -g --ignore-scripts "$spec" >>"$LOG" 2>&1 || { fail "npm i -g --ignore-scripts $spec"; return 1; }
+  patch_bundled_bun
+  node "$(xtmux_root)/scripts/install.mjs" --from-npm >>"$LOG" 2>&1 || { fail "xtmux install.mjs --from-npm"; return 1; }
+  patch_bundled_bun || { fail "could not place musl bun in $(xtmux_root)/node_modules/bun/bin"; return 1; }
+  run "xtmux-obs runs after musl bun shim" xtmux-obs --help
+}
+
+# install_from_source <name> <dir> <pkg> — pack the checked-out ref and install
+# it globally. --ignore-scripts keeps prepublish gates (which need
+# devDependencies) out of the smoke path; cli/dist is tracked so the packed
+# tarball is complete.
+install_from_source() {
+  local name="$1" dir="$2" pkg="$3" tarball
+  tarball="$(cd "$dir" && npm pack --ignore-scripts --silent 2>>"$LOG" | tail -1)"
+  if [ -z "$tarball" ] || [ ! -f "$dir/$tarball" ]; then
+    fail "$name: npm pack produced no tarball"
+    return 1
+  fi
+  if [ "$pkg" = "@jaggerxtrm/xtmux" ]; then
+    install_xtmux "$dir/$tarball"
+  else
+    run "install $name from source ($tarball)" npm i -g "$dir/$tarball"
+  fi
+}
+
+# snapshot <label> <repo dir> — records the state stage 5 compares.
+snapshot() {
+  # Separate statements: `local a=$1 b=$a` trips `set -u` in bash.
+  local label="$1" dir="$2"
+  local out="$WORK/snap-$label.txt"
+  {
+    printf 'xt_version=%s\n'         "$(xt --version 2>/dev/null | tail -1)"
+    printf 'sp_version=%s\n'         "$(sp --version 2>/dev/null | tail -1)"
+    # xtmux's bin has no --version; read the installed manifest instead.
+    printf 'xtmux_version=%s\n'      "$(jq -r '.version' "$(xtmux_root)/package.json" 2>/dev/null)"
+    printf 'registry_assets=%s\n'    "$(jq '.assets | length' "$dir/.xtrm/registry.json" 2>/dev/null || echo 0)"
+    printf 'registry_sha=%s\n'       "$(sha256sum "$dir/.xtrm/registry.json" 2>/dev/null | cut -c1-16)"
+    printf 'hook_commands=%s\n'      "$(jq '[.. | .command? | select(.)] | length' "$dir/.xtrm/config/hooks.json" 2>/dev/null || echo 0)"
+    printf 'hook_files=%s\n'         "$(find "$dir/.xtrm/hooks" -type f 2>/dev/null | wc -l | tr -d ' ')"
+    printf 'skill_roots_repo=%s\n'   "$(find "$dir/.xtrm/skills" -maxdepth 3 -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')"
+    printf 'skill_roots_global=%s\n' "$(find "$HOME/.xtrm/skills/default" -maxdepth 2 -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')"
+    printf 'symlinks=%s\n'           "$(find "$dir/.xtrm" -type l 2>/dev/null | wc -l | tr -d ' ')"
+  } > "$out"
+  printf '  snapshot %-22s %s\n' "$label" "$(paste -sd' ' "$out")"
+}
+
+printf 'xtrm trio smoke test — %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+printf 'dist-tag: %s   branch(all): %s   live checks: %s\n' \
+  "$TAG" "${BRANCH_ALL:-<none>}" "$([ "$SKIP_LIVE" -eq 1 ] && echo skipped || echo on)"
+
+# ===========================================================================
+stage "1-install"
+# ===========================================================================
+run "npm i -g xtrm-tools@$TAG" npm i -g "xtrm-tools@$TAG"
+run "npm i -g @jaggerxtrm/specialists@$TAG" npm i -g "@jaggerxtrm/specialists@$TAG"
+install_xtmux "@jaggerxtrm/xtmux@$TAG"
+
+for bin in xt sp xtmux xtmux-obs xtmux-events bd bun; do
+  if command -v "$bin" >/dev/null 2>&1; then ok "$bin resolves ($(command -v "$bin"))"
+  else fail "$bin is not on PATH"; fi
+done
+run "bun on PATH executes (musl build wins over npm's bun link)" bun --version
+printf '  versions: xt=%s sp=%s xtmux=%s bd=%s\n' \
+  "$(xt --version 2>/dev/null | tail -1)" "$(sp --version 2>/dev/null | tail -1)" \
+  "$(jq -r '.version' "$(xtmux_root)/package.json" 2>/dev/null)" "$(bd version 2>/dev/null | head -1)"
+
+[ "$FAILED" -eq 0 ] || { printf '\nRESULT: FAIL (%s)\n' "$FIRST_FAIL"; exit 1; }
+
+# ===========================================================================
+stage "2-update-mechanisms"
+# ===========================================================================
+run "npm i -g xtrm-tools@latest" npm i -g xtrm-tools@latest
+run "npm i -g @jaggerxtrm/specialists@latest" npm i -g @jaggerxtrm/specialists@latest
+install_xtmux "@jaggerxtrm/xtmux@latest"
+
+SCRATCH="$WORK/scratch"
+mkdir -p "$SCRATCH"
+run "git init scratch project" git init -q "$SCRATCH"
+( cd "$SCRATCH" && run "xt init -y" xt init -y ) || true
+( cd "$SCRATCH" && run "xt update --apply" xt update --apply --repo . ) || true
+[ -f "$SCRATCH/.xtrm/registry.json" ] \
+  && ok "scratch project has .xtrm/registry.json" \
+  || fail "xt init/update produced no .xtrm/registry.json in a fresh project"
+
+# ===========================================================================
+stage "3-clone-and-init"
+# ===========================================================================
+for entry in "${REPOS[@]}"; do
+  IFS='|' read -r name url _pkg <<<"$entry"
+  dir="$WORK/repos/$name"
+  mkdir -p "$(dirname "$dir")"
+  run "clone $name" git clone --quiet --depth 1 "$url" "$dir" || continue
+  ( cd "$dir" && run "xt init -y ($name)" xt init -y ) || true
+  snapshot "$name-pre" "$dir"
+done
+
+# ===========================================================================
+stage "4-apply-edits-and-update"
+# ===========================================================================
+# Two edit modes. With --branch: check the ref out and install that package from
+# source, i.e. test an unreleased branch. Without: induce hook/registry drift so
+# stage 5 proves `xt update --apply` repairs it.
+for entry in "${REPOS[@]}"; do
+  IFS='|' read -r name url pkg <<<"$entry"
+  dir="$WORK/repos/$name"
+  [ -d "$dir" ] || continue
+  ref="${BRANCH_FOR[$name]:-$BRANCH_ALL}"
+
+  if [ -n "$ref" ]; then
+    if git -C "$dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
+      run "fetch $name@$ref" git -C "$dir" fetch --quiet --depth 1 origin "$ref" \
+        && run "checkout $name@$ref" git -C "$dir" checkout --quiet FETCH_HEAD \
+        && install_from_source "$name" "$dir" "$pkg"
+    else
+      skip "$name has no branch '$ref' on origin"
+    fi
+  fi
+
+  # Drift: drop a hook payload and blank the registry, then let xt repair it.
+  victim="$(find "$dir/.xtrm/hooks" -type f 2>/dev/null | head -1)"
+  if [ -n "$victim" ]; then
+    printf 'drift_victim=%s\n' "$victim" >> "$WORK/snap-$name-pre.txt"
+    rm -f "$victim"
+    ok "$name: removed hook payload $(basename "$victim") to simulate drift"
+  else
+    skip "$name: no .xtrm/hooks payload to drift"
+  fi
+
+  ( cd "$dir" && run "xt update --apply ($name)" xt update --apply --repo . ) || true
+  snapshot "$name-post" "$dir"
+done
+
+# ===========================================================================
+stage "5-verify"
+# ===========================================================================
+for entry in "${REPOS[@]}"; do
+  IFS='|' read -r name _url _pkg <<<"$entry"
+  pre="$WORK/snap-$name-pre.txt"; post="$WORK/snap-$name-post.txt"
+  [ -f "$post" ] || { fail "$name: no post snapshot (earlier stage did not complete)"; continue; }
+  printf '  --- %s\n' "$name"
+
+  expect_ge "$name hook_commands"  "$(field hook_commands "$post")"  1
+  expect_ge "$name hook_files"     "$(field hook_files "$post")"     "$(field hook_files "$pre")"
+  expect_ge "$name registry_assets" "$(field registry_assets "$post")" 1
+  expect_ge "$name skill_roots_global" "$(field skill_roots_global "$post")" 1
+  expect_eq "$name symlinks under .xtrm" "$(field symlinks "$post")" 0
+
+  victim="$(field drift_victim "$pre")"
+  if [ -n "$victim" ]; then
+    [ -f "$victim" ] \
+      && ok "$name: xt update --apply restored $(basename "$victim")" \
+      || fail "$name: xt update --apply did NOT restore removed hook $(basename "$victim")"
+  fi
+done
+
+# The release contract: specialists-owned skills must land in the global mirror.
+for s in using-specialists update-specialists using-specialists-auto; do
+  [ -f "$HOME/.xtrm/skills/default/$s/SKILL.md" ] \
+    && ok "global skill mirror has $s" \
+    || fail "global skill mirror is missing $s/SKILL.md"
+done
+
+# Global npm bins must not shadow system commands. Released
+# @jaggerxtrm/specialists declares bin "install", which shadows install(1) for
+# any shell with the npm global bin dir ahead of /usr/bin — it silently hijacks
+# build scripts. WARN not FAIL: it is a known released defect, and a hard fail
+# would keep this gate red for something the release under test cannot repair.
+shadowing=""
+for p in "$(npm prefix -g)"/bin/*; do
+  [ -e "$p" ] || continue
+  b="$(basename "$p")"
+  { [ -e "/bin/$b" ] || [ -e "/usr/bin/$b" ]; } && shadowing="$shadowing $b"
+done
+if [ -n "$shadowing" ]; then
+  warn "global npm bins shadow system commands:$shadowing"
+else
+  ok "no global npm bin shadows a system command"
+fi
+
+# The fresh-machine regression this gate exists to catch.
+if grep -qr "Source and destination must not be the same" "$LOG"; then
+  fail "'Source and destination must not be the same' appeared in install/update output"
+else
+  ok "no 'Source and destination must not be the same' regression"
+fi
+
+# --- live scenario ---------------------------------------------------------
+if [ "$SKIP_LIVE" -eq 1 ]; then
+  skip "live xtmux/sp scenario (--skip-live)"
+else
+  run "xtmux-obs migrate (observability db schema)" xtmux-obs migrate
+  if xtmux-obs health 2>/dev/null | jq -e '.ok == true' >/dev/null 2>&1; then
+    ok "xtmux-obs health reports ok"
+  else
+    fail "xtmux-obs health is not ok"
+    xtmux-obs health 2>&1 | head -3 | sed 's/^/         /'
+  fi
+
+  if tmux new-session -d -s xtrm-smoke "sleep 600" >>"$LOG" 2>&1; then
+    ok "tmux session xtrm-smoke started"
+    sid="$(tmux display-message -p -t xtrm-smoke '#{session_id}' 2>/dev/null)"
+    follow="$WORK/follow.json"; events="$WORK/events.json"
+    # Both followers are bounded by timeout, so `wait` ends the scenario.
+    timeout 15 xtmux log follow --after-id 0 --json >"$follow" 2>&1 &
+    timeout 15 xtmux-events --json >"$events" 2>&1 &
+    sleep 4
+    key="$(xtmux message-send --to "$sid" --bead xtrm-smoke --expects-reply=false \
+             --text 'smoke-container live ping' --json 2>>"$LOG" | jq -r '.messageKey // empty')"
+    [ -n "$key" ] && ok "xtmux message-send accepted ($key)" || fail "xtmux message-send failed"
+    wait
+
+    # Live delivery: the journal must carry the event to a running follower.
+    if [ -n "$key" ] && grep -q "$key" "$follow" 2>/dev/null; then
+      ok "xtmux log follow delivered messages.sent live"
+    else
+      fail "xtmux log follow did not deliver the messages.sent event (see $follow)"
+      head -5 "$follow" 2>/dev/null | sed 's/^/         /'
+    fi
+
+    # The events dashboard on top of it.
+    if grep -q 'following .* open xtmux sessions' "$events" 2>/dev/null; then
+      ok "xtmux-events started and is following the live session"
+    else
+      fail "xtmux-events did not start (see $events)"
+      head -5 "$events" 2>/dev/null | sed 's/^/         /'
+    fi
+    if [ -n "$key" ] && ! grep -q "$key" "$events" 2>/dev/null; then
+      # WARN not FAIL: xtmux-events joins the journal's session_id ("$0") against
+      # `xtmux dashboard`'s composite sessionId ("$0_name_%0_path_ts"), so the join
+      # drops the event. Upstream in xtmux, not something a release can repair here.
+      warn "xtmux-events did not render the event it followed (dashboard sessionId vs journal session_id join)"
+    else
+      [ -n "$key" ] && ok "xtmux-events rendered the live message event"
+    fi
+    tmux kill-session -t xtrm-smoke >>"$LOG" 2>&1
+  else
+    fail "tmux could not start a session"
+  fi
+
+  run "sp list" sp list
+  if [ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}" ]; then
+    ( cd "$SCRATCH" && run "sp run (smoke prompt)" \
+        timeout 300 sp run explorer --prompt 'Reply with the single word OK.' ) || true
+  else
+    skip "sp run needs model credentials (pass -e ANTHROPIC_API_KEY=... to docker run)"
+  fi
+fi
+
+# ===========================================================================
+printf '\n=== SUMMARY ===\n'
+printf '  failures: %d   warnings: %d   skipped: %d\n' "$FAILED" "$WARNED" "$SKIPPED"
+if [ "$FAILED" -eq 0 ]; then
+  printf 'RESULT: PASS\n'
+  exit 0
+fi
+printf 'RESULT: FAIL — first failure in %s\n' "$FIRST_FAIL"
+printf 'full command log: %s (re-run with --keep to retain it)\n' "$LOG"
+exit 1

--- a/scripts/smoke-container/verify.sh
+++ b/scripts/smoke-container/verify.sh
@@ -74,6 +74,18 @@ run() {
   return 1
 }
 
+# run_in <dir> <desc> <cmd...> — same, in another directory. Only the command
+# runs in a subshell; ok/fail stay in this shell, so a failure still reaches
+# FAILED and the exit code. `( cd … && run … )` would lose both.
+run_in() {
+  local dir="$1" desc="$2"; shift 2
+  printf '\n$ (in %s) %s\n' "$dir" "$*" >>"$LOG"
+  if ( cd "$dir" && "$@" ) >>"$LOG" 2>&1; then ok "$desc"; return 0; fi
+  fail "$desc (tail of $LOG below)"
+  tail -20 "$LOG" | sed 's/^/         /'
+  return 1
+}
+
 field() { grep "^$1=" "$2" 2>/dev/null | cut -d= -f2-; }
 
 # expect_ge <label> <actual> <floor>
@@ -142,6 +154,29 @@ install_from_source() {
   fi
 }
 
+# registry_parity <repo dir> — every file the registry declares must exist under
+# its group's source_dir. Prints "total/missing/mismatch"; mismatch is recorded
+# but only reported, because a source clone can legitimately sit ahead of the
+# released registry's hashes.
+registry_parity() {
+  local dir="$1"
+  local reg="$dir/.xtrm/registry.json"
+  [ -f "$reg" ] || { printf '0/0/0'; return; }
+  local total=0 missing=0 mismatch=0 path hash
+  while IFS='|' read -r path hash; do
+    [ -n "$path" ] || continue
+    total=$((total + 1))
+    if [ ! -f "$dir/$path" ]; then
+      missing=$((missing + 1))
+      continue
+    fi
+    [ "$(sha256sum "$dir/$path" | cut -d' ' -f1)" = "$hash" ] || mismatch=$((mismatch + 1))
+  done < <(jq -r '.assets | to_entries[] | .value as $g
+                  | ($g.files // {}) | to_entries[]
+                  | "\($g.source_dir)/\(.key)|\(.value.hash)"' "$reg" 2>/dev/null)
+  printf '%s/%s/%s' "$total" "$missing" "$mismatch"
+}
+
 # snapshot <label> <repo dir> — records the state stage 5 compares.
 snapshot() {
   # Separate statements: `local a=$1 b=$a` trips `set -u` in bash.
@@ -153,7 +188,7 @@ snapshot() {
     # xtmux's bin has no --version; read the installed manifest instead.
     printf 'xtmux_version=%s\n'      "$(jq -r '.version' "$(xtmux_root)/package.json" 2>/dev/null)"
     printf 'registry_assets=%s\n'    "$(jq '.assets | length' "$dir/.xtrm/registry.json" 2>/dev/null || echo 0)"
-    printf 'registry_sha=%s\n'       "$(sha256sum "$dir/.xtrm/registry.json" 2>/dev/null | cut -c1-16)"
+    printf 'registry_parity=%s\n'    "$(registry_parity "$dir")"
     printf 'hook_commands=%s\n'      "$(jq '[.. | .command? | select(.)] | length' "$dir/.xtrm/config/hooks.json" 2>/dev/null || echo 0)"
     printf 'hook_files=%s\n'         "$(find "$dir/.xtrm/hooks" -type f 2>/dev/null | wc -l | tr -d ' ')"
     printf 'skill_roots_repo=%s\n'   "$(find "$dir/.xtrm/skills" -maxdepth 3 -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')"
@@ -195,8 +230,8 @@ install_xtmux "@jaggerxtrm/xtmux@latest"
 SCRATCH="$WORK/scratch"
 mkdir -p "$SCRATCH"
 run "git init scratch project" git init -q "$SCRATCH"
-( cd "$SCRATCH" && run "xt init -y" xt init -y ) || true
-( cd "$SCRATCH" && run "xt update --apply" xt update --apply --repo . ) || true
+run_in "$SCRATCH" "xt init -y" xt init -y || true
+run_in "$SCRATCH" "xt update --apply" xt update --apply --repo .
 [ -f "$SCRATCH/.xtrm/registry.json" ] \
   && ok "scratch project has .xtrm/registry.json" \
   || fail "xt init/update produced no .xtrm/registry.json in a fresh project"
@@ -209,7 +244,7 @@ for entry in "${REPOS[@]}"; do
   dir="$WORK/repos/$name"
   mkdir -p "$(dirname "$dir")"
   run "clone $name" git clone --quiet --depth 1 "$url" "$dir" || continue
-  ( cd "$dir" && run "xt init -y ($name)" xt init -y ) || true
+  run_in "$dir" "xt init -y ($name)" xt init -y || true
   snapshot "$name-pre" "$dir"
 done
 
@@ -245,7 +280,7 @@ for entry in "${REPOS[@]}"; do
     skip "$name: no .xtrm/hooks payload to drift"
   fi
 
-  ( cd "$dir" && run "xt update --apply ($name)" xt update --apply --repo . ) || true
+  run_in "$dir" "xt update --apply ($name)" xt update --apply --repo .
   snapshot "$name-post" "$dir"
 done
 
@@ -264,6 +299,15 @@ for entry in "${REPOS[@]}"; do
   expect_ge "$name skill_roots_global" "$(field skill_roots_global "$post")" 1
   expect_eq "$name symlinks under .xtrm" "$(field symlinks "$post")" 0
 
+  # registry parity: total/missing/mismatch
+  parity="$(field registry_parity "$post")"
+  expect_ge "$name registry files declared" "${parity%%/*}" 1
+  expect_eq "$name registry files missing on disk" "$(printf '%s' "$parity" | cut -d/ -f2)" 0
+  mismatch="$(printf '%s' "$parity" | cut -d/ -f3)"
+  [ "$mismatch" = "0" ] \
+    && ok "$name registry hashes all match" \
+    || warn "$name has $mismatch registry hash mismatch(es) — clone is ahead of the released registry"
+
   victim="$(field drift_victim "$pre")"
   if [ -n "$victim" ]; then
     [ -f "$victim" ] \
@@ -278,6 +322,24 @@ for s in using-specialists update-specialists using-specialists-auto; do
     && ok "global skill mirror has $s" \
     || fail "global skill mirror is missing $s/SKILL.md"
 done
+
+# Skill roots within budget: run core's own budget script against its clone, so
+# the numbers stay in one place instead of being duplicated here. The clone's
+# .xtrm/skills/default holds whatever the *installed* package shipped, so a
+# pre-release run legitimately reports overruns that the release being gated is
+# about to fix — hence WARN with the numbers, not a gate failure.
+budget_script="$WORK/repos/core/scripts/check-skill-root-budget.mjs"
+if [ -f "$budget_script" ]; then
+  budget_out="$(cd "$WORK/repos/core" && node "$budget_script" 2>&1)"
+  printf '\n$ check-skill-root-budget.mjs\n%s\n' "$budget_out" >>"$LOG"
+  if printf '%s' "$budget_out" | grep -q '^FAIL'; then
+    warn "installed skill roots exceed documented budget: $(printf '%s' "$budget_out" | awk '/^FAIL/{printf "%s %s ", $2, $3$4$5}')"
+  else
+    ok "skill roots within documented budget"
+  fi
+else
+  skip "skill-root budget script not present in the core clone"
+fi
 
 # Global npm bins must not shadow system commands. Released
 # @jaggerxtrm/specialists declares bin "install", which shadows install(1) for
@@ -297,7 +359,7 @@ else
 fi
 
 # The fresh-machine regression this gate exists to catch.
-if grep -qr "Source and destination must not be the same" "$LOG"; then
+if grep -q "Source and destination must not be the same" "$LOG"; then
   fail "'Source and destination must not be the same' appeared in install/update output"
 else
   ok "no 'Source and destination must not be the same' regression"
@@ -358,11 +420,14 @@ else
 
   run "sp list" sp list
   if [ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}" ]; then
-    ( cd "$SCRATCH" && run "sp run (smoke prompt)" \
-        timeout 300 sp run explorer --prompt 'Reply with the single word OK.' ) || true
+    run_in "$SCRATCH" "sp run (smoke prompt)" \
+      timeout 300 sp run explorer --prompt 'Reply with the single word OK.'
   else
     skip "sp run needs model credentials (pass -e ANTHROPIC_API_KEY=... to docker run)"
   fi
+  # SCOPE also asked for "terminal notification lands". Not assertable here —
+  # a headless container has no terminal to receive one.
+  skip "terminal notification delivery (no terminal in a headless container)"
 fi
 
 # ===========================================================================


### PR DESCRIPTION
Bead: **xtrm-wiy5n.4.1** — pre/post-release smoke gate for the coordinated Sprint 3c release wave.

## What

`scripts/smoke-container/` — one Alpine `Dockerfile`, one `verify.sh`, one `README.md`. No compose, no k8s, no CI wiring (per NON_GOALS).

```
docker build -t xtrm-smoke scripts/smoke-container/
docker run --rm xtrm-smoke ./verify.sh                     # released packages
docker run --rm xtrm-smoke ./verify.sh --tag next           # a release candidate, in every stage
docker run --rm xtrm-smoke ./verify.sh --branch core=xt/f   # an unreleased branch, installed from source
```

Five stages: install the trio from npm at `--tag` → re-install at the same tag and run `xt init -y` + `xt update --apply` in a fresh repo → clone `core`/`specialists`/`xtmux` and init each, snapshotting state → delete a hook payload to induce drift (and check out `--branch`, packing and installing that package from source) and re-run `xt update --apply` → verify. `exit 0` = PASS; a failure names the stage and prints the command-log tail.

Stage 5 asserts, per repo: wired hook commands present, hook payload count not regressed, non-empty registry, **every one of the 362 files the registry declares present on disk** under its group's `source_dir`, a populated global skill mirror, zero symlinks under `.xtrm`, and that `xt update --apply` restored the deleted hook. Globally: the three specialists-owned skills landed in `~/.xtrm/skills/default`, core's own `check-skill-root-budget.mjs` runs against its clone, no `Source and destination must not be the same` regression, `xtmux-obs health` ok, and `xtmux log follow` delivers a live `messages.sent` event for a real `xtmux message-send`.

## Validation

Against released `xtrm-tools@0.11.2` / `specialists@3.21.1` / `xtmux@0.2.2`:

| Run | Result |
|---|---|
| `./verify.sh` (full, live scenario on) | **PASS** — 0 failures, 5 warnings, 2 skipped, exit 0 |
| `./verify.sh --branch core=main --branch xtmux=no-such-branch --skip-live` | **PASS** — 0 failures; `core@main` packed and installed from source, `xtmux` correctly `[SKIP]`ped for the missing ref |

Full stage report posted as a [PR comment](https://github.com/xtrm-dev/core/pull/513#issuecomment-5084354352) and on the bead. Failure diagnostics were exercised during development (e.g. `RESULT: FAIL — first failure in 5-verify: …`).

Repo checks pass, and are identical with the new directory moved aside: `check:payload-hygiene`, `check:registry-pack-parity`, `check:layout-guards`, `check-forbidden-phrases`, `check:specialists-vendor`, `test:scripts` (12 pass / 0 fail). `gitnexus detect_changes`: 0 changed symbols, 0 affected processes, low risk (additive only).

## Review history

Reviewer specialist: **PARTIAL/81 → PASS/95** after two rounds. Codex found two further issues. All four findings were real and are fixed in this branch:

1. **Failures did not propagate** (reviewer P1). `( cd … && run … )` ran `ok`/`fail` in a subshell, so `FAILED`/`FIRST_FAIL` never reached the parent — `xt init`, `xt update --apply` and `sp run` failures could not fail the gate. Replaced with a `run_in` helper that subshells only the command.
2. **`--tag` was defeated past stage 1** (Codex P1). Stage 2 re-installed at a hardcoded `@latest`, so a `--tag next` candidate was never exercised by stages 2–5 and a broken candidate could report PASS.
3. **Registry parity was not a parity check** (reviewer). It asserted "asset groups ≥ 1" and recorded a `registry_sha` it never compared. Now every declared file must exist on disk; hash mismatches are `[WARN]`, since a default-branch clone legitimately sits ahead of the released registry.
4. **x64-only artifacts** (Codex P2). bun and beads downloads are now selected from `TARGETARCH`; an unsupported arch fails the build with a named error. Only the amd64 path has been run end to end — the README says so.

Also added the skill-root budget check and made terminal-notification delivery an explicit `[SKIP]` with its reason rather than an unstated omission.

## Three upstream defects the gate surfaces

Reported as `[WARN]`, not `[FAIL]`, so the gate stays usable — none can be repaired by the release under test. All named in the README:

1. **`npm i -g @jaggerxtrm/xtmux` fails on musl.** Its `bun` dependency ships a glibc binary (`ENOEXEC` on Alpine). `XTMUX_BUN` does not help: `scripts/xtmux-obs.mjs` resolves the bundled `bun/package.json` path and overwrites the env var unconditionally. The harness retries with `--ignore-scripts` and drops a musl bun over the bundled `bun.exe`.
2. **`@jaggerxtrm/specialists` declares a bin named `install`**, which shadows coreutils `install(1)` for any shell with the npm global bin dir ahead of `/usr/bin`. This silently hijacked the harness's own file copy until diagnosed. Stage 5 now names every global npm bin that shadows a system command.
3. **`xtmux-events` renders nothing** for events it correctly follows: it joins the journal's `session_id` (`$0`) against `xtmux dashboard`'s composite `sessionId` (`$0_name_%0_path_ts`). Relevant to the xtmux 0.2.3 events-widening bead. `xtmux log follow` delivering the same event is the hard assertion.

A fourth `[WARN]`: released 0.11.2 exceeds the documented budget on four skill roots (`multiplexing` 686/160, `multiplexing-team` 342/140, `deploy-monitor` 264/180, `pr-reviewer` 209/160). Those are the roots #504 already slimmed on main — the `--branch core=main` run passes the budget, which is the gate doing its job. A hard failure there would have blocked the very release that fixes it.

## Notes for review

- Root in the container is deliberate and `nosemgrep`-annotated: the harness exists to exercise the documented `npm i -g` path into `/usr/local`; the image serves nothing and is discarded with `--rm`.
- `bd` comes from the GitHub release binary plus `gcompat` — `@beads/bd`'s postinstall download does not resolve on musl.
- `sp run` gates when model credentials are present (`-e ANTHROPIC_API_KEY=…`) and is `[SKIP]` otherwise.
- Expect 12–15 minutes per run; `gitnexus analyze` inside `xt init` (120 s internal timeout per repo) dominates.
- Known non-blocking advisory from the reviewer: `registry_parity` splits on `|`, so a registry path containing a pipe would mis-split. Theoretical — registry paths are `.mjs`/`.md` filenames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
