### PR TITLE
chore(vendor): re-vendor specialists skills at master ba8526cd

### DIFF
--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -978,7 +978,7 @@
           "version": "0.11.2"
         },
         "using-specialists/references/content-migration-map.json": {
-          "hash": "32ec8787652b925b5c7dde04adff81baf129a5154decc5ffcd1034655da0bd5f",
+          "hash": "095dc0573b575521ca25cdc4f75d9d12239aad01ec924494819aa8e5ae2910eb",
           "version": "0.11.2"
         },
         "using-specialists/references/dispatch-preconditions.md": {
@@ -990,7 +990,7 @@
           "version": "0.11.2"
         },
         "using-specialists/references/monitoring.md": {
-          "hash": "7b1aa2cec42756fb752467da14552d1e7233c892232abbc24d563abeb19cd537",
+          "hash": "4871fca2072cffd73ba0932ce0f4514ab2dcbab974ce7bd17e77dc73c1807465",
           "version": "0.11.2"
         },
         "using-specialists/references/registry-and-locations.md": {
@@ -998,7 +998,7 @@
           "version": "0.11.2"
         },
         "using-specialists/SKILL.md": {
-          "hash": "af5725c1e034dd9181452704abdaf5eaa0e0476e2f1c54d9734e3a50e49fbdb7",
+          "hash": "74fb9a29fdcb679c90b34e614c9e43645da5a12ad8cb1d44d10d9a723a2d792d",
           "version": "0.11.2"
         },
         "using-tdd/SKILL.md": {
@@ -1385,9 +1385,9 @@
   "specialists_source": {
     "version": 1,
     "source": {
-      "kind": "ref",
-      "ref": "v3.21.0",
-      "resolved_sha": "22573c647715be526c02164e16745b1906d32b26",
+      "kind": "repo",
+      "ref": "master",
+      "resolved_sha": "ba8526cd867733b8c73ee56ed5142e01e36a09f8",
       "repo_path": "../specialists",
       "source_path": "config/skills"
     },
@@ -1420,7 +1420,7 @@
         "SKILL.md": "e87511d685eb7bc95c374641056194931a9da79434b624fdfb2805bd9dbac7b6"
       },
       "using-specialists": {
-        "evals/evals.json": "1a995301b27b35bef5e59bf8cf6a290c6c289639d6ce21a5aa8931fff1f80d18",
+        "evals/evals.json": "8fdca75958021860c95b35676f5ce3ca24aae7e046acffecdc259bbd993a4172",
         "evals/fixtures/qa-routing/bad-test-result.json": "20e0d3698809c87f9445ea533545998143ffc151a0c2774ea37415b5a984a011",
         "evals/fixtures/qa-routing/reviewer-input.json": "8c3bea5b93a55944aef036c498a090c3e2a6ae4a86c378d66cddfe7cda2aa093",
         "evals/fixtures/qa-routing/source-regression-result.json": "0f566ca2ad84458ce183a1ca4a925ef0b308c8d8cc61fa75b90dc14685d9e3bf",
@@ -1428,12 +1428,12 @@
         "evals/README.md": "c6c871a9e2a5ca8d9cea7b23f89033018791fd1fcdb8fec775b888fe88d4dfa9",
         "references/bead-contracts.md": "b2c3f08758e5a998d52b37c8b5239db81f496a5ea63d93b680a5f49dd0446db4",
         "references/chain-recipes.md": "c92e6447f8ec443db30a28b369d59bdec1f8438115803b9f4661437e97f88f75",
-        "references/content-migration-map.json": "32ec8787652b925b5c7dde04adff81baf129a5154decc5ffcd1034655da0bd5f",
+        "references/content-migration-map.json": "095dc0573b575521ca25cdc4f75d9d12239aad01ec924494819aa8e5ae2910eb",
         "references/dispatch-preconditions.md": "66c7f52379fe546e79fe3eac0c0d52c47df1fc8d1491f805531f48cf83a89dd8",
         "references/merge-and-integration.md": "7884a445b5ee7031fd0cf2b548a6f6bf4df8daa2ab1db5ec28f32c47cbc4d6dd",
-        "references/monitoring.md": "7b1aa2cec42756fb752467da14552d1e7233c892232abbc24d563abeb19cd537",
+        "references/monitoring.md": "4871fca2072cffd73ba0932ce0f4514ab2dcbab974ce7bd17e77dc73c1807465",
         "references/registry-and-locations.md": "d02cb1c2e68f59e14f57d8fda7e80e109fe5666bbd33cae4c0ab8f9b10814460",
-        "SKILL.md": "af5725c1e034dd9181452704abdaf5eaa0e0476e2f1c54d9734e3a50e49fbdb7"
+        "SKILL.md": "74fb9a29fdcb679c90b34e614c9e43645da5a12ad8cb1d44d10d9a723a2d792d"
       },
       "using-specialists-auto": {
         "SKILL.md": "0668f03dc701d3895defc1e3f3973fa41976355db5a1c38278b6272c95f145c4"

--- a/.xtrm/skills/default/using-specialists/SKILL.md
+++ b/.xtrm/skills/default/using-specialists/SKILL.md
@@ -30,7 +30,7 @@ This root file is a **router**. It carries the policy that applies to every task
 | Write or promote a bead so it is dispatchable | [references/bead-contracts.md](references/bead-contracts.md) |
 | Pick a specialist, or run a chain (QA gates, single-chain, epic, review/fix loop) | [references/chain-recipes.md](references/chain-recipes.md) |
 | Dispatch a chain that depends on prior chain output | [references/dispatch-preconditions.md](references/dispatch-preconditions.md) |
-| Wait on a running job, steer it, rebut it, or escalate | [references/monitoring.md](references/monitoring.md) |
+| Choose the run invocation form (foreground vs `--background`), then wait on a job, steer it, rebut it, or escalate | [references/monitoring.md](references/monitoring.md) |
 | Merge, integrate, restitch, smoke, or recover a failed chain | [references/merge-and-integration.md](references/merge-and-integration.md) |
 | Find where a specialist lives, or which `sp` / `xt` commands exist | [references/registry-and-locations.md](references/registry-and-locations.md) |
 

--- a/.xtrm/skills/default/using-specialists/evals/evals.json
+++ b/.xtrm/skills/default/using-specialists/evals/evals.json
@@ -68,15 +68,15 @@
       "id": 4,
       "eval_name": "merge-publication-flow",
       "prompt": "Reviewer passed an executor chain. What should the orchestrator do next to publish the specialist work?",
-      "expected_output": "Agent uses sp merge <chain-root-bead> for standalone chains or sp epic merge <epic-id> for epic-owned work, avoids manual git merge, and closes the bead only after required gates are confirmed.",
+      "expected_output": "Agent follows references/merge-and-integration.md and uses its documented manual git publication workflow only after required gates are confirmed, then closes the bead at the prescribed point.",
       "assertions": [
         {
-          "name": "uses_specialist_merge",
-          "description": "Agent names sp merge or sp epic merge as the publication path"
+          "name": "uses_manual_git_publication",
+          "description": "Agent follows the documented manual git publication workflow"
         },
         {
-          "name": "avoids_manual_git_merge",
-          "description": "Agent explicitly avoids manual git merge for specialist-owned work"
+          "name": "avoids_broken_publication_verbs",
+          "description": "Agent does not invoke the known-broken Specialists publication verbs"
         },
         {
           "name": "honors_reviewer_gate",
@@ -182,7 +182,7 @@
       "id": 9,
       "eval_name": "progressive-disclosure-merge-routing",
       "prompt": "A specialist chain finished and the reviewer returned PASS. I need to merge it. Which part of the using-specialists skill do you consult, and what is the merge rule?",
-      "expected_output": "Agent uses the router's routing table to open references/merge-and-integration.md for the merge procedure, and states rule 9 (manual git only: Cherry-Pick Playbook / FF / git merge --no-ff; never sp merge or sp epic merge) \u2014 which it can answer from the router alone.",
+      "expected_output": "Agent uses the router's routing table to open references/merge-and-integration.md for the merge procedure, and states rule 9 (manual git only: Cherry-Pick Playbook / FF / git merge --no-ff; never the broken Specialists publication verbs) \u2014 which it can answer from the router alone.",
       "assertions": [
         {
           "name": "routes_to_merge_reference",
@@ -190,7 +190,7 @@
         },
         {
           "name": "states_manual_merge_rule",
-          "description": "Agent states that sp merge / sp epic merge are forbidden and merging is manual git."
+          "description": "Agent states that the broken Specialists publication verbs are forbidden and merging is manual git."
         },
         {
           "name": "does_not_load_irrelevant_references",

--- a/.xtrm/skills/default/using-specialists/references/content-migration-map.json
+++ b/.xtrm/skills/default/using-specialists/references/content-migration-map.json
@@ -1,14 +1,21 @@
 {
   "source_version": "3.7",
   "router_version": "3.8",
-  "source_heading_count": 41,
+  "source_heading_count": 40,
+  "retired": [
+    {
+      "heading": "Notification Via Observability DB (Preferred Over `sp ps` Polling)",
+      "retired_in": "xtrm-wiy5n.4.20",
+      "why": "It taught orchestrators to open `.specialists/db/observability.db` and query `specialist_jobs` directly. That database is private to the repo that owns it and is an implementation detail, not a consumer contract (docs/cli-reference.md, `specialists integration record`) — external consumers shell out to a published verb instead of writing the schema themselves.",
+      "reader_served_by": "references/monitoring.md 'Retrieval hierarchy' (sp result --json / --wait, sp feed --json, sp ps --json) for job state; the /using-kpi skill for genuine analysis of that database."
+    }
+  ],
   "source_headings": [
     "Specialist File Locations",
     "Orchestration Discipline (Paranoid Mode)",
     "Project-Specific Specialists",
     "Mandatory Gates: Seconder, Obligations, Security (Iron-style)",
     "Monitoring Long-Running Jobs: Sleep Timers Are Mandatory",
-    "Notification Via Observability DB (Preferred Over `sp ps` Polling)",
     "Worktree Cleanup After Merge",
     "When To Delegate",
     "Non-Negotiable Rules",
@@ -82,7 +89,6 @@
     ],
     "references/monitoring.md": [
       "Monitoring Long-Running Jobs: Sleep Timers Are Mandatory",
-      "Notification Via Observability DB (Preferred Over `sp ps` Polling)",
       "Monitoring And Steering",
       "Specialist Rebuttal As Routine"
     ],

--- a/.xtrm/skills/default/using-specialists/references/monitoring.md
+++ b/.xtrm/skills/default/using-specialists/references/monitoring.md
@@ -1,205 +1,117 @@
 # Monitoring and steering
 
-> Sleep timers, observability-DB notification, steering a running chain, and rebutting a specialist.
+> Retrieval paths, steering verbs, sleep cadence, and rebuttal doctrine for specialist output.
 > Loaded on demand from [SKILL.md](../SKILL.md) — not eagerly injected.
-> Always-needed policy (rules, gates, escalation, specialist choice) stays in the router; it is not repeated here.
+> Flag surfaces are deliberately **not** restated here — run `sp ps --help`, `sp feed --help`,
+> `sp result --help`. Restated flags are what rotted this file twice. The one exception is
+> `sp run`'s dispatch form, stated below because choosing it wrong kills the job silently.
 
-## Monitoring Long-Running Jobs: Sleep Timers Are Mandatory
+## Retrieval hierarchy
 
-Specialists run async. You will lose the chain if you do not actively monitor it.
+Use the narrowest source that already owns the answer:
 
-**`sp run` semantics — read carefully.** There is NO `--background` flag (older versions of this doc used it — it never existed).
-
-- **CLI form** (`sp run <role> --bead <id> ...`) prints `[job started: <id>]` on stderr AT THE START, but the process **keeps streaming stdout until the specialist finishes** — the shell call BLOCKS. This is async in the "job runs on the sp side" sense, not in the "your shell returns" sense.
-- **MCP form** (`use_specialist`) is foreground and returns the result directly.
-- **True background detach** requires shell-level `&` plus log redirect: `sp run <role> --bead <id> --prompt "..." > /tmp/job.log 2>&1 &`. Then `disown` if you want it to outlive the shell. Poll via the observability DB or `sp ps` afterward.
-
-**Required pattern after every dispatch (interactive orchestrator, blocking shell OK):**
-
-```bash
-# tracked (bead-driven) — specialist reads the bead as its prompt
-sp run <role> --bead <id>                      # blocks; streams output; returns when done
-
-# ad-hoc (no bead) — arbitrary prompt
-sp run <role> --prompt "..."                   # blocks; streams output; returns when done
+```text
+foreground run → returned stream/result
+background/workflow run → sp run/feed --json
+terminal truth → sp result --json
+waiting → sp result + sp resume
+generic interactive turn → agent-last
+coordination message → message-get
 ```
 
-`--bead` and `--prompt` are **mutually exclusive**. Use `--bead` for tracked work (the default for chains); use `--prompt` only for ad-hoc off-board queries.
+- A foreground `sp run` streams until it returns; consume that output directly.
+- Dispatch form. A foreground `sp run` BLOCKS the calling shell until the job ends. From an agent pane, always use `--background`: it detaches at process level, returns the job id immediately, and keeps the parent binding so the terminal notification still arrives. A trailing `&` is NOT sufficient — an agent bash tool reaps descendant processes when it returns or times out, which kills the job and reports `SessionKilledError` with zero turns. `--bead` and `--prompt` are mutually exclusive.
+- For workflow progress, retain the job ID and use `sp feed <job-id> --json`.
+- At terminal status (`done`, `error`, or `cancelled`), use `sp result <job-id> --json` as truth.
+- A `waiting` job exposes its latest turn through `sp result`; continue it with `sp resume <job-id> "<prompt>"`.
+- For an ordinary interactive pane turn, use `xtmux agent-last <pane-or-session> --json`.
+- For a coordination notification, preserve its key and use `xtmux message-get <message-key> --json`.
 
-**Required pattern for non-blocking dispatch (orchestrator wants to do other work while it runs):**
+MSG-05 direct parent notification is landing; treat it as a retrieval prompt, not as terminal result data.
 
-```bash
-sp run <role> --bead <id> > /tmp/job-<id>.log 2>&1 &
-JOB_PID=$!
-sleep 10 && sp ps                              # confirm started
-```
-
-**Pi runtime caveat (xtmux-19y):** dispatch `sp`/`xt`/`gh` via the **bash tool**, not pi's `process` tool. Pi's `process` tool spawns subprocesses with a stripped PATH that lacks `~/.nvm/.../bin` (or wherever npm globals live), so `sp run …` inside `process start` exits 127 (`command not found`). The bash tool inherits your PATH normally. If you must use `process` for a background dispatch, hand it an absolute path (`$(which sp)`) or wrap through `bash -lc '…'` to force a login shell.
-
-Then cycle sleeps based on average completion time per role, checking `sp ps` each cycle:
-
-| Role | Typical duration | Initial sleep cycle |
-|------|------------------|---------------------|
-| sync-docs, changelog-keeper | 60–180s | `sleep 60` then `sleep 60` |
-| seconder, security-auditor | 60–180s | `sleep 60` then `sleep 60` |
-| reviewer | 90–240s | `sleep 90` then `sleep 60` |
-| explorer, debugger, planner, overthinker | 120–300s | `sleep 120` then `sleep 90` |
-| executor | 180–600s+ | `sleep 180` then `sleep 120` |
-| test-runner | varies with suite | start at `sleep 120`, adjust |
-
-Rules:
-- After dispatch, **always** `sleep 10 && sp ps` first to confirm the job is `running`, not stuck in `queued` or already `failed`.
-- Then sleep again per the table; check `sp ps` each cycle.
-- Do not poll faster than every 30s after the initial check — it wastes context.
-- When status flips to `completed`, run `sp result <job-id>` immediately to consume output before context grows.
-- If a job exceeds 2× its typical duration without completing, inspect with `sp feed <job-id>` before assuming hang.
-
-You are not "done" until every dispatched job is `completed` or `failed` and consumed.
-
-## Notification Via Observability DB (Preferred Over `sp ps` Polling)
-
-`sp ps` prints the same data the observability SQLite database holds. Query the DB directly instead of polling `sp ps` in a sleep loop — it is faster, structured, filterable, and survives session restarts. Works identically from Claude Code and Pi (both can shell out to `sqlite3` or `python3 -c "import sqlite3;..."`).
-
-**DB location**: `.specialists/db/observability.db` under the project root — always per-repo, never at `~/.specialists/`. Any 0-byte file at `~/.specialists/observability.db` is a placeholder, not a real DB; ignore it. Missing until the first `sp run` in that repo auto-provisions it. If missing, `sp ps` returns empty — same signal.
-
-**Sanity check when DB seems empty:**
-
-```bash
-DB="$(git rev-parse --show-toplevel 2>/dev/null)/.specialists/db/observability.db"
-[ -s "$DB" ] || { echo "no DB in this repo yet — fall back to sp ps"; sp ps; }
-```
-
-**Key table**: `specialist_jobs`. Columns of interest for notification:
-- `job_id` — primary key
-- `specialist` — role name
-- `bead_id`, `epic_id`, `chain_id`, `chain_root_job_id`
-- `status` — canonical values: `done`, `error`, `cancelled` (terminal); `queued`, `running` (in-flight); `waiting` (blocked on human/parent)
-- `updated_at_ms` — epoch millis
-- `last_output` — final assistant text
-- `pr_url`, `pr_state`, `pr_classification` — chain outcomes
-
-**Notification patterns:**
-
-```bash
-DB="${SPECIALISTS_DB:-$PWD/.specialists/db/observability.db}"
-
-# Just-completed jobs since a timestamp (dispatch time)
-sqlite3 "$DB" "SELECT job_id, specialist, bead_id, status FROM specialist_jobs
-  WHERE status IN ('done','error','cancelled')
-  AND updated_at_ms > $SINCE_MS
-  ORDER BY updated_at_ms DESC"
-
-# Latest status for a specific bead (any specialist)
-sqlite3 "$DB" "SELECT job_id, specialist, status, updated_at_ms FROM specialist_jobs
-  WHERE bead_id = '$BEAD' ORDER BY updated_at_ms DESC LIMIT 1"
-
-# All jobs in an epic (chain-scoped view)
-sqlite3 "$DB" "SELECT specialist, status, pr_state FROM specialist_jobs
-  WHERE epic_id = '$EPIC' ORDER BY updated_at_ms DESC"
-
-# Waiting-on-you jobs (needs orchestrator/parent input)
-sqlite3 "$DB" "SELECT job_id, specialist, bead_id, last_output FROM specialist_jobs
-  WHERE status = 'waiting'"
-```
-
-**When to use DB queries vs `sp ps`:**
-
-| Situation | Use |
-|---|---|
-| Waiting for one specific job/bead | DB query on `bead_id` or `job_id` |
-| Multi-chain / epic-level view | DB query on `epic_id` |
-| Detecting completions during a batch | DB query with `updated_at_ms > $SINCE_MS` (loop with sleep) |
-| Human-readable status board | `sp ps` (formatted) |
-| Debugging one job | `sp feed <job-id>` (event stream) |
-
-**Rules:**
-- Capture `SINCE_MS=$(date +%s%3N)` right before dispatch so subsequent queries filter noise.
-- Prefer targeted queries (by `bead_id` / `epic_id`) over full scans — the DB grows unbounded.
-- The DB is authoritative. If `sp ps` and the DB disagree, trust the DB.
-- Applies to both Pi and Claude Code — same shell-out to `sqlite3`. Do not build a language-specific SDK.
-
-Interactive coordinators (chain-coordinator role sessions launched via `xt pi --role` or `xt claude --role`) should prefer this pattern over `sp ps` polling because they escalate to the parent orchestrator via `message-send` only when a job actually transitions, not on every poll cycle. Full launcher-flag surface (`--reuse` / `--new-session` / `--parent` / `--child` / `--model` / `--thinking` / `--` passthrough), session-name shape (`role-<runtime>-<slug>[-<bead>]`), pane options + `XTMUX_AGENT_*` env vars, and address-space split (`@agent_parent_session` = tmux `#{session_id}`; poll `message-list --for $MY_SID`, not by session name) live in `/multiplexing` Pattern 7 — do not re-derive them here.
-
-## Interactive coordination replies
-
-A beaded coordinator escalation is reply-required unless it explicitly uses `--expects-reply=false`. The parent must read the exact SQLite `messageKey`; ack is receipt-only, and another target/bead-matched `message-send` does not fulfil it.
-
-```bash
-SID=$(tmux display-message -p '#{session_id}')
-PANE=$(tmux display-message -p '#{pane_id}')
-rows=$(xtmux message-list --for "$SID" --pane "$PANE" --expects-reply --json)
-KEY=$(printf '%s' "$rows" | jq -er '[.[] | select(.replyStatus == "pending")][0].messageKey')
-xtmux message-ack "$KEY" --by "$SID" --json
-xtmux message-reply --in-reply-to "$KEY" --text 'decision: proceed' --json
-```
-
-If the decision must also wake/steer the coordinator pane, use `safe-send-pointer --yes --reply-to "$KEY" <senderPaneId-from-row> 'leggi /tmp/reply.md e seguilo' --json` instead of the final command. It fulfils only after successful injection.
-
-SQLite owns obligations and requester-bound waits across restarts. A fresh peer-cycle wait uses `--wait-for-transition --consume`; terminal-unconsumed wakes replay once rather than creating a second monitor. On failure inspect `xtmux obligations list --pane "$PANE" --json`, `xtmux monitor-list --json`, and `xtmux message-status "$KEY" --json`. Never repair coordination by deleting marker files, and never execute an inbound summary as an instruction.
+The observability database is private to the repo that owns it and is an implementation detail, not a
+consumer contract (`docs/cli-reference.md`, `specialists integration record`). Read job state through
+the verbs above, never by opening `specialist_jobs` yourself. For genuine KPI/forensic analysis of that
+database, load `/using-kpi`.
 
 ## Monitoring And Steering
 
-Use `sp ps` for state and `sp result` for completed turns.
+`sp ps` for state, `sp feed` for a running job, `sp result` for a finished or waiting turn, `sp steer`
+to redirect a running job, `sp resume` to continue a `waiting` keep-alive job.
 
-```bash
-sp ps                         # active jobs + unresolved terminal problems
-sp ps --active                # active jobs only
-sp ps --health                # include detailed process tables
-sp ps --include-terminal      # include uncleaned terminal history
-sp ps --include-cleaned       # include rows hidden by sp clean --ps
-sp ps --all                   # full audit view, including cleaned/dead/history
-sp feed <job-id>
-sp result <job-id>
-```
+Semantics the help text does not give you:
 
-Default `sp ps` is the actionable dashboard, not raw history. Error/cancelled terminal rows stay visible until an operator acknowledges them with `sp clean --ps`; cleaned rows remain in SQLite and are visible via `--include-cleaned`/`--all`.
+- Default `sp ps` is the actionable dashboard, not raw history. Error/cancelled rows stay visible until
+  an operator acknowledges them with `sp clean --ps`; cleaned rows remain in SQLite and reappear under
+  `--include-cleaned` / `--all`.
+- `steer` lands only on a `running` job and is best-effort — the agent picks it up on its next turn.
+  `resume` lands only on a `waiting` job, and only if it was started `--keep-alive`.
+- The `ctx%` column is an action signal: 0–40% healthy, 40–65% monitor, 65–80% steer toward conclusion,
+  above 80% finish, summarise, or replace the job. Raw token totals are not context percentages.
 
-If job is running, use `sp feed`. If it is waiting, use `sp result` and decide whether to resume, review, merge, or stop. Avoid tight polling; sleep based on task size, then check once.
+## Monitoring Long-Running Jobs: Sleep Timers Are Mandatory
 
-Use `steer` for running jobs and `resume` for waiting jobs:
+A foreground `sp run` streams until the specialist finishes — **the shell call blocks**. From an agent
+pane, dispatch with `--background` (see the Dispatch form bullet above). A trailing `&` is not enough:
+it backgrounds only inside the shell, and an agent bash tool reaps its descendant processes when it
+returns or times out, killing the job and reporting `SessionKilledError` with zero turns. `--background`
+detaches at process level — a separate tmux session with a live feed, or a detached re-invocation —
+and propagates the runtime origin so the terminal notification still binds to the original pane
+(`src/cli/run.ts:938-996`).
 
-```bash
-sp steer <job-id> "Stop broad audit. Answer only the three bead questions."
-sp resume <job-id> "Continue with the next scoped fix. Do not refactor."
-```
+Wrapping a foreground `sp run` in a caller-side timeout likewise kills your own job; the `cancelled`
+row that follows is your timeout, not a product defect. Misreading that cost a full misdiagnosis on
+2026-07-26.
 
-Context usage is an action signal when available:
+For a **one-shot** job, prefer `sp result <job-id> --wait` over a hand-rolled poll loop — it blocks
+until the job is terminal and needs no cadence at all. Do **not** use `--wait` on a `--keep-alive` job:
+it parks in `waiting` after each turn, and `--wait` counts `waiting` as still active
+(`src/cli/result.ts:472`), so it polls until your timeout instead of handing you the turn. Plain
+`sp result <job-id>` returns a waiting job's latest turn; resume it with `sp resume`.
 
-- 0-40%: healthy.
-- 40-65%: monitor.
-- 65-80%: steer toward conclusion.
-- Above 80%: finish, summarize, or replace job.
+Poll only when you must do other work meanwhile, and size the first sleep by role:
 
-Raw token totals are not context percentages.
+| Role | Typical duration | First sleep |
+|------|------------------|-------------|
+| sync-docs, changelog-keeper, seconder, security-auditor | 60–180s | 60s, then 60s |
+| reviewer | 90–240s | 90s, then 60s |
+| explorer, debugger, planner, overthinker | 120–300s | 120s, then 90s |
+| executor | 180–600s+ | 180s, then 120s |
+| test-runner | varies with suite | 120s, then adjust |
 
-### Long autonomous runs — dual-mechanism monitoring
+- After a backgrounded dispatch, `sleep 10 && sp ps` first — confirm `running`, not `queued` or already failed.
+- Never poll faster than every 30s afterwards; it only burns context.
+- On terminal status, consume with `sp result` immediately, before context grows.
+- Past 2× the typical duration, inspect with `sp feed <job-id>` before declaring a hang.
+- Pi runtime: dispatch `sp` / `xt` / `gh` from the bash tool, not pi's `process` tool — `process` strips
+  PATH and `sp` exits 127 (xtmux-19y). Use an absolute path or `bash -lc` if you must.
+- Operator-offline runs: pair the per-dispatch sleep with a fixed-cadence heartbeat. The sleep waits for
+  an expected completion; the heartbeat catches the ones that land while you are busy reading another
+  result. **Claude Code** has this built in — `/loop 180s sp ps`. `/loop` is a Claude Code slash command,
+  not a shell or `sp` verb: from **Pi** or any other runtime, schedule the heartbeat externally (cron, a
+  systemd timer, or a detached `while true; do sp ps; sleep 180; done`).
 
-For sessions where the operator is offline (overnight, async windows), use both:
-
-1. **Bash sleep timers per dispatch**, sized per role (see Monitoring Long-Running Jobs above). Bash sleep waits for an expected completion.
-2. **External cron loop** (Claude Code: `/loop 180s sp ps`) as a heartbeat at fixed cadence regardless of orchestrator's bash sleeps. Cron catches specialists that finished while the orchestrator was busy reading other results, and catches stalls.
-
-The two complement: bash sleep waits for an expected completion; cron catches unexpected completions and stalls. Without the cron, the orchestrator can miss specialists that completed during a long bash poll cycle and waste turns re-polling.
+You are not done until every dispatched job is terminal **and consumed**.
 
 ## Specialist Rebuttal As Routine
 
-Several specialists default to over-cautious verdicts when an evidence gate looks unsatisfied. The orchestrator's job is to challenge that verdict with cited evidence, not to accept it. Common rebuttal-worthy patterns:
+Several roles default to an over-cautious verdict when an evidence gate looks unsatisfied. Challenging
+that verdict with cited evidence is the orchestrator's job, not optional politeness.
 
-### Overthinker
+- Reviewer `PARTIAL — missing gitnexus_impact` on a test-only or LOW-blast-radius diff → cite the scope
+  (files entirely under `test/`, or the executor's `impact_report.highest_risk: LOW` plus LOC and
+  consumer count). The reviewer prompt accepts `gitnexus_impact` **or** `gitnexus_detect_changes` **or**
+  a LOW `impact_report` as evidence.
+- Reviewer `FAIL` on a suite failure that is a known concurrent-run flake → rerun the suspect test in
+  isolation, paste the clean output, resume with "Isolated rerun: P/P. Re-evaluate."
+- Overthinker "hold for operator decision" / "close as superseded" / "split vs merge" with no stated
+  reason → demand file-line evidence for the claim. If a supersede is verified, record it structurally
+  with `bd supersede <old> --with <new>`; if the beads stay parallel siblings, link them with
+  `bd dep relate`, never `blocks`.
 
-- "Hold for operator decision" without specifying what decision is needed → push: "Cite file/line evidence for why this is a product decision rather than a mechanical resolution."
-- "Close as superseded by X" without verification → push: "Read the current state of `<file>` and check whether feature Y from this bead is actually present." If verified, record it structurally with `bd supersede <old> --with <new>` instead of burying the replacement in notes.
-- "Run separate small beads" or "run one big bead" without rationale → push: "Pick one and explain operationally — cost difference, conflict expectations, reviewer scope." If one big bead wins, mark replaced split beads with `bd supersede`; if the small beads remain parallel siblings, link overlap with `bd dep relate`, not `blocks`.
+Argue from new evidence, not authority. A clean seconder verdict or a security-auditor "no findings" is
+legitimate ammunition against a reviewer's "looks too complex" or "may have security risk" — cite the
+advisory job id.
 
-### Reviewer
-
-- "PARTIAL — missing `gitnexus_impact` evidence" on a test-only diff → rebut: "Diff is entirely under `test/` (N files). `gitnexus_impact` analyzes runtime call graphs; test fixture mocks have no callers in the production graph. Bead's impact-gate constraint is conditional on modifying a runtime entrypoint, which did not happen here."
-- "PARTIAL — missing `gitnexus_impact`" on a small LOW-blast-radius production diff where executor used `gitnexus_detect_changes` instead → rebut: cite the executor's `impact_report.highest_risk: LOW`, the LOC count, single helper / single consumer scope. The reviewer prompt accepts `gitnexus_impact` OR `$gitnexus_summary` OR `gitnexus_detect_changes` OR LOW `impact_report` as evidence.
-- "FAIL — full suite shows N+1 fails" where one is a known concurrent-run flake → rebut: rerun the suspect test in isolation, paste clean output, resume reviewer with "Isolated rerun: P/P. Re-evaluate."
-
-### General rule
-
-Resume with explicit ammunition: file/line refs, exact rerun output, link to the bead memory documenting the rebuttal pattern. Don't argue from authority; argue from new evidence. **Findings from seconder / security-auditor are legitimate rebuttal evidence** — a clean seconder OK or a security-auditor "no findings" is concrete proof against a reviewer's "looks too complex" or "may have security risk" gate. Cite the advisory job id when rebutting on this axis.
-
-**One rebuttal per reviewer is the limit.** Second FAIL after rebuttal means stop and report. After a successful rebuttal, save the rebuttal text to `bd remember "<key>"` so the next session inherits it.
-
+**One rebuttal per reviewer.** A second FAIL after rebuttal means stop and report. After a successful
+rebuttal, `bd remember` it so the next session inherits the pattern.

--- a/.xtrm/specialists-source.json
+++ b/.xtrm/specialists-source.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
   "source": {
-    "kind": "ref",
-    "ref": "v3.21.0",
-    "resolved_sha": "22573c647715be526c02164e16745b1906d32b26",
+    "kind": "repo",
+    "ref": "master",
+    "resolved_sha": "ba8526cd867733b8c73ee56ed5142e01e36a09f8",
     "repo_path": "../specialists",
     "source_path": "config/skills"
   },
@@ -36,7 +36,7 @@
       "SKILL.md": "e87511d685eb7bc95c374641056194931a9da79434b624fdfb2805bd9dbac7b6"
     },
     "using-specialists": {
-      "evals/evals.json": "1a995301b27b35bef5e59bf8cf6a290c6c289639d6ce21a5aa8931fff1f80d18",
+      "evals/evals.json": "8fdca75958021860c95b35676f5ce3ca24aae7e046acffecdc259bbd993a4172",
       "evals/fixtures/qa-routing/bad-test-result.json": "20e0d3698809c87f9445ea533545998143ffc151a0c2774ea37415b5a984a011",
       "evals/fixtures/qa-routing/reviewer-input.json": "8c3bea5b93a55944aef036c498a090c3e2a6ae4a86c378d66cddfe7cda2aa093",
       "evals/fixtures/qa-routing/source-regression-result.json": "0f566ca2ad84458ce183a1ca4a925ef0b308c8d8cc61fa75b90dc14685d9e3bf",
@@ -44,12 +44,12 @@
       "evals/README.md": "c6c871a9e2a5ca8d9cea7b23f89033018791fd1fcdb8fec775b888fe88d4dfa9",
       "references/bead-contracts.md": "b2c3f08758e5a998d52b37c8b5239db81f496a5ea63d93b680a5f49dd0446db4",
       "references/chain-recipes.md": "c92e6447f8ec443db30a28b369d59bdec1f8438115803b9f4661437e97f88f75",
-      "references/content-migration-map.json": "32ec8787652b925b5c7dde04adff81baf129a5154decc5ffcd1034655da0bd5f",
+      "references/content-migration-map.json": "095dc0573b575521ca25cdc4f75d9d12239aad01ec924494819aa8e5ae2910eb",
       "references/dispatch-preconditions.md": "66c7f52379fe546e79fe3eac0c0d52c47df1fc8d1491f805531f48cf83a89dd8",
       "references/merge-and-integration.md": "7884a445b5ee7031fd0cf2b548a6f6bf4df8daa2ab1db5ec28f32c47cbc4d6dd",
-      "references/monitoring.md": "7b1aa2cec42756fb752467da14552d1e7233c892232abbc24d563abeb19cd537",
+      "references/monitoring.md": "4871fca2072cffd73ba0932ce0f4514ab2dcbab974ce7bd17e77dc73c1807465",
       "references/registry-and-locations.md": "d02cb1c2e68f59e14f57d8fda7e80e109fe5666bbd33cae4c0ab8f9b10814460",
-      "SKILL.md": "af5725c1e034dd9181452704abdaf5eaa0e0476e2f1c54d9734e3a50e49fbdb7"
+      "SKILL.md": "74fb9a29fdcb679c90b34e614c9e43645da5a12ad8cb1d44d10d9a723a2d792d"
     },
     "using-specialists-auto": {
       "SKILL.md": "0668f03dc701d3895defc1e3f3973fa41976355db5a1c38278b6272c95f145c4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Assign beads from the runtime readiness handshake (xtrm-wiy5n.4.18) (#510)** ([359af43](https://github.com/xtrm-dev/core/commit/359af431f8c90d33044002525039cb39579dc388)) — 2026-07-26 16:06
 
+- **Invert the sp-run-background rule, which asserted a falsehood** ([a1a65de](https://github.com/xtrm-dev/core/commit/a1a65de03ca9aaca16ee05bace79efc9d7554b40)) — 2026-07-26 16:44
+
 ### Other changes
 
 - **Dump CI changelog:check diagnostics (#489)** ([428a27b](https://github.com/xtrm-dev/core/commit/428a27bfa1dcf3ae6d2e819db92533823ca0aa58)) — 2026-07-23 13:40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Assign beaded sessions from runtime origin (#508)** ([2fdcef8](https://github.com/xtrm-dev/core/commit/2fdcef84933664a908d06e301b164625afe93fe4)) — 2026-07-25 18:21
 
-- **Drift-lint gates for forbidden phrases and vendored specialists parity** ([0ae3714](https://github.com/xtrm-dev/core/commit/0ae3714378b6ed780ddccd17b37919745719e77c)) — 2026-07-26 16:02
+- **Drift-lint gates for forbidden phrases and vendored specialists parity (xtrm-wiy5n.4.3) (#514)** ([a89f55d](https://github.com/xtrm-dev/core/commit/a89f55db0b7da94bebd3fa3c10ae78f987157863)) — 2026-07-26 16:25
 
 ### Fixed
 
@@ -32,8 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Retire dead Specialists hook payloads (#509)** ([75ee080](https://github.com/xtrm-dev/core/commit/75ee080ebedfacc86a55dd6d3af0f75cca9fd05b)) — 2026-07-25 20:13
 
 - **Assign beads from the runtime readiness handshake (xtrm-wiy5n.4.18) (#510)** ([359af43](https://github.com/xtrm-dev/core/commit/359af431f8c90d33044002525039cb39579dc388)) — 2026-07-26 16:06
-
-- **Tighten forbidden-phrase predicates per Codex review** ([06582f7](https://github.com/xtrm-dev/core/commit/06582f7379c601b25f80ebb9998da60a62436d04)) — 2026-07-26 16:20
 
 ### Other changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Claude-column contract matrix for the cross-runtime gate (#512)** ([c48b46b](https://github.com/xtrm-dev/core/commit/c48b46b1c66734c66f154451f85f3bb31f21745c)) — 2026-07-26 15:48
 
+- **Re-vendor specialists skills at master ba8526cd** ([1ae4a49](https://github.com/xtrm-dev/core/commit/1ae4a499388dbb9cf2f47d5caf8de8abfa60961c)) — 2026-07-26 16:35
+
 ## [v0.11.2] — 2026-07-22
 
 ### Changed

--- a/scripts/check-forbidden-phrases.mjs
+++ b/scripts/check-forbidden-phrases.mjs
@@ -11,10 +11,11 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const vendored = new Set(JSON.parse(readFileSync(path.join(repoRoot, '.xtrm/specialists-source.json'), 'utf8')).skills);
 
 const RULES = [
-  // Deliberately not anchored to an `sp run` on the same line: both real occurrences this
-  // gate first caught sat on a continuation line of a multi-line dispatch.
-  { id: 'sp-run-background', why: '`sp run` has no --background flag; use shell `&` plus a log redirect',
-    test: (l) => /(^|\s)--background(\s|$)/.test(l) },
+  // `sp run --background` IS supported (specialists src/cli/run.ts:938-996, documented by
+  // specialists#228 with a help/flag parity test). The inverse is the real drift: a trailing
+  // `&` does not survive an agent bash tool, which reaps descendants on return or timeout.
+  { id: 'sp-run-ampersand-detach', why: 'a trailing `&` does not detach `sp run` from an agent pane; use --background',
+    test: (l) => /\bsp run\b/.test(l) && /(>|2>&1)?\s*&\s*$/.test(l) && !/--background/.test(l) },
   // Exemption must be the negative wording valid guidance uses — merely naming `final-result`
   // would let "use capture-pane as the final-result protocol" through.
   { id: 'capture-pane-as-result', why: 'capture-pane is live-state diagnosis only; terminal truth is `sp result` / `agent-last` / `message-get`',


### PR DESCRIPTION
## Problem

Core `main` is red. The workflow **Specialists asset validation** fails on `.xtrm/skills/default/using-specialists/SKILL.md`.

Four specialists pull requests merged today: #225, #227, #228, #230. Each changed `config/skills/using-specialists/`. Core carries a vendored copy of that directory. The two copies stopped matching.

The proof is exact. Commit `75ee080e` passed this workflow at 2026-07-25 20:14. The same commit failed at 2026-07-26 14:59. Core did not change. Specialists changed.

## Change

Re-vendor at specialists master `ba8526cd`. Record that immutable SHA in `.xtrm/specialists-source.json`.

## Why the pin moves to master

An advisor compared four options.

| Option | Result |
|---|---|
| Keep the pin at `v3.21.0` | Core `main` stays red until Specialists 3.21.2 exists. Every later specialists merge keeps it red. |
| Vendor content, keep the pin text | Records a false source. |
| Change only the workflow fallback | Does not fix it. Today's runs used explicit dispatch SHAs. |
| **Vendor at master, re-pin at release** | **Chosen.** |

Core tracks master now. This is temporary. Bead `xtrm-wiy5n.4.4` re-pins at `v3.21.2` during the coordinated release.

Known cost: core carries specialists content that no release contains, until that release.

## Verification

- `verify-asset-contract.mjs` against the specialists `dist/asset-contract.json` — **PASS**
- `npm run check:specialists-vendor` — **OK**
- `npm run gen-registry` — regenerated `.xtrm/registry.json`

## Not fixed here

Neither is caused by this change:

1. The CHANGELOG check on `main`. It fails since 2026-07-25.
2. An OSV finding for `fast-uri`.

Bead: xtrm-wiy5n.4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)