### PR TITLE
docs(agents): remove the ambiguous tool prohibition (xtrm-wiy5n.4.36)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Clearly distinguish verified facts, observations, assumptions, inferences, recom
 
 ## Task Tracking (two-tier)
 
-Up to two task systems coexist in this repo. Where the runtime exposes both, use both; do not substitute one for the other. On a runtime with no task tools, beads alone is correct and complete — do not call tools this file names.
+Up to two task systems coexist in this repo. Where the runtime exposes both, use both; do not substitute one for the other. On a runtime with no task tools, beads alone is correct and complete — do not invent or call a native task API the runtime does not expose.
 
 - **Beads (`bd`)** — top-level durable tracking, on every runtime. Authoritative for ownership, dependencies, cross-session memory, and closure. Read the rest of this file and run `bd prime` for beads context before starting work. File, claim, and close work here.
 - **The runtime's own task system, when the runtime has one** — this-session execution tracking. Use it to mirror the active bead and break it into smaller intermediate steps. Ephemeral; does not replace beads. Names differ per runtime; read the runtime's own tool list rather than assuming a name.


### PR DESCRIPTION
Follow-up to #518. Codex found on xtrm-dev/specialists#238 that the clause I added there — and merged here — is ambiguous.

`AGENTS.md` said: *"do not call tools this file names"*. But `AGENTS.md` names `bd` a few lines below and requires `bd prime`. Read literally, the clause disables the one tracking system the same sentence tells the reader to use.

It now says: **do not invent or call a native task API the runtime does not expose.** That is the thing actually being prohibited.

The identical commit goes to xtrm-dev/specialists#238 and Jaggerxtrm/xtmux#83, so the block stays the same across the three repos. The xtmux copy carries one extra hunk, for a contradiction that exists only there.

Documentation only.

Bead: xtrm-wiy5n.4.36

🤖 Generated with [Claude Code](https://claude.com/claude-code)