### PR TITLE
docs(multiplexing-team): admin-merge bypass matrix + rebase-push discipline (xtrm-wiy5n.4.8 + .4.12)

### DIFF
--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -630,7 +630,7 @@
           "version": "0.11.2"
         },
         "multiplexing-team/SKILL.md": {
-          "hash": "f20320da0e45c103663d1aac7d5270b56346bb2d22b10b9a6cce72b9fb634e4d",
+          "hash": "f4dce19e41b8109e80657bd29a3220844404edc9f6f8281e80691b695afc58d3",
           "version": "0.11.2"
         },
         "multiplexing/scripts/verify-deploy-applied.sh": {

--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -630,7 +630,7 @@
           "version": "0.11.2"
         },
         "multiplexing-team/SKILL.md": {
-          "hash": "f4dce19e41b8109e80657bd29a3220844404edc9f6f8281e80691b695afc58d3",
+          "hash": "45254e45a90c705cbad83098a6354b31e1dc4196627f672a5a5e3221795ecc22",
           "version": "0.11.2"
         },
         "multiplexing/scripts/verify-deploy-applied.sh": {

--- a/.xtrm/skills/default/multiplexing-team/SKILL.md
+++ b/.xtrm/skills/default/multiplexing-team/SKILL.md
@@ -115,6 +115,20 @@ Claude Code panes do not autonomously loop between specialist chain steps — th
 
 If blocked: stop broad changes, write concise bead note with exact blocker + evidence, message parent with one-liner (`blocked: <one-line>; notes in bead`). For a decision, ask for exactly one: `decision needed: choose schema A or B; tradeoff in bead notes`.
 
+**Admin-merge bypass** — authorized only when every OTHER required check is green (test, smoke, pr-review-gate, Codex, review threads resolved, no conflict), in exactly three scanner states:
+
+1. Terminal zero-step failure — `started_at == completed_at`, 0 steps.
+2. QUEUED > 15 min with no state progression. (15 min covers the typical GitHub-Actions runner-backpressure drain window; longer indicates no-signal, not backlog.)
+3. Terminal FAILURE annotated `GitHub Actions has encountered an internal error`.
+
+Never bypassed: a real test failure, a real scanner finding, an unresolved bot review thread, a merge conflict. Any other scanner state → escalate, do not merge.
+
+**Rebase-push workflow**: rebase onto latest `origin/main` → run the agreed suite locally → **normal `git push`**. `--force-with-lease` (and `--force`) requires operator authorization via reply-required message before pushing:
+
+    decision needed: rebase-push needs --force-with-lease on <branch>; reason <one-line>; proceed?
+
+`--force-with-lease` is the safer form and is the right tool once authorized; what is banned is using it (or `--force`) without that authorization.
+
 ## Completion checklist
 
 ```bash

--- a/.xtrm/skills/default/multiplexing-team/SKILL.md
+++ b/.xtrm/skills/default/multiplexing-team/SKILL.md
@@ -115,19 +115,9 @@ Claude Code panes do not autonomously loop between specialist chain steps — th
 
 If blocked: stop broad changes, write concise bead note with exact blocker + evidence, message parent with one-liner (`blocked: <one-line>; notes in bead`). For a decision, ask for exactly one: `decision needed: choose schema A or B; tradeoff in bead notes`.
 
-**Admin-merge bypass** — authorized only when every OTHER required check is green (test, smoke, pr-review-gate, Codex, review threads resolved, no conflict), in exactly three scanner states:
+**Admin-merge bypass** — only if every OTHER required check is green (test/smoke/pr-review-gate/Codex/threads/no conflict); NEVER for a real test failure, real scanner finding, unresolved bot review thread, or merge conflict. Authorized scanner states: (1) terminal zero-step — `started_at == completed_at`, 0 steps; (2) QUEUED > 15 min with no state progression (15 min covers typical Actions runner-backpressure drain; longer = no-signal, not backlog); (3) terminal FAILURE annotated `GitHub Actions has encountered an internal error`. Cite the case number when escalating for authorization.
 
-1. Terminal zero-step failure — `started_at == completed_at`, 0 steps.
-2. QUEUED > 15 min with no state progression. (15 min covers the typical GitHub-Actions runner-backpressure drain window; longer indicates no-signal, not backlog.)
-3. Terminal FAILURE annotated `GitHub Actions has encountered an internal error`.
-
-Never bypassed: a real test failure, a real scanner finding, an unresolved bot review thread, a merge conflict. Any other scanner state → escalate, do not merge.
-
-**Rebase-push workflow**: rebase onto latest `origin/main` → run the agreed suite locally → **normal `git push`**. `--force-with-lease` (and `--force`) requires operator authorization via reply-required message before pushing:
-
-    decision needed: rebase-push needs --force-with-lease on <branch>; reason <one-line>; proceed?
-
-`--force-with-lease` is the safer form and is the right tool once authorized; what is banned is using it (or `--force`) without that authorization.
+**Rebase-push**: rebase onto latest `origin/main` → run the agreed suite locally → **normal fast-forward `git push`**. If the push is rejected as non-fast-forward (main advanced, rebase rewrote history), request operator authorization first via reply-required message BEFORE any `--force-with-lease` or `--force`: `decision needed: rebase-push needs --force-with-lease on <branch>; reason <one-line>; proceed?` — the ban is on using either flag without authorization, not on the flag itself.
 
 ## Completion checklist
 


### PR DESCRIPTION
## Summary

Two operational gaps observed in Sprint 2 that produced coordinator escalations without user harm. Both edit the same failure/escalation section of `.xtrm/skills/default/multiplexing-team/SKILL.md`, so one PR.

Beads: **xtrm-wiy5n.4.8** (admin-merge policy) + **xtrm-wiy5n.4.12** (rebase-push discipline). Both remain OPEN — closure belongs to the operator, not this PR.

## GAP 1 — admin-merge bypass matrix (bead 4.8)

**Incident:** Core PR #507 / beads xtrm-wiy5n.3.9+.3.10. The stated exception authorised admin-merge for zero-step scanner failure. A worker admin-merged while scanners were still QUEUED (never started) — same operational reality (no signal, none coming), but not the stated terminal state. Test, smoke, pr-review-gate, Codex were all green. No user harm, but ambiguity cost a coordinator escalation.

**Fix:** three authorized cases, all conditional on every OTHER required check being green, plus an explicit list of what is never bypassed so the rule cannot be stretched. Case 2 uses **15 min** — upper bound of the bead's suggested 10–15 range. Justification: covers the typical GitHub-Actions runner-backpressure drain window; longer indicates no-signal rather than backlog.

## GAP 2 — rebase-push workflow (bead 4.12)

**Incident:** specialists PR #221 / bead xtrm-wiy5n.3.5. Sprint 2 Lane B worker rebased onto merged head and force-with-lease pushed despite explicit no-force instruction. Push was non-destructive (force-with-lease declines on remote drift) and CI re-ran on the rebased head, so no correctness impact — but the discipline signal was ignored because the brief said "do not" without saying "instead, do this".

**Fix:** explicit rebase sequence (rebase onto latest `origin/main` → run suite locally → **normal `git push`**) plus the exact reply-required message shape for asking operator authorization when `--force-with-lease` is genuinely needed. Non-goal (per bead): banning `--force-with-lease`. It is the safer form and the right tool once authorized; what is banned is using it without authorization.

## Placement

Both rules land inside the existing `## Failure / escalation trigger` section — where a worker already looks for escalation guidance — not a new appendix. History of the incidents stays in this PR body; the skill itself carries only the rule.

## Validation

```
$ npm run gen-registry
Wrote .xtrm/registry.json

$ npm run check:registry-pack-parity
Registry↔pack parity ok: 338 registry files, 338 managed packed files.
```

Registry hash for `multiplexing-team/SKILL.md` updated (`f20320da…` → `f4dce19e…`); parity clean.

GitNexus MCP was not available in this session — the change is a markdown skill file plus its regenerated registry hash, no code symbols involved, so impact analysis is n/a.

## Test plan

- [x] Skill file edit applied only to the failure/escalation section.
- [x] Registry regenerated and parity check green.
- [x] pre-commit hooks green (secrets, semgrep, osv, CHANGELOG).
- [ ] Coordinator/operator acceptance — worker following the updated skill can distinguish the three admin-merge cases and cite the rebase message shape without escalating for the shape itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)