### PR TITLE
fix(ci): scope Policy parity step to a scratch PI_AGENT_DIR (xtrm-spcuo)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,16 @@ jobs:
       run: npm run check:skills-ownership
 
     - name: Policy parity checks (Claude + Pi)
+      # PI_AGENT_DIR points at a scratch dir so this step never writes to the
+      # runner's real HOME. On the self-hosted runner HOME is the operator's
+      # machine, and copying loose extensions into ~/.pi/agent/extensions/
+      # broke Pi startup (module resolution + tool-name conflicts vs the
+      # global npm package). See bead xtrm-spcuo.
+      env:
+        PI_AGENT_DIR: ${{ runner.temp }}/pi-agent
       run: |
-        mkdir -p ~/.pi/agent/extensions
-        cp -r packages/pi-extensions/extensions/* ~/.pi/agent/extensions/
+        mkdir -p "$PI_AGENT_DIR/extensions"
+        cp -r packages/pi-extensions/extensions/* "$PI_AGENT_DIR/extensions/"
         node scripts/compile-policies.mjs --check
         node scripts/compile-policies.mjs --check-pi
 


### PR DESCRIPTION
## Summary
- The Policy parity step wrote into `~/.pi/agent/extensions/` on every push to `main`. That job routes to the self-hosted runner where `HOME` is the operator's real machine, so every merge overwrote the operator's Pi extension tree with loose file copies and broke Pi startup (module resolution + tool-name conflicts vs the global `@jaggerxtrm/pi-extensions` npm package). Bead `xtrm-spcuo`.
- Fix: set `PI_AGENT_DIR=${{ runner.temp }}/pi-agent` on the step and rewrite the copy target to `$PI_AGENT_DIR/extensions`. `scripts/compile-policies.mjs:46` already honors `PI_AGENT_DIR`, so the parity check keeps running against the scratch copy and still fails on drift. `HOME` is never touched.
- Non-goals: removing the parity check.

## Red-then-green proof (local)
Run the CI step logic against a scratch dir:

```
GREEN — full parity → "✓ Pi extensions are in sync with policy declarations"
RED   — remove policy-managed `beads` from scratch dir →
        "✗ Pi extension deployment drift detected  Missing deployed extensions: beads"
GREEN — restore → "✓ Pi extensions are in sync with policy declarations"
HOME .pi/agent mtime unchanged before and after the whole cycle.
```

## Test plan
- [ ] CI green on this PR (runs on `ubuntu-latest` for `pull_request`).
- [ ] After merge, the self-hosted push run must leave `~/.pi/agent/extensions/` untouched (mtime unchanged; no loose extension dirs matching repo sources).
- [ ] Parity check still fails if a policy-declared extension is removed from `packages/pi-extensions/extensions/`.

Bead: xtrm-spcuo (kept open, closure is the operator's).