### PR TITLE
fix(smoke): invoke xtmux installer bare, not --from-npm (xtrm-9hq6w)

### DIFF
--- a/scripts/smoke-container/verify.sh
+++ b/scripts/smoke-container/verify.sh
@@ -141,7 +141,11 @@ install_xtmux() {
   warn "npm i -g $spec needed the musl bun shim (bundled bun.exe is a glibc binary — Alpine/musl install path is not clean upstream)"
   npm i -g --ignore-scripts "$spec" >>"$LOG" 2>&1 || { fail "npm i -g --ignore-scripts $spec"; return 1; }
   patch_bundled_bun
-  node "$(xtmux_root)/scripts/install.mjs" --from-npm >>"$LOG" 2>&1 || { fail "xtmux install.mjs --from-npm"; return 1; }
+  # Bare invocation, NOT --from-npm: that flag is the postinstall marker and
+  # makes the installer exit 0 without doing anything unless npm_config_global
+  # is set (install.mjs:18). Here we NEED it to run — the --ignore-scripts
+  # install above deliberately skipped the postinstall (xtrm-9hq6w).
+  node "$(xtmux_root)/scripts/install.mjs" >>"$LOG" 2>&1 || { fail "xtmux install.mjs"; return 1; }
   patch_bundled_bun || { fail "could not place musl bun in $(xtmux_root)/node_modules/bun/bin"; return 1; }
   run "xtmux-obs runs after musl bun shim" xtmux-obs --help
 }
@@ -337,8 +341,11 @@ global_drift_and_repair() {
   local xtmux_installer; xtmux_installer="$(xtmux_root)/scripts/install.mjs"
   if [ -f "$xtmux_installer" ]; then
     patch_bundled_bun
-    run "xtmux install.mjs --from-npm (drift repair, in-place)" \
-      node "$xtmux_installer" --from-npm
+    # Bare invocation, NOT --from-npm — see install_xtmux above. Passing the
+    # postinstall marker here silently no-opped the repair, so the gate
+    # measured drift that was never repaired (xtrm-9hq6w, Codex xtmux#88).
+    run "xtmux install.mjs (drift repair, in-place)" \
+      node "$xtmux_installer"
   else
     fail "xtmux install.mjs missing at $xtmux_installer — cannot repair global hooks"
   fi


### PR DESCRIPTION
## Release blocker — paired with Jaggerxtrm/xtmux#88

`--from-npm` is the postinstall marker. `install.mjs:18` exits 0 doing nothing unless `npm_config_global=true`. It is the **only** thing that flag controls.

Both smoke-container call sites passed it while needing the installer to actually run. Both were silent no-ops that still reported `ok`.

### `install_xtmux` musl-bun fallback (verify.sh:144)

The preceding `npm i -g --ignore-scripts` deliberately skips the postinstall, so the explicit invocation is the only thing that places hooks and bins. It placed nothing. This site was not in the original bead — found while fixing the other one.

### `global_drift_and_repair` (verify.sh:341)

The gate injected drift, "repaired" it with a no-op, then measured the drift it never repaired:

```
[WARN] fault injected: stripped --new-instance from every SessionStart agent-state.sh entry
[OK]   xtmux install.mjs --from-npm (drift repair, in-place)   <- did nothing
[FAIL] drift-repair: SessionStart entries missing --new-instance = 1, expected 0
```

That FAIL is what blocked the release candidate.

## Why bare, and not a new flag

Codex on xtmux#88 showed the first attempt at this fix — gating on `npm_lifecycle_event` — breaks Bun, which runs `postinstall` **without** setting that variable (reproduced on Bun 1.2.14). A local `bun install` would then have written into the user's real HOME. Same class as core#526.

So xtmux#88 restores the original guard verbatim and the caller simply stops claiming to be a postinstall. Bare `node scripts/install.mjs` is already the shape xtmux's own `install:global` script uses. No new flag, no env matrix to keep in sync with every future package runner.

## Verification

- `bash -n scripts/smoke-container/verify.sh` clean.
- xtmux#88 carries the red-then-green proof and 19/19 installer tests, including a bun-postinstall regression test.
- Both PRs must land before the gate can PASS. Full container re-run follows the merge.

Closes xtrm-9hq6w (core-side half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)