### PR TITLE
fix(smoke): force branch checkout past the generated registry (xtrm-kqf0y)

### DIFF
--- a/scripts/smoke-container/verify.sh
+++ b/scripts/smoke-container/verify.sh
@@ -538,9 +538,18 @@ for entry in "${REPOS[@]}"; do
   ref="${BRANCH_FOR[$name]:-$BRANCH_ALL}"
 
   if [ -n "$ref" ]; then
+    # --force is required, not sloppiness. Stage 3 ran `xt init` in this clone,
+    # which rewrites the TRACKED generated file .xtrm/registry.json. The clone
+    # and this fetch read origin at two different moments, so when a PR lands
+    # in between, FETCH_HEAD carries a different registry.json and a plain
+    # checkout aborts with "local changes would be overwritten". That made the
+    # release gate fail for whoever was merging at the time — precisely when
+    # the gate gets run. The generated scaffolding is not signal here: we want
+    # the branch's source, and stage 4 regenerates it via `xt update --apply`
+    # immediately after injecting drift.
     if git -C "$dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
       run "fetch $name@$ref" git -C "$dir" fetch --quiet --depth 1 origin "$ref" \
-        && run "checkout $name@$ref" git -C "$dir" checkout --quiet FETCH_HEAD \
+        && run "checkout $name@$ref" git -C "$dir" checkout --quiet --force FETCH_HEAD \
         && install_from_source "$name" "$dir" "$pkg"
     else
       skip "$name has no branch '$ref' on origin"


### PR DESCRIPTION
## The gate failed for whoever is merging

Release-candidate run, stage 4:

```
[FAIL] checkout core@main
error: Your local changes to the following files would be overwritten by checkout:
	.xtrm/registry.json
Aborting
```

**Not a flake — a race, proven by timestamps:**

| Time | Event |
|---|---|
| `01:14:44Z` | gate starts; stage 3 clones core at `main` = `3b9d6e6d` |
| | `xt init -y (core)` rewrites the **tracked, generated** `.xtrm/registry.json` (snapshot: parity `362/0/15`) |
| `01:16:58Z` | **core#528 merges**; `main` → `653dae6d`, changing `releasing/SKILL.md` and therefore the registry |
| `~01:17Z` | stage 4 fetches `main`; `FETCH_HEAD` now carries a **different** `registry.json` → checkout aborts |

Stage 3 and stage 4 read origin roughly two minutes apart. A PR landing in that window breaks the gate.

**Ruled out:** stage 3 output is byte-identical between the passing run and the failing run — same clone, same `xt init`, same `362/0/15` parity. The only difference is what `main` pointed at by stage 4.

This matters because the gate is run *at release time*, which is exactly when merges are landing.

## Why `--force` is correct here

The step exists to test **the branch's source**. The `xt init` scaffolding is not signal at that point, and stage 4 regenerates the registry via `xt update --apply` immediately after injecting drift. A comment at the call site records this so the flag is not later removed as sloppiness.

## Verification

Same run confirmed the *other* release blocker (xtrm-9hq6w) is genuinely fixed once the corrected `verify.sh` is actually in the image:

```
[OK] xtmux install.mjs (drift repair, in-place)          <- bare invocation
[OK] drift-repair:    SessionStart entries missing --new-instance = 0
[OK] claude settings: SessionStart entries missing --new-instance = 0
```

`failures: 1` — that one failure is this race. Full gate re-run follows the merge.

Closes xtrm-kqf0y.

🤖 Generated with [Claude Code](https://claude.com/claude-code)