### PR TITLE
style(changelog): compact entries — no bold, no blank line between bullets

### DIFF
--- a/changelog/cliff.toml
+++ b/changelog/cliff.toml
@@ -4,8 +4,7 @@ body = """
 {% if version %}## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}{% else %}## [Unreleased]{% endif %}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group }}
-{% for commit in commits %}
-- **{{ commit.message | split(pat="\n") | first | trim | upper_first }}** ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/xtrm-dev/core/commit/{{ commit.id }})) — {{ commit.author.timestamp | date(format="%Y-%m-%d %H:%M", timezone="UTC") }}
+{% for commit in commits %}- {{ commit.message | split(pat="\n") | first | trim | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/xtrm-dev/core/commit/{{ commit.id }}))
 {% endfor %}{% endfor %}
 """
 trim = false


### PR DESCRIPTION
Operator request: the changelog — and the GitHub release body that now mirrors it — should be compact. No bold, no blank line between entries.

## Before / after

```
- **Alpine smoke-test container for the xtrm trio (xtrm-wiy5n.4.1) (#513)** ([335c6e7](...)) — 2026-07-26 19:10

- **Fail build on payload/wiring mismatch (xtrm-wiy5n.4.38) (#523)** ([b602bac](...)) — 2026-07-26 23:25
```

```
- Alpine smoke-test container for the xtrm trio (xtrm-wiy5n.4.1) (#513) ([335c6e7](...))
- Fail build on payload/wiring mismatch (xtrm-wiy5n.4.38) (#523) ([b602bac](...))
```

A 40-entry release went from 80+ lines of mostly whitespace to 40 lines.

## Why this shape

**xtmux's template already renders exactly this way.** This makes core match the existing house style rather than inventing a third one. specialists is the remaining outlier and follows separately — it is deliberately not touched while the release DAG is mid-flight, because moving specialists `master` would desync the specialists pin core is about to capture.

## The blank line was a template bug, not a style choice

```
{% for commit in commits %}
- entry
{% endfor %}
```

Each iteration emits `"\n- entry\n"`, so consecutive entries are separated by a blank line. Moving `- ` onto the `{% for %}` line makes each iteration emit one line.

## Kept, and dropped

- **Kept** `split(pat="\n") | first | trim` — takes only the subject of a multi-line commit message. xtmux's template lacks this guard; core's is better and stays.
- **Dropped** the trailing `— YYYY-MM-DD HH:MM` author timestamp. xtmux omits it, it is redundant with the linked commit, and it was the longest part of every line.

## Verification

Rendered via `npm run changelog:preview` against the real unreleased range — output confirmed compact, unbolded, one line per entry, groups intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)