### PR TITLE
release: v0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.4] - 2026-07-30
+
+### Added
+- Unify native tool rendering (xtrm-cgxqy) (#534) ([5a897c8](https://github.com/xtrm-dev/core/commit/5a897c89e991a4741850abbc3d31d32d496f2104))
+
 ## [0.11.3] - 2026-07-28
 
 ### Added

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xtrm-cli",
   "private": true,
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xtrm-tools",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtrm-tools",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "license": "MIT",
       "workspaces": [
         "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtrm-tools",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "license": "MIT",
   "type": "module",

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Cuts v0.11.4 to publish the unified native tool rendering work landed in #534.

## Summary
- Bumps root/cli/pi-extensions to 0.11.4
- Promotes [Unreleased] → [v0.11.4] via changelog-update.mjs --tag

## Changelog scope
- feat(pi-extensions): unify native tool rendering (xtrm-cgxqy) (#534)

## Test plan
- [x] npm version 0.11.4 ran changelog + sync-cli-version + staged files
- [x] release commit clean (5 files: CHANGELOG, package.json, package-lock, cli/pkg, pi-extensions/pkg)
- [ ] merge PR, tag v0.11.4 on merged commit, push tag, npm publish pi-extensions + root