### PR TITLE
test(codex): characterize runtime boundary (xtrm-ozknq.5)

### DIFF
--- a/cli/src/tests/codex-k1-characterization.test.ts
+++ b/cli/src/tests/codex-k1-characterization.test.ts
@@ -128,7 +128,9 @@ describe('K1 runtime characterization', () => {
     });
 
     const serialized = JSON.stringify({ metadata, events });
+    const userHomePath = /\/(?:home|Users)\/[^/"\s]+/;
     expect(serialized).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
-    expect(serialized).not.toMatch(/\/(?:home|Users)\/[^/"\\s]+/);
+    expect(serialized).not.toMatch(userHomePath);
+    expect('/home/sam/.codex').toMatch(userHomePath);
   });
 });

--- a/cli/src/tests/codex-k1-characterization.test.ts
+++ b/cli/src/tests/codex-k1-characterization.test.ts
@@ -100,9 +100,12 @@ describe('K1 runtime characterization', () => {
         config_root: 'ignored with --ignore-user-config',
       },
     });
-    expect(metadata.runtime.executable_source).toContain('/codex');
+    expect(metadata.runtime.executable_source).toBe(
+      '<CODEX_HOME>/packages/standalone/releases/0.146.0-x86_64-unknown-linux-musl/bin/codex',
+    );
     expect(metadata.capture.command).toContain('--ephemeral');
     expect(metadata.capture.redactions).toContain('thread_id');
+    expect(metadata.capture.redactions).toContain('executable_source_home');
 
     expect(events.map((event) => event.type)).toEqual([
       'thread.started',
@@ -124,8 +127,8 @@ describe('K1 runtime characterization', () => {
       },
     });
 
-    const serialized = JSON.stringify(events);
+    const serialized = JSON.stringify({ metadata, events });
     expect(serialized).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
-    expect(serialized).not.toContain('/home/dawid');
+    expect(serialized).not.toMatch(/\/(?:home|Users)\/[^/"\\s]+/);
   });
 });

--- a/cli/src/tests/codex-k1-characterization.test.ts
+++ b/cli/src/tests/codex-k1-characterization.test.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  buildBareTmuxPlan,
+  chooseAttachCommand,
+} from '../utils/worktree-session.js';
+
+const fixtureRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures/codex/0.146.0',
+);
+
+type FixtureMetadata = {
+  schema_version: string;
+  runtime: {
+    product: string;
+    version: string;
+    executable_source: string;
+  };
+  capture: {
+    captured_at: string;
+    surface: string;
+    command: string[];
+    config_root: string;
+    redactions: string[];
+  };
+};
+
+function readMetadata(): FixtureMetadata {
+  return JSON.parse(fs.readFileSync(path.join(fixtureRoot, 'metadata.json'), 'utf8')) as FixtureMetadata;
+}
+
+function readEvents(): Array<Record<string, unknown>> {
+  return fs.readFileSync(path.join(fixtureRoot, 'exec-success.jsonl'), 'utf8')
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe('K1 runtime characterization', () => {
+  it('freezes the released Pi and Claude launcher argv and identity baseline', () => {
+    const shared = {
+      sessionSlug: 'k1-baseline',
+      bead: 'xtrm-ozknq.5',
+      parentSessionId: '$41',
+      worktreePath: '/workspace/core-k1',
+      branchName: 'feature/xtrm-ozknq-5-characterization',
+      turn1Body: 'characterize only',
+      modelOverride: 'baseline-model',
+      passthrough: ['--verbose'],
+    };
+
+    const pi = buildBareTmuxPlan({
+      ...shared,
+      runtime: 'pi',
+      thinkingOverride: 'high',
+      explicitSkillPaths: ['/skills/multiplexing-team'],
+    });
+    const claude = buildBareTmuxPlan({ ...shared, runtime: 'claude' });
+
+    expect(pi).toMatchObject({
+      sessionName: 'pi-k1-baseline',
+      runtimeCmd: 'pi',
+      runtimeArgs: [
+        '--skill', '/skills/multiplexing-team',
+        '--model', 'baseline-model',
+        '--thinking', 'high',
+        '--verbose',
+        'characterize only',
+      ],
+    });
+    expect(claude).toMatchObject({
+      sessionName: 'claude-k1-baseline',
+      runtimeCmd: 'claude',
+      runtimeArgs: [
+        '--dangerously-skip-permissions',
+        '--model', 'baseline-model',
+        '--verbose',
+        '--',
+        'characterize only',
+      ],
+    });
+    expect(pi.paneOptions).toEqual(claude.paneOptions);
+    expect(chooseAttachCommand('pi-k1-baseline', true)).toEqual(['switch-client', '-t', 'pi-k1-baseline']);
+    expect(chooseAttachCommand('pi-k1-baseline', false)).toEqual(['attach-session', '-t', 'pi-k1-baseline']);
+  });
+
+  it('accepts only versioned and redacted Codex exec fixtures', () => {
+    const metadata = readMetadata();
+    const events = readEvents();
+
+    expect(metadata).toMatchObject({
+      schema_version: 'xtrm.codex.fixture-metadata.v1',
+      runtime: { product: 'codex-cli', version: '0.146.0' },
+      capture: {
+        captured_at: '2026-08-02',
+        surface: 'exec-jsonl',
+        config_root: 'ignored with --ignore-user-config',
+      },
+    });
+    expect(metadata.runtime.executable_source).toContain('/codex');
+    expect(metadata.capture.command).toContain('--ephemeral');
+    expect(metadata.capture.redactions).toContain('thread_id');
+
+    expect(events.map((event) => event.type)).toEqual([
+      'thread.started',
+      'turn.started',
+      'item.completed',
+      'item.completed',
+      'turn.completed',
+    ]);
+    expect(events[0]).toEqual({ type: 'thread.started', thread_id: '<redacted-thread-id>' });
+    expect(events[3]).toMatchObject({
+      type: 'item.completed',
+      item: { type: 'agent_message', text: 'CODEX_K1_OK' },
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: 'turn.completed',
+      usage: {
+        input_tokens: expect.any(Number),
+        output_tokens: expect.any(Number),
+      },
+    });
+
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+    expect(serialized).not.toContain('/home/dawid');
+  });
+});

--- a/cli/src/tests/fixtures/codex/0.146.0/exec-success.jsonl
+++ b/cli/src/tests/fixtures/codex/0.146.0/exec-success.jsonl
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"<redacted-thread-id>"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"error","message":"Skill descriptions were shortened to fit the 2% skills context budget. Codex can still see every skill, but some descriptions are shorter. Disable unused skills or plugins to leave more room for the rest."}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"CODEX_K1_OK"}}
+{"type":"turn.completed","usage":{"input_tokens":20787,"cached_input_tokens":9984,"cache_write_input_tokens":0,"output_tokens":9,"reasoning_output_tokens":0}}

--- a/cli/src/tests/fixtures/codex/0.146.0/metadata.json
+++ b/cli/src/tests/fixtures/codex/0.146.0/metadata.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "xtrm.codex.fixture-metadata.v1",
+  "runtime": {
+    "product": "codex-cli",
+    "version": "0.146.0",
+    "executable_source": "/home/dawid/.codex/packages/standalone/releases/0.146.0-x86_64-unknown-linux-musl/bin/codex"
+  },
+  "capture": {
+    "captured_at": "2026-08-02",
+    "surface": "exec-jsonl",
+    "command": [
+      "codex",
+      "--sandbox",
+      "read-only",
+      "--ask-for-approval",
+      "never",
+      "exec",
+      "--json",
+      "--ephemeral",
+      "--ignore-user-config",
+      "--skip-git-repo-check",
+      "Return exactly CODEX_K1_OK and do not use tools."
+    ],
+    "config_root": "ignored with --ignore-user-config",
+    "redactions": [
+      "thread_id"
+    ]
+  },
+  "stderr": [
+    "Reading additional input from stdin..."
+  ],
+  "notes": [
+    "The skill-budget item is an observed non-fatal item from the installed runtime.",
+    "Token counts are retained because they are not credentials and demonstrate the terminal usage payload shape.",
+    "The fixture records event shape, not a stable promise that every successful run emits the same advisory items."
+  ]
+}

--- a/cli/src/tests/fixtures/codex/0.146.0/metadata.json
+++ b/cli/src/tests/fixtures/codex/0.146.0/metadata.json
@@ -3,7 +3,7 @@
   "runtime": {
     "product": "codex-cli",
     "version": "0.146.0",
-    "executable_source": "/home/dawid/.codex/packages/standalone/releases/0.146.0-x86_64-unknown-linux-musl/bin/codex"
+    "executable_source": "<CODEX_HOME>/packages/standalone/releases/0.146.0-x86_64-unknown-linux-musl/bin/codex"
   },
   "capture": {
     "captured_at": "2026-08-02",
@@ -23,7 +23,8 @@
     ],
     "config_root": "ignored with --ignore-user-config",
     "redactions": [
-      "thread_id"
+      "thread_id",
+      "executable_source_home"
     ]
   },
   "stderr": [

--- a/docs/design/codex-runtime-boundary.md
+++ b/docs/design/codex-runtime-boundary.md
@@ -5,7 +5,7 @@ Status: K1 evidence for `xtrm-ozknq.5`. This document records observed behavior.
 ## Evidence and provenance
 
 - Core commit: `9b823f80d373a4cb82173ec594f525b1f20caa39`.
-- Codex: `codex-cli 0.146.0`, resolved from `/home/dawid/.local/bin/codex` to the standalone `0.146.0-x86_64-unknown-linux-musl` release.
+- Codex: `codex-cli 0.146.0`, resolved from `<USER_BIN>/codex` to the standalone `0.146.0-x86_64-unknown-linux-musl` release.
 - Pi and Claude behavior: characterized by `cli/src/tests/worktree-session-role.test.ts`, `cli/src/tests/worktree-session-bare-slash.test.ts`, `cli/src/tests/worktree-session-beads-noise.test.ts`, `cli/src/tests/end-worktree.test.ts`, and `cli/src/tests/pi-launch-self-heal-regression.test.ts`.
 - Codex lifecycle payload: `cli/src/tests/fixtures/codex/0.146.0/exec-success.jsonl`, captured on 2026-08-02 with the exact argv recorded in its metadata.
 - Codex product reference: the current OpenAI Codex manual fetched on 2026-08-02. Runtime observations take precedence for this installed version.

--- a/docs/design/codex-runtime-boundary.md
+++ b/docs/design/codex-runtime-boundary.md
@@ -1,0 +1,74 @@
+# Codex runtime boundary characterization
+
+Status: K1 evidence for `xtrm-ozknq.5`. This document records observed behavior. It does not authorize a production `xt codex` command.
+
+## Evidence and provenance
+
+- Core commit: `9b823f80d373a4cb82173ec594f525b1f20caa39`.
+- Codex: `codex-cli 0.146.0`, resolved from `/home/dawid/.local/bin/codex` to the standalone `0.146.0-x86_64-unknown-linux-musl` release.
+- Pi and Claude behavior: characterized by `cli/src/tests/worktree-session-role.test.ts`, `cli/src/tests/worktree-session-bare-slash.test.ts`, `cli/src/tests/worktree-session-beads-noise.test.ts`, `cli/src/tests/end-worktree.test.ts`, and `cli/src/tests/pi-launch-self-heal-regression.test.ts`.
+- Codex lifecycle payload: `cli/src/tests/fixtures/codex/0.146.0/exec-success.jsonl`, captured on 2026-08-02 with the exact argv recorded in its metadata.
+- Codex product reference: the current OpenAI Codex manual fetched on 2026-08-02. Runtime observations take precedence for this installed version.
+- Programme sequencing: [KAN-127 execution note](https://github.com/xtrm-dev/xtrm/blob/ed06ba222307030c7153c43cd2370262706b78a4/docs/shared/xtrm-codex-kan-127-execution-note.md).
+
+## Released launcher baseline
+
+Core currently owns one shared worktree launcher for Pi and Claude. Both create one branch and one worktree, publish bead, parent, worktree and branch identity to tmux, wait for runtime readiness, and clean up a failed launch. Their argv heads remain runtime-specific:
+
+| Concern | Pi | Claude |
+| --- | --- | --- |
+| Runtime command | `pi` | `claude` |
+| Default authority profile | Pi process permissions | `--dangerously-skip-permissions` |
+| Explicit skills | repeated native `--skill PATH` | discoverability check plus slash prefix |
+| Thinking override | `--thinking LEVEL` | unsupported and omitted |
+| Turn-one separator | none | `--` |
+| Resume used by `xt attach` | `pi -c` | `claude --continue --dangerously-skip-permissions` |
+| Interactive machine outcome | no versioned outcome object | no versioned outcome object |
+
+Human output reports the worktree and branch before launch and supplies recovery prose after failures. JSON consumers instead use tmux pane options, runtime-origin and xtmux events. K2 must introduce a stable machine outcome without changing these released argv and metadata baselines.
+
+## Observed Codex boundary
+
+Codex is a distinct interactive harness, not the `openai-codex/...` Pi provider spelling. The installed CLI exposes interactive launch, `exec --json`, exact UUID-based `resume`, archive/delete/fork, sandbox and approval controls, hooks, plugins, MCP, apps and native multi-agent features.
+
+The minimal XTRM adapter consumes only the following native surfaces:
+
+- `codex [OPTIONS] [PROMPT]` for an interactive thread;
+- `codex resume SESSION_ID [PROMPT]` for exact persistence;
+- `codex exec --json` only for isolated contract and smoke evidence;
+- stable lifecycle and hook payloads for readiness, identity and turn capture.
+
+Native Codex multi-agent execution is outside the parity architecture. Specialists and xtmux remain the worker, orchestration and monitoring authorities. Plugins, MCP bundles, apps/connectors and other extended capabilities remain optional K7 work.
+
+## Safety profiles
+
+The managed default profile is `--yolo`, expanded by Core to `--dangerously-bypass-approvals-and-sandbox`. The explicit `--no-yolo` profile expands to `--sandbox workspace-write --ask-for-approval on-request`; normal writes inside the active worktree do not require per-edit approval. Worktree isolation is a Git workflow boundary, not a host-security sandbox.
+
+Hook trust is independent from approval and sandbox policy. Core must never generate or forward `--dangerously-bypass-hook-trust`. Conflicting native policy flags must fail before worktree creation. These rules are design inputs for K3, not behavior implemented by K1.
+
+## Capability and ownership ledger
+
+| Capability | Current Codex capability | XTRM parity owner | Minimum parity decision |
+| --- | --- | --- | --- |
+| Worktree and branch | Native Codex surfaces exist | Core | Core remains the single owner for `xt codex` |
+| Thread persistence | UUID thread plus exact `resume` | Core | Store exact thread ID and exact resume argv |
+| Sandbox and approvals | Native profiles and flags | Core | Expose validated YOLO/no-YOLO profiles |
+| Hook trust | Persisted independently | Core installer plus xtmux adapter | Preserve trust; never bypass it |
+| Messages and replies | No XTRM-compatible authority | xtmux | Adapt existing message and obligation domains |
+| Monitors, wakes and recovery | Native lifecycle differs | xtmux | Adapt existing state and recovery domains |
+| Roles and results | Native agents exist but conflict with programme ownership | Specialists | Add a Codex surface; do not use native subagents |
+| Skills | Native user and repository discovery | Core distribution | Project managed projection; preserve unowned content |
+| Plugins, MCP and apps | Native and useful | Optional K7 | Do not block parity |
+| Serena | Not installed as an active Claude plugin | None for parity | Remove only active conflicting management in K4 |
+
+## K2 contract boundary
+
+K2 can add one additive, versioned outcome with runtime/version, status/reason, thread/session/pane identity, worktree/branch, readiness, safety profile, side effects, persistence result and exact next-action argv. It must not parse human prose, fabricate mutations, duplicate xtmux or Specialists domains, or require a production `xt codex` launcher to prove the generic contract.
+
+The Codex JSONL capture proves that a non-fatal `item.completed` error can coexist with a successful agent message and terminal `turn.completed`. Consumers must therefore determine success from the versioned adapter contract, not from the presence of an arbitrary error item or a matching line of prose.
+
+## Observed gaps retained for later phases
+
+- The installed global `~/.codex/hooks.json` contains both an xtmux-owned agent-state registration and a byte-equivalent unowned registration for `SessionStart` and `UserPromptSubmit`. K1 records the duplication; owner-aware reconciliation belongs to the xtmux/Core lifecycle work.
+- The Core full test suite currently fails its installed-hook parity assertion because the installed xtmux `auto-monitor-drain-stop.mjs` is older than the vendored Core fixture. The same assertion fails on unchanged Core `main`, so this is baseline drift rather than a K1 regression.
+- Core has no versioned machine launch outcome today. Human launch/failure prose and tmux metadata must remain compatibility inputs only until K2 adds the deterministic outcome spine.


### PR DESCRIPTION
## Summary

- freeze released Pi and Claude launcher argv and identity behavior
- add a real, versioned and redacted Codex 0.146.0 exec JSONL fixture
- document the distinct Codex runtime, safety, ownership and K2 contract boundary
- record existing hook-registration and installed-fixture drift without changing production behavior

## Validation

- targeted launcher suite: 155 passed
- npm run typecheck --workspace cli
- npm run check:payload-hygiene
- full CLI suite: one pre-existing installed xtmux fixture drift failure, reproduced on unchanged main

## Rollback

Revert commit 94ac1d05. The change adds only characterization tests, fixture data, and design documentation; it changes no production launcher behavior.

Closes xtrm-ozknq.5