### PR TITLE
chore(vendor): refresh Specialists-owned assets to K4 master (xtrm-ozknq.15)

### DIFF
--- a/.xtrm/registry.json
+++ b/.xtrm/registry.json
@@ -770,7 +770,7 @@
           "version": "0.11.4"
         },
         "specialists-creator/SKILL.md": {
-          "hash": "f825f500e531e3a04b252c0f9a22b8acaa396f9d093368338d13e21ac43c30d4",
+          "hash": "636c6d90e55b9d14fed26f93d1e66296a0a48e706d1ce4c067ccebc2638b69bd",
           "version": "0.11.4"
         },
         "sre-triage/scripts/alert_history.py": {
@@ -914,7 +914,7 @@
           "version": "0.11.4"
         },
         "using-specialists/SKILL.md": {
-          "hash": "74fb9a29fdcb679c90b34e614c9e43645da5a12ad8cb1d44d10d9a723a2d792d",
+          "hash": "8ba5c2fc32044ee44f689b565da4dbd275fd5dbcc8d75df127a26c29e040c8d0",
           "version": "0.11.4"
         },
         "using-tdd/SKILL.md": {
@@ -1302,8 +1302,8 @@
     "version": 1,
     "source": {
       "kind": "ref",
-      "ref": "master",
-      "resolved_sha": "c1e660ab4e6ec4369e890074d822cd9ef1eb6e83",
+      "ref": "7053236fcac9b5d244fd8edf9c9a08979c2491fe",
+      "resolved_sha": "7053236fcac9b5d244fd8edf9c9a08979c2491fe",
       "repo_path": "../specialists",
       "source_path": "config/skills"
     },
@@ -1321,7 +1321,7 @@
         "scripts/audit-spec-uniformity.mjs": "0ada06784cfd5c3adfa9c9908a9cd23380e8278fb57329fc616a83140a47fb33",
         "scripts/scaffold-specialist.ts": "c1bfa3693d644072e6d387d2519e131624d99c5b85521ae638680d7485267403",
         "scripts/validate-specialist.ts": "3a5f5a3a77c50e98ecf9188634ff2882f8143b19d0f28a53aff5c42e1bd09dfa",
-        "SKILL.md": "f825f500e531e3a04b252c0f9a22b8acaa396f9d093368338d13e21ac43c30d4"
+        "SKILL.md": "636c6d90e55b9d14fed26f93d1e66296a0a48e706d1ce4c067ccebc2638b69bd"
       },
       "update-specialists": {
         "SKILL.md": "fdf8c680cf3e5dce80c9426f52b56c953f4f7f663c23a33a3378b2b6e4bab5a9"
@@ -1349,7 +1349,7 @@
         "references/merge-and-integration.md": "7884a445b5ee7031fd0cf2b548a6f6bf4df8daa2ab1db5ec28f32c47cbc4d6dd",
         "references/monitoring.md": "4871fca2072cffd73ba0932ce0f4514ab2dcbab974ce7bd17e77dc73c1807465",
         "references/registry-and-locations.md": "d02cb1c2e68f59e14f57d8fda7e80e109fe5666bbd33cae4c0ab8f9b10814460",
-        "SKILL.md": "74fb9a29fdcb679c90b34e614c9e43645da5a12ad8cb1d44d10d9a723a2d792d"
+        "SKILL.md": "8ba5c2fc32044ee44f689b565da4dbd275fd5dbcc8d75df127a26c29e040c8d0"
       },
       "using-specialists-auto": {
         "SKILL.md": "0668f03dc701d3895defc1e3f3973fa41976355db5a1c38278b6272c95f145c4"

--- a/.xtrm/skills/default/specialists-creator/SKILL.md
+++ b/.xtrm/skills/default/specialists-creator/SKILL.md
@@ -22,7 +22,7 @@ Example:
 
 ```json
 {
-  "mandatory_rules": { "template_sets": ["serena-cheatsheet"] },
+  "mandatory_rules": { "template_sets": ["git-workflow-safe"] },
   "skills": { "paths": ["releasing"] }
 }
 ```
@@ -198,7 +198,6 @@ sp edit my-specialist specialist.metadata.version 1.0.0
 sp edit my-specialist specialist.execution.model anthropic/claude-sonnet-4-6
 sp edit my-specialist specialist.execution.fallback_model google-gemini-cli/gemini-3.1-pro-preview
 sp edit my-specialist specialist.execution.permission_required READ_ONLY
-sp edit my-specialist specialist.execution.extensions.serena false
 sp edit my-specialist specialist.execution.extensions.gitnexus false
 
 # 4. Use --file only for multiline prompt fields
@@ -271,7 +270,7 @@ Avoid vague descriptions like "general purpose assistant" or "helps with code". 
 | `output_type` | enum | `custom` | `codegen` \| `analysis` \| `review` \| `synthesis` \| `orchestration` \| `workflow` \| `research` \| `custom` |
 | `permission_required` | enum | `READ_ONLY` | see tier table below |
 | `thinking_level` | enum | — | `off` \| `minimal` \| `low` \| `medium` \| `high` \| `xhigh` |
-| `extensions.serena` | boolean | `true` | set `false` to opt out of Serena extension injection for this specialist |
+| `extensions.serena` | boolean | — | DEPRECATED, ignored (Serena retired); kept only so legacy specs keep validating |
 | `extensions.gitnexus` | boolean | `true` | set `false` to opt out of GitNexus extension injection for this specialist |
 
 **When to use `execution.interactive`**
@@ -284,7 +283,7 @@ Avoid vague descriptions like "general purpose assistant" or "helps with code". 
 - Effective precedence: explicit disable (`--no-keep-alive` / `no_keep_alive`) → explicit enable (`--keep-alive` / `keep_alive`) → merged `execution.interactive` (package / global user.json / repo) → one-shot default.
 - When the operator wants a cross-repo default, prefer `sp edit --global --set <name>.execution.interactive true|false` over forking per-repo specs.
 
-**Permission tiers** — controls the *native* pi tools the specialist gets. The full resolved tool set also includes catalog-defined GitNexus and Serena tools per tier; see [docs/manifest.md](../../../docs/manifest.md) for the complete picture.
+**Permission tiers** — controls the *native* pi tools the specialist gets. The full resolved tool set also includes catalog-defined GitNexus tools per tier; see [docs/manifest.md](../../../docs/manifest.md) for the complete picture.
 
 | Level | Native tools (cumulative) | Use when |
 |-------|---------------------------|----------|
@@ -339,14 +338,13 @@ See [docs/manifest.md](../../../docs/manifest.md) for full deny-mode semantics, 
 **Per-specialist extension opt-out**
 
 Use `execution.extensions` only when this specialist must suppress default extension injection.
-Both flags default to `true`, so omit this block unless opt-out is required.
+This flag defaults to `true`, so omit this block unless opt-out is required.
 
 ```json
 {
   "specialist": {
     "execution": {
       "extensions": {
-        "serena": false,
         "gitnexus": false
       }
     }
@@ -355,9 +353,10 @@ Both flags default to `true`, so omit this block unless opt-out is required.
 ```
 
 Typical use cases:
-- `serena: false` for specialists that must avoid Serena tool/LSP injection
 - `gitnexus: false` for specialists that should not receive GitNexus graph tooling
-- set both `false` for constrained runs that need clean extension surface
+
+Legacy note: `serena: false` may still appear in older specs; it parses but is
+ignored (Serena extension retired, unitAI-e67up.8).
 
 ### Bare specialists
 
@@ -497,7 +496,7 @@ Runtime layering:
 `disable_default_globals` only removes the inline `STATIC_WORKFLOW_RULES_BLOCK`. It does **not** suppress index-driven sets. True user-rules-only runs need both `disable_default_globals: true` and a user overlay index in `.specialists/user/mandatory-rules/index.json` that clears required/default sets.
 
 Canonical set ids in `config/mandatory-rules/*.md`:
-`bead-id-verbatim`, `changelog-conventions`, `changelog-keeper-scope`, `code-quality-defaults`, `core-session-boundary`, `diagnose-loop`, `executor-delivery`, `explorer-readonly`, `git-workflow-safe`, `gitnexus-required`, `overthinker-4phase`, `per-turn-handoff-schema`, `research-tool-routing`, `researcher-source-discipline`, `reviewer-verdict-format`, `security-review-defaults`, `serena-cheatsheet`, `sync-docs-scope-discipline`, `test-runner-execution-scope`.
+`bead-id-verbatim`, `changelog-conventions`, `changelog-keeper-scope`, `code-quality-defaults`, `core-session-boundary`, `diagnose-loop`, `executor-delivery`, `explorer-readonly`, `git-workflow-safe`, `gitnexus-required`, `overthinker-4phase`, `per-turn-handoff-schema`, `research-tool-routing`, `researcher-source-discipline`, `reviewer-verdict-format`, `security-review-defaults`, `sync-docs-scope-discipline`, `test-runner-execution-scope`.
 
 Minimal user-rules-only spec:
 
@@ -728,8 +727,8 @@ repo). Examples:
 sp edit --global --set sync-docs.notes_mode final-only
 sp edit --global --set sync-docs.output_file ".specialists/sync-docs-result.md"
 
-# Opt out of Serena MCP injection on a read-only specialist (RAM saver)
-sp edit --global --set overthinker.execution.extensions.serena false
+# Opt out of GitNexus MCP injection for a specialist
+sp edit --global --set overthinker.execution.extensions.gitnexus false
 
 # Set the default keep-alive behavior globally for one specialist
 sp edit --global --set reviewer.execution.interactive false
@@ -1055,7 +1054,7 @@ Pi flags:
 
 | Runner | Pi flags |
 |--------|----------|
-| Package-class | `--no-extensions`, then re-enable quality-gates/service-skills/caveman/gitnexus/serena |
+| Package-class | `--no-extensions`, then re-enable quality-gates/service-skills/caveman/gitnexus |
 | Script-class | `--no-extensions --no-tools --offline --no-context-files --no-prompt-templates --no-themes` and `--no-skills` when `skills.paths` is empty |
 
 Settings that silently do nothing on script-class:

--- a/.xtrm/skills/default/using-specialists/SKILL.md
+++ b/.xtrm/skills/default/using-specialists/SKILL.md
@@ -140,7 +140,7 @@ OUTPUT: TBD — needs exploration"
 **The promotion gate (rule #15).** No specialist may be dispatched against a `contract:draft` bead. Before dispatch, the orchestrator must:
 
 1. Re-read the bead (`bd show <id>`).
-2. Actually explore — the same Phase 2 evidence-gathering the `planning` skill requires before writing a real contract (`gitnexus_query`/`gitnexus_context`/`gitnexus_impact`, or Serena symbol reads).
+2. Actually explore — the same Phase 2 evidence-gathering the `planning` skill requires before writing a real contract (`gitnexus_query`/`gitnexus_context`/`gitnexus_impact`, or native reads/grep).
 3. Rewrite the bead in place to the full 7-section contract (`bd update <id> --description "..."`), replacing every `TBD` with real content grounded in what was just found.
 4. Flip the state: `bd set-state <id> contract=ready --reason "Explored via <what>; rewrote to full contract"`.
 

--- a/.xtrm/specialists-source.json
+++ b/.xtrm/specialists-source.json
@@ -2,8 +2,8 @@
   "version": 1,
   "source": {
     "kind": "ref",
-    "ref": "master",
-    "resolved_sha": "c1e660ab4e6ec4369e890074d822cd9ef1eb6e83",
+    "ref": "7053236fcac9b5d244fd8edf9c9a08979c2491fe",
+    "resolved_sha": "7053236fcac9b5d244fd8edf9c9a08979c2491fe",
     "repo_path": "../specialists",
     "source_path": "config/skills"
   },
@@ -21,7 +21,7 @@
       "scripts/audit-spec-uniformity.mjs": "0ada06784cfd5c3adfa9c9908a9cd23380e8278fb57329fc616a83140a47fb33",
       "scripts/scaffold-specialist.ts": "c1bfa3693d644072e6d387d2519e131624d99c5b85521ae638680d7485267403",
       "scripts/validate-specialist.ts": "3a5f5a3a77c50e98ecf9188634ff2882f8143b19d0f28a53aff5c42e1bd09dfa",
-      "SKILL.md": "f825f500e531e3a04b252c0f9a22b8acaa396f9d093368338d13e21ac43c30d4"
+      "SKILL.md": "636c6d90e55b9d14fed26f93d1e66296a0a48e706d1ce4c067ccebc2638b69bd"
     },
     "update-specialists": {
       "SKILL.md": "fdf8c680cf3e5dce80c9426f52b56c953f4f7f663c23a33a3378b2b6e4bab5a9"
@@ -49,7 +49,7 @@
       "references/merge-and-integration.md": "7884a445b5ee7031fd0cf2b548a6f6bf4df8daa2ab1db5ec28f32c47cbc4d6dd",
       "references/monitoring.md": "4871fca2072cffd73ba0932ce0f4514ab2dcbab974ce7bd17e77dc73c1807465",
       "references/registry-and-locations.md": "d02cb1c2e68f59e14f57d8fda7e80e109fe5666bbd33cae4c0ab8f9b10814460",
-      "SKILL.md": "74fb9a29fdcb679c90b34e614c9e43645da5a12ad8cb1d44d10d9a723a2d792d"
+      "SKILL.md": "8ba5c2fc32044ee44f689b565da4dbd275fd5dbcc8d75df127a26c29e040c8d0"
     },
     "using-specialists-auto": {
       "SKILL.md": "0668f03dc701d3895defc1e3f3973fa41976355db5a1c38278b6272c95f145c4"


### PR DESCRIPTION
## Why

The `xtrm-ozknq.15` cross-repository K4 observation gate carries an explicit precondition in its notes:

> K4 is not complete until .8 also lands **and Core refreshes the Specialists-owned vendored assets through the normal vendor flow.**

Core's pin was at `c1e660ab`; Specialists master had advanced to `7053236f` (the K4 Serena runtime retirement, `unitAI-e67up.8`). Three specialists-owned skills plus `dist/asset-contract.json` changed across that range, so the pin was genuinely stale rather than cosmetically behind.

## What

Re-vendored via `scripts/vendor-specialists-skills.mjs --specialists-ref=7053236f…`.

Pinned to the **immutable SHA** rather than the moving `master` ref. This matches the existing release-contract intent that `prepublishOnly` must not re-vendor from a moving branch.

Content delta is the Serena retirement propagating into the two skills Core vendors:

- `specialists-creator` — `extensions.serena` documented as deprecated/ignored, `serena-cheatsheet` dropped from the mandatory-rule set, Serena removed from the tier/tool-injection description
- `using-specialists` — Serena removed from exploration guidance (`gitnexus_*` or native reads/grep)

`setup-specialists` also changed upstream but is not vendored by Core, so it is correctly absent here.

## Verification

| Gate | Result |
|---|---|
| `check:specialists-vendor` | PASS |
| `check:vendored-specialists-parity` | PASS |
| `check:registry-pack-parity` | PASS |
| `check:skills-ownership` | PASS |

Registry diff is scoped to the two vendored SKILL.md hashes plus the pin — no registry churn. Confirmed no untracked content under `.xtrm/skills/default/` before `gen-registry`, so nothing outside the tracked payload was indexed.

## Scope

Vendor refresh only. No behavior change, no Serena re-introduction. This unblocks — but does not close — `xtrm-ozknq.15`; that gate still waits on `xtmux-s96.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)