### PR TITLE
docs(deploy-monitor): add committed-artifact case to the deploy-gap guard (xtrm-7tjik)

### DIFF
--- a/.xtrm/skills/default/deploy-monitor/SKILL.md
+++ b/.xtrm/skills/default/deploy-monitor/SKILL.md
@@ -89,7 +89,18 @@ docker inspect --format '{{.Name}} {{.State.StartedAt}} {{.Image}}' <container>
 # GitOps / Kubernetes
 kubectl rollout status deployment/<name> --timeout=10m
 # PASS the guard only if observed generation/revision > mergedAt or matches merge SHA.
+
+# Committed-artifact CLI — npm link into a dev checkout; no container, no rollout
+bin=$(readlink -f "$(command -v <cmd>)"); repo=$(git -C "$(dirname "$bin")" rev-parse --show-toplevel)
+git -C "$repo" fetch -q origin
+git -C "$repo" merge-base --is-ancestor <mergeSha> HEAD  # 0 → merge is in the checkout
+git -C "$repo" rev-list --count HEAD..origin/main        # 0 → checkout not behind origin
+git -C "$repo" ls-files --error-unmatch "$bin"           # 0 → artifact is committed
+# PASS the guard only if all three hold. If the artifact is NOT committed, additionally
+# require its mtime > mergedAt. Any one failing → BLOCKED, same as a stale StartedAt.
 ```
+
+**Committed-artifact trap** — `xt` resolves to `dev/core/cli/dist/index.cjs`, `xtmux` to `dev/xtmux/bin/tmux-session-picker`. Nothing is running, so `verify-deploy-applied` has nothing to inspect and the guard passes on a deploy that never happened. When the artifact is committed, `git pull` **is** the deployment — no rebuild. When it is not committed, the orchestrator must rebuild before the window; `/update-xt` carries the caveat that building from `.xtrm/worktrees/*` contaminates `dist` with absolute paths.
 
 **docker-compose `.env` trap** — a fresh `StartedAt` isn't proof of a healthy deploy. `docker compose up` from a CWD without `.env` (worktrees, cron scripts) silently interpolates `${VAR}` refs to empty strings. Reject:
 

--- a/scripts/check-skill-root-budget.mjs
+++ b/scripts/check-skill-root-budget.mjs
@@ -14,7 +14,8 @@ const BUDGETS = {
   // 'using-specialists' is specialists-owned and vendored via specialists-source.json.
   // Its slim must land in the specialists repo first, then re-vendor here. Re-add
   // with { max: 150 } once that lands.
-  'deploy-monitor':   { max: 180 },
+  // 180 → 190 for the committed-artifact deploy-gap case (xtrm-7tjik).
+  'deploy-monitor':   { max: 190 },
   'pr-reviewer':      { max: 160 },
 };
 


### PR DESCRIPTION
## Problem

`deploy-monitor` exists to "refuse to watch the wrong artifact". Its deploy-gap guard covered two deployment shapes — Docker (`StartedAt` vs `mergedAt`) and GitOps/Kubernetes (`kubectl rollout status`). Both assume a running artifact you can inspect.

A third shape exists in this estate: CLI tooling deployed as a **committed build artifact inside a local checkout**. No container, no rollout, nothing for `verify-deploy-applied` to inspect — so the guard passed silently on a deploy that never happened.

Hit three times on 2026-08-05/06:

1. `xt worktree reap` (dev/core PR #543) — merged, bead closed, systemd timer scheduled to fire `--apply --yes`, while `xt` resolved to a checkout **5 commits behind origin**. The subcommand did not exist.
2. The `@agent_state` liveness fix (dev/xtmux PR #95) — merged, CI green both sides, while `xtmux` resolved to a checkout **16 commits behind**. Three panes reported `running` for 28 hours after the fix for exactly that had merged.
3. Same class again during the same teardown.

## Change

One case added to the existing **Deploy-gap guard** section, in the idiom of the other two:

```bash
# Committed-artifact CLI — npm link into a dev checkout; no container, no rollout
bin=$(readlink -f "$(command -v <cmd>)"); repo=$(git -C "$(dirname "$bin")" rev-parse --show-toplevel)
git -C "$repo" fetch -q origin
git -C "$repo" merge-base --is-ancestor <mergeSha> HEAD  # 0 → merge is in the checkout
git -C "$repo" rev-list --count HEAD..origin/main        # 0 → checkout not behind origin
git -C "$repo" ls-files --error-unmatch "$bin"           # 0 → artifact is committed
# PASS the guard only if all three hold. If the artifact is NOT committed, additionally
# require its mtime > mergedAt. Any one failing → BLOCKED, same as a stale StartedAt.
```

Plus a short **Committed-artifact trap** paragraph: when the artifact is committed, `git pull` **is** the deployment (no rebuild); when it is not, a rebuild is required and `/update-xt` carries the caveat that building from `.xtrm/worktrees/*` contaminates `dist` with absolute paths.

`scripts/check-skill-root-budget.mjs`: deploy-monitor slim-root budget 180 → 190 to fit the case (187/190 after the edit).

## Validation

Executed verbatim against `xt` and dev/core PR #543 (`mergeSha` `691f19ba`, `mergedAt` `2026-08-05T16:28:08Z`):

```
bin=/home/dawid/dev/core/cli/dist/index.cjs   repo=/home/dawid/dev/core
merge-base --is-ancestor      -> 0
rev-list --count HEAD..origin/main -> 0
ls-files --error-unmatch      -> 0
=> guard PASS (correct: the merge is present in the checkout today)
```

Negative branch, reconstructing the incident state (checkout 5 commits behind the merge):

```
git merge-base --is-ancestor 691f19ba 691f19ba~5  -> non-zero
=> guard BLOCKED (correct: this is the state that shipped a timer for a missing subcommand)
```

Repo checks:

- `node scripts/check-skill-root-budget.mjs` — OK, deploy-monitor 187/190
- `node scripts/check-forbidden-phrases.mjs` — 87 files, 0 violations
- `node scripts/check-payload-hygiene.mjs` — ok, 402 packed files
- `npm run check:registry-pack-parity` — 318/318
- Frontmatter unchanged and parsing; file mode reset to 0664

## Scope

Two files. No other skill touched — `sre-triage`, `capacity-reclaim` and `update-xt` were each checked and do not need this. No restructuring of `deploy-monitor`, no change to its verdict vocabulary, sampling plan, or message policy.

Bead: xtrm-7tjik

🤖 Generated with [Claude Code](https://claude.com/claude-code)