### PR TITLE
feat(pi-extensions): phase-color only the tool prefix, dim command unless success

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -296,6 +296,41 @@ describe("xtrm-ui built-in tool rendering", () => {
     expect(lines.at(-1)).toContain("showing 6/8 lines (ctrl+o expand)");
   });
 
+  it("colors only the Ran prefix with phase status and dims the command unless success", () => {
+    const { tools } = loadExtension();
+    const colors: string[] = [];
+    const spyTheme = {
+      ...theme,
+      fg: (color: string, text: string) => {
+        colors.push(color);
+        return text;
+      },
+    };
+    const result = { content: [{ type: "text", text: "" }], details: {} };
+    const renderOptions = { expanded: false, isPartial: false };
+
+    colors.length = 0;
+    tools.bash.renderResult(result, renderOptions, spyTheme, context({ command: "echo ok" }));
+    expect(colors.slice(0, 3)).toEqual(["success", "success", "text"]); // • , Ran, command
+
+    colors.length = 0;
+    tools.bash.renderResult(
+      result,
+      renderOptions,
+      spyTheme,
+      context({ command: "echo fail" }, { isError: true }),
+    );
+    expect(colors.slice(0, 3)).toEqual(["error", "error", "dim"]); // • , Ran, command
+
+    colors.length = 0;
+    tools.bash.renderCall(
+      { command: "echo pending" },
+      spyTheme,
+      context({ command: "echo pending" }, { executionStarted: false, isPartial: true }),
+    );
+    expect(colors).toEqual(["accent", "accent", "dim"]); // • , Ran, command
+  });
+
   it("keeps tree indentation when a tool line wraps", () => {
     const text = [
       "• Ran set -u",

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -883,10 +883,11 @@ function renderBashTree(
   outputLines: string[] = [],
   meta?: string,
 ): string {
+  const commandColor = statusColor === "success" ? "text" : "dim";
   const [firstCommand = "", ...continuedCommands] = command.split("\n");
   return appendToolTree(theme, [
-    `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold("Ran"))} ${theme.fg(statusColor, firstCommand)}`,
-    ...continuedCommands.map((line) => `  ${theme.fg("muted", "│")} ${theme.fg(statusColor, line)}`),
+    `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold("Ran"))} ${theme.fg(commandColor, firstCommand)}`,
+    ...continuedCommands.map((line) => `  ${theme.fg("muted", "│")} ${theme.fg(commandColor, line)}`),
   ], outputLines, meta);
 }
 
@@ -898,8 +899,9 @@ function renderNamedToolTree(
   outputLines: string[] = [],
   meta?: string,
 ): string {
+  const subjectColor = statusColor === "success" ? "text" : "dim";
   return appendToolTree(theme, [
-    `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold(label))}${subject ? ` ${theme.fg(statusColor, subject)}` : ""}`,
+    `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold(label))}${subject ? ` ${theme.fg(subjectColor, subject)}` : ""}`,
   ], outputLines, meta);
 }
 


### PR DESCRIPTION
## Summary

The tool tree currently colors the entire row (`• Ran <command>` and `• <tool> <subject>`) with the phase status color (accent blue / success green / error red), so commands, flags, and args are indistinguishable from the tool name.

**Change** (`packages/pi-extensions/extensions/xtrm-ui/index.ts`):
- `renderBashTree` / `renderNamedToolTree`: keep the phase `statusColor` only on the `• Ran` prefix and the native tool name.
- The command/subject now renders in the theme `text` token (empty → `\\x1b[39m` → default terminal color) on success, and `dim` while pending (accent) or failed (error).

**Tests** (`cli/test/extensions/xtrm-ui.test.ts`): new case asserts the color token selection per phase (success → text, error → dim, pending → dim) with the prefix keeping the phase color.

## Verification
- `npx vitest run cli/test/extensions/xtrm-ui.test.ts`: 35/35 pass.
- `tsc --noEmit -p cli/tsconfig.json`: no errors in changed files.