### PR TITLE
fix(pi-extensions): eliminate O(n²) tool-row wrap path causing render lag

### DIFF
--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -919,15 +919,18 @@ function splitToolLine(line: string, prefixWidth: number): { prefix: string; con
   let offset = 0;
 
   while (offset < line.length) {
-    const ansi = line.slice(offset).match(ANSI_CODE_PATTERN)?.[0];
-    if (ansi) {
-      if (visible < prefixWidth) prefix += ansi;
-      else content += ansi;
-      offset += ansi.length;
-      continue;
+    // ESC is rare; only regex-slice at escape positions, not per character.
+    if (line.charCodeAt(offset) === 0x1b) {
+      const ansi = ANSI_CODE_PATTERN.exec(line.slice(offset))?.[0];
+      if (ansi) {
+        if (visible < prefixWidth) prefix += ansi;
+        else content += ansi;
+        offset += ansi.length;
+        continue;
+      }
     }
-
-    const character = Array.from(line.slice(offset))[0] ?? "";
+    const codePoint = line.codePointAt(offset) ?? 0;
+    const character = String.fromCodePoint(codePoint);
     if (visible < prefixWidth) prefix += character;
     else content += character;
     visible += visibleWidth(character);
@@ -937,8 +940,7 @@ function splitToolLine(line: string, prefixWidth: number): { prefix: string; con
   return { prefix, content };
 }
 
-function toolLineWrap(line: string): ToolLineWrap | undefined {
-  const plain = stripAnsi(line);
+function toolLineWrap(plain: string): ToolLineWrap | undefined {
   if (plain.startsWith("  │ ")) return { prefixWidth: 4, continuationPrefix: "  │ " };
   if (plain.startsWith("  └ ")) return { prefixWidth: 4, continuationPrefix: "    " };
   if (plain.startsWith("    ")) return { prefixWidth: 4, continuationPrefix: "    " };
@@ -950,9 +952,11 @@ function toolLineWrap(line: string): ToolLineWrap | undefined {
 export function wrapToolTreeText(text: string, width: number): string {
   const renderWidth = Math.max(1, width);
   return text.split("\n").flatMap((line) => {
-    const wrapping = toolLineWrap(line);
+    const plain = stripAnsi(line);
+    const wrapping = toolLineWrap(plain);
     if (!wrapping) return wrapTextWithAnsi(line, renderWidth);
-
+    // Fast path: whole line fits — skip the split/wrap machinery entirely.
+    if (visibleWidth(plain) <= renderWidth) return [line];
     const { prefix, content } = splitToolLine(line, wrapping.prefixWidth);
     const chunks = wrapTextWithAnsi(content, Math.max(1, renderWidth - wrapping.prefixWidth));
     return chunks.map((chunk, index) => index === 0


### PR DESCRIPTION
## Problem

The session lags badly after the #546 wrap change. `wrapToolTreeText` runs on **every render** for **every tool row**. Its `splitToolLine` scanned per character with `line.slice(offset)` + regex match + `Array.from(line.slice(offset))[0]` — O(L²) per line.

Benchmark (2000 renders of 2 long tool lines, width 120):
- before: **7143ms** (3.5ms per render)
- after: **279ms** (25x faster)

## Fix (`packages/pi-extensions/extensions/xtrm-ui/index.ts`)

1. **Fast path** in `wrapToolTreeText`: when the ANSI-stripped line fits the render width, return it unchanged — skip the split/wrap machinery entirely (the common case).
2. **Linear `splitToolLine`**: regex-slice only at ESC positions; iterate with `codePointAt` instead of allocating `Array.from` per character.

## Verification

- `npx vitest run cli/test/extensions/xtrm-ui.test.ts`: 35/35 pass (incl. the #546 wrap tests — tree prefix preserved, fitting lines untouched).
- `tsc --noEmit -p cli/tsconfig.json`: no errors in changed files.
- Short-line benchmark: 8ms per 2000 renders (4µs each).