### PR TITLE
fix(pi-extensions): remove tool-row wrap feature causing render lag (xtrm-ql4xs)

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -45,7 +45,6 @@ const {
   DEFAULT_PREFS,
   default: xtrmUiExtension,
   renderExternalToolBackgroundLines,
-  wrapToolTreeText,
 } = await import("../../../packages/pi-extensions/extensions/xtrm-ui/index");
 
 function loadExtension() {
@@ -329,30 +328,6 @@ describe("xtrm-ui built-in tool rendering", () => {
       context({ command: "echo pending" }, { executionStarted: false, isPartial: true }),
     );
     expect(colors).toEqual(["accent", "accent", "dim"]); // • , Ran, command
-  });
-
-  it("keeps tree indentation when a tool line wraps", () => {
-    const text = [
-      "• Ran set -u",
-      '  │ s=color-env-check; tmux kill-session -t "$s" 2>/dev/null || true',
-    ].join("\n");
-
-    const lines = wrapToolTreeText(text, 32).split("\n");
-
-    expect(lines[0]).toBe("• Ran set -u");
-    expect(lines.slice(1).length).toBeGreaterThan(1);
-    expect(lines.slice(1).every((line) => line.startsWith("  │ "))).toBe(true);
-    expect(Math.max(...lines.map((line) => line.length))).toBeLessThanOrEqual(32);
-  });
-
-  it("uses the command tree marker for a wrapped single-line command", () => {
-    const text = "• Ran stat -c '%F %N' /home/dawid/.pi/agent/npm/node_modules/@jaggerxtrm/pi-extensions; cmp -s /home/dawid/dev/core/packages/pi-extensions/extensions/xtrm-ui/index.ts /home/dawid/.pi/agent/npm/node_modules/@jaggerxtrm/pi-extensions/extensions/xtrm-ui/index.ts; echo cmp=$?; grep -n 'wrapToolTreeText\|function renderPendingCall' /home/dawid/.pi/agent/npm/node_modules/@jaggerxtrm/pi-extensions/extensions/xtrm-ui/index.ts | head";
-    const lines = wrapToolTreeText(text, 32).split("\n");
-
-    expect(lines[0]).toMatch(/^• Ran /);
-    expect(lines.slice(1).length).toBeGreaterThan(1);
-    expect(lines.slice(1).every((line) => line.startsWith("  │ "))).toBe(true);
-    expect(Math.max(...lines.map((line) => line.length))).toBeLessThanOrEqual(32);
   });
 
   it.each([

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -23,7 +23,7 @@ import {
   createReadTool,
   createWriteTool,
 } from "@earendil-works/pi-coding-agent";
-import { Box, Text, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { Box, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -905,80 +905,11 @@ function renderNamedToolTree(
   ], outputLines, meta);
 }
 
-type ToolLineWrap = {
-  prefixWidth: number;
-  continuationPrefix: string;
-};
-
-const ANSI_CODE_PATTERN = /^\x1b\[[0-9;?]*[ -/]*[@-~]/u;
-
-function splitToolLine(line: string, prefixWidth: number): { prefix: string; content: string } {
-  let prefix = "";
-  let content = "";
-  let visible = 0;
-  let offset = 0;
-
-  while (offset < line.length) {
-    // ESC is rare; only regex-slice at escape positions, not per character.
-    if (line.charCodeAt(offset) === 0x1b) {
-      const ansi = ANSI_CODE_PATTERN.exec(line.slice(offset))?.[0];
-      if (ansi) {
-        if (visible < prefixWidth) prefix += ansi;
-        else content += ansi;
-        offset += ansi.length;
-        continue;
-      }
-    }
-    const codePoint = line.codePointAt(offset) ?? 0;
-    const character = String.fromCodePoint(codePoint);
-    if (visible < prefixWidth) prefix += character;
-    else content += character;
-    visible += visibleWidth(character);
-    offset += character.length;
-  }
-
-  return { prefix, content };
-}
-
-function toolLineWrap(plain: string): ToolLineWrap | undefined {
-  if (plain.startsWith("  │ ")) return { prefixWidth: 4, continuationPrefix: "  │ " };
-  if (plain.startsWith("  └ ")) return { prefixWidth: 4, continuationPrefix: "    " };
-  if (plain.startsWith("    ")) return { prefixWidth: 4, continuationPrefix: "    " };
-  if (plain.startsWith("• Ran ")) return { prefixWidth: 6, continuationPrefix: "  │ " };
-  if (plain.startsWith("• ")) return { prefixWidth: 2, continuationPrefix: "  " };
-  return undefined;
-}
-
-export function wrapToolTreeText(text: string, width: number): string {
-  const renderWidth = Math.max(1, width);
-  return text.split("\n").flatMap((line) => {
-    const plain = stripAnsi(line);
-    const wrapping = toolLineWrap(plain);
-    if (!wrapping) return wrapTextWithAnsi(line, renderWidth);
-    // Fast path: whole line fits — skip the split/wrap machinery entirely.
-    if (visibleWidth(plain) <= renderWidth) return [line];
-    const { prefix, content } = splitToolLine(line, wrapping.prefixWidth);
-    const chunks = wrapTextWithAnsi(content, Math.max(1, renderWidth - wrapping.prefixWidth));
-    return chunks.map((chunk, index) => index === 0
-      ? `${prefix}${chunk}`
-      : `${wrapping.continuationPrefix}${chunk}`);
-  }).join("\n");
-}
-
-function createToolText(text: string, customBgFn?: (line: string) => string) {
-  return {
-    invalidate() {},
-    render(width: number): string[] {
-      return new Text(wrapToolTreeText(text, width), 0, 0, customBgFn).render(width);
-    },
-  };
-}
-
-function renderPendingCall(toolName: string, args: Record<string, unknown>, theme: any) {
+function renderPendingCall(toolName: string, args: Record<string, unknown>, theme: any): Text {
   if (toolName === "bash") {
-    return createToolText(renderBashTree(theme, "accent", String(args.command ?? "")));
+    return new Text(renderBashTree(theme, "accent", String(args.command ?? "")), 0, 0);
   }
-  return createToolText(renderNamedToolTree(theme, "accent", toolName, summarizeToolSubject(toolName, args) ?? ""));
+  return new Text(renderNamedToolTree(theme, "accent", toolName, summarizeToolSubject(toolName, args) ?? ""), 0, 0);
 }
 
 function summarizeToolSubject(toolName: string, args: Record<string, unknown>): string | undefined {
@@ -1129,10 +1060,13 @@ const XTRM_BUILTIN_TOOLS = new Set(["bash", "read", "edit", "write", "find", "gr
 
 function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): void {
   const tools = getTools(process.cwd());
-  const toolRowText = (theme: any, text: string) => createToolText(
-    text,
-    getPrefs().toolRowBg ? (line: string) => theme.bg("selectedBg", line) : undefined,
-  );
+  const toolRowText = (theme: any, text: string) =>
+    new Text(
+      text,
+      0,
+      0,
+      getPrefs().toolRowBg ? (line: string) => theme.bg("selectedBg", line) : undefined,
+    );
   const renderCall = (
     toolName: string,
     args: Record<string, unknown>,


### PR DESCRIPTION
## Problem

PR #546 added ANSI-aware `wrapToolTreeText`/\`splitToolLine\` (tool-row wrap with tree-prefix continuation) to xtrm-ui. It runs on every render for every tool row. PR #548 cut the O(n²) cost 25x (7.1s → 279ms per 2000 renders), but residual per-render strip/split/width work still causes meaningful interactive lag.

## Change

Remove the wrap feature entirely; restore pre-#546 rendering:

- `renderPendingCall` and `toolRowText` render directly via `new Text(...)` — long rows truncate at render width (no wrap continuation).
- Delete `ToolLineWrap`, `ANSI_CODE_PATTERN`, `splitToolLine`, `toolLineWrap`, `wrapToolTreeText`, `createToolText`.
- Drop the now-unused `wrapTextWithAnsi` import.
- Remove the two wrap tests; keep phase-color (#547) code and tests intact.

## Verification

- xtrm-ui tests: 33/33 pass (35 − 2 wrap tests).
- `tsc --noEmit`: same 11 pre-existing Codex errors with and without this change; zero in touched files.
- Net −91 lines in xtrm-ui.