### PR TITLE
docs(bd): --notes REPLACES notes, document --append-notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,8 @@ bd search <text>                       # Full-text search across issues
 
 # Claiming & updating
 bd update <id> --claim                 # Claim (sets you as owner, status→in_progress)
-bd update <id> --notes "..."           # Append notes inline
+bd update <id> --notes "..."           # REPLACES notes (destructive — overwrites prior)
+bd update <id> --append-notes "..."    # Append to existing notes (newline-separated)
 bd update <id> --status=blocked        # Mark blocked
 bd update                              # Update last-touched issue (no ID needed)
 

--- a/templates/claude-md-fragments/bd-workflow.md
+++ b/templates/claude-md-fragments/bd-workflow.md
@@ -45,7 +45,8 @@ bd search <text>                       # Full-text search across issues
 
 # Claiming & updating
 bd update <id> --claim                 # Claim (sets you as owner, status→in_progress)
-bd update <id> --notes "..."           # Append notes inline
+bd update <id> --notes "..."           # REPLACES notes (destructive — overwrites prior)
+bd update <id> --append-notes "..."    # Append to existing notes (newline-separated)
 bd update <id> --status=blocked        # Mark blocked
 bd update                              # Update last-touched issue (no ID needed)
 


### PR DESCRIPTION
Doc-only. No behaviour change, and the string is not embedded in `cli/dist`, so no rebuild.

## The defect
The bd command reference documents `bd update <id> --notes` as **"Append notes inline"**. It *replaces* the notes field. `--append-notes` is the appending flag, and it was documented nowhere.

This file is the template every `CLAUDE.md` and `AGENTS.md` is synced from (`claude-sync`, `<!-- BEGIN INJECTED BLOCK -->`), and the block is byte-identical across all 12 xtrm repos — so the wrong semantics reached every one of them.

## Why it matters
Two lanes destroyed bead notes with it on the same night, independently:
- **market-data**: ~5,300 bytes of a production stopgap audit (dry run, 18-row reconstruction, rolled-back write, the manual GCQ26→GCZ26 row)
- **another lane**: ~40KB across six beads — including two *other* coordinators' notes

It fails silently: no warning, no diff, and the bead still looks well-populated because the newest note is always present. The only tell is comparing byte counts across committed exports, and recovery is possible **only** where an export happened to be committed between overwrites.

Two independent agents hitting the same trap the same night makes this a documentation defect, not two operator errors.

## The change
```
bd update <id> --notes "..."           # REPLACES notes (destructive — overwrites prior)
bd update <id> --append-notes "..."    # Append to existing notes (newline-separated)
```

Authored in an isolated worktree off `origin/main` so the active `fix/xtrm-ql4xs-remove-tool-wrap` branch and its unrelated dirty files were never touched. The 25 consumer files across the other repos have been corrected in place to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)