### PR TITLE
fix(pi-extensions): pad external tool rows to full width before phase bg (xtrm-6rnpj)

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -579,7 +579,7 @@ describe("xtrm-ui external tool rendering", () => {
         state,
         bgTheme,
       );
-      expect(stripAnsi(rendered[0] ?? "")).toBe("• Serena execute_shell_command");
+      expect(stripAnsi(rendered[0] ?? "").trim()).toBe("• Serena execute_shell_command");
       expect(rendered[0]).toContain("\x1b[38;2;82;210;255m• Serena\x1b[39m");
       expect(rendered[0]).toContain(actionStyled);
       expect(bgTokens.length).toBeGreaterThan(0);

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -421,6 +421,11 @@ function externalToolStateBgToken(state: ExternalToolState): string {
   return state === "failure" ? "toolErrorBg" : "toolSuccessBg";
 }
 
+function padToRenderWidth(line: string, width: number): string {
+  const fitted = truncateToWidth(line, width);
+  return fitted + " ".repeat(Math.max(0, width - visibleWidth(fitted)));
+}
+
 export function collapsedExternalToolLines(contentLines: string[], expanded: boolean): string[] {
   if (expanded || contentLines.length <= 6) return contentLines;
   return [
@@ -510,7 +515,7 @@ export function renderExternalToolBackgroundLines(
     ...visiblePayload.map((rawLine) => truncateToWidth(rawLine, renderWidth)),
   ];
   const bgFn = themeLike
-    ? (line: string) => themeLike.bg(externalToolStateBgToken(state), line)
+    ? (line: string) => themeLike.bg(externalToolStateBgToken(state), padToRenderWidth(line, renderWidth))
     : (line: string) => line;
   return footerMeta
     ? [...body.map(bgFn), bgFn(`\x1b[2m${truncateToWidth(`└─ ${footerMeta}`, renderWidth)}\x1b[22m`)]


### PR DESCRIPTION
## Problem

PR #552 applied the phase background (`toolPendingBg`/`toolSuccessBg`/`toolErrorBg`) per line, but over text length only. Those tokens are near-black tints designed for pi's built-in `Box`, which pads every line to full row width before painting. Result: external rows showed at most a faint strip behind the label — read as "no background" (and a step down from the old bright badge chips).

## Change

`padToRenderWidth` pads each header/payload/footer line to `renderWidth` (truncate-to-width + space pad via `visibleWidth`) before `theme.bg` — the phase panel now spans the row, matching built-in tool rows.

## Verification

- 45/45 xtrm-ui tests (lifecycle test tolerates trailing pad).
- tsc: 15 errors with and without the change (pre-existing Codex + post-#553 baseline), none in touched files.