### PR TITLE
fix(pi-extensions): restore exact pre-change badge chip on external tool names (xtrm-ma1je)

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -526,7 +526,7 @@ describe("xtrm-ui external tool rendering", () => {
       "find_symbol",
     );
 
-    expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;82;210;255mSerena\x1b[39m\x1b[49m \x1b[1mfind_symbol\x1b[22m");
+    expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;82;210;255m Serena \x1b[39m\x1b[49m \x1b[1mfind_symbol\x1b[22m");
     expect(rendered.length).toBeGreaterThan(2);
     expect(rendered.join("\n")).toContain('"name_path": "highlightExternalToolBadge"');
   });
@@ -540,7 +540,7 @@ describe("xtrm-ui external tool rendering", () => {
       "mcp_custom_tool",
     );
 
-    expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;178;190;210mmcp\x1b[39m\x1b[49m \x1b[1mcustom_tool\x1b[22m");
+    expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;178;190;210m mcp \x1b[39m\x1b[49m \x1b[1mcustom_tool\x1b[22m");
   });
 
   it("keeps a colored provider label and action for raw GitNexus output", () => {
@@ -552,7 +552,7 @@ describe("xtrm-ui external tool rendering", () => {
       "gitnexus_query",
     );
 
-    expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;178;154;255mGitNexus\x1b[39m\x1b[49m \x1b[1mquery\x1b[22m");
+    expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;178;154;255m GitNexus \x1b[39m\x1b[49m \x1b[1mquery\x1b[22m");
   });
 
   it("keeps the static chip identical across lifecycle states (no color changing)", () => {
@@ -562,7 +562,7 @@ describe("xtrm-ui external tool rendering", () => {
       "[Serena] execute_shell_command",
       "[Serena] execute_shell_command",
     ] as const;
-    const expected = "› Serena execute_shell_command";
+    const expected = "›  Serena  execute_shell_command";
 
     for (const header of states) {
       const rendered = renderExternalToolBackgroundLines(
@@ -573,7 +573,7 @@ describe("xtrm-ui external tool rendering", () => {
         "execute_shell_command",
       );
       expect(stripAnsi(rendered[0] ?? "")).toBe(expected);
-      expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;82;210;255mSerena\x1b[39m\x1b[49m \x1b[1mexecute_shell_command\x1b[22m");
+      expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;82;210;255m Serena \x1b[39m\x1b[49m \x1b[1mexecute_shell_command\x1b[22m");
     }
   });
 

--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -526,7 +526,7 @@ describe("xtrm-ui external tool rendering", () => {
       "find_symbol",
     );
 
-    expect(rendered[0]).toContain("\x1b[38;2;82;210;255m• Serena\x1b[39m \x1b[1mfind_symbol\x1b[22m");
+    expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;82;210;255mSerena\x1b[39m\x1b[49m \x1b[1mfind_symbol\x1b[22m");
     expect(rendered.length).toBeGreaterThan(2);
     expect(rendered.join("\n")).toContain('"name_path": "highlightExternalToolBadge"');
   });
@@ -540,7 +540,7 @@ describe("xtrm-ui external tool rendering", () => {
       "mcp_custom_tool",
     );
 
-    expect(rendered[0]).toContain("\x1b[38;2;178;190;210m• mcp\x1b[39m \x1b[1mcustom_tool\x1b[22m");
+    expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;178;190;210mmcp\x1b[39m\x1b[49m \x1b[1mcustom_tool\x1b[22m");
   });
 
   it("keeps a colored provider label and action for raw GitNexus output", () => {
@@ -552,38 +552,28 @@ describe("xtrm-ui external tool rendering", () => {
       "gitnexus_query",
     );
 
-    expect(rendered[0]).toContain("\x1b[38;2;178;154;255m• GitNexus\x1b[39m \x1b[1mquery\x1b[22m");
+    expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;178;154;255mGitNexus\x1b[39m\x1b[49m \x1b[1mquery\x1b[22m");
   });
 
-  it("keeps the kind-colored label stable across states; failure dims the action; bg follows the phase", () => {
+  it("keeps the static chip identical across lifecycle states (no color changing)", () => {
     const stripAnsi = (value: string) => value.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "");
-    const bgTokens: string[] = [];
-    const bgTheme = {
-      bg: (token: string, text: string) => { bgTokens.push(token); return text; },
-    };
     const states = [
-      ["running", "toolPendingBg", "\x1b[1mexecute_shell_command\x1b[22m"],
-      ["success", "toolSuccessBg", "\x1b[1mexecute_shell_command\x1b[22m"],
-      ["failure", "toolErrorBg", "\x1b[2mexecute_shell_command\x1b[22m"],
+      "› [Serena] execute_shell_command",
+      "[Serena] execute_shell_command",
+      "[Serena] execute_shell_command",
     ] as const;
+    const expected = "› Serena execute_shell_command";
 
-    for (const [state, bgToken, actionStyled] of states) {
-      bgTokens.length = 0;
+    for (const header of states) {
       const rendered = renderExternalToolBackgroundLines(
-        ["[Serena] execute_shell_command", "result"],
+        [header, "result"],
         200,
         "serena",
         false,
         "execute_shell_command",
-        undefined,
-        state,
-        bgTheme,
       );
-      expect(stripAnsi(rendered[0] ?? "").trim()).toBe("• Serena execute_shell_command");
-      expect(rendered[0]).toContain("\x1b[38;2;82;210;255m• Serena\x1b[39m");
-      expect(rendered[0]).toContain(actionStyled);
-      expect(bgTokens.length).toBeGreaterThan(0);
-      expect(bgTokens.every((token) => token === bgToken)).toBe(true);
+      expect(stripAnsi(rendered[0] ?? "")).toBe(expected);
+      expect(rendered[0]).toContain("\x1b[38;2;3;8;12m\x1b[48;2;82;210;255mSerena\x1b[39m\x1b[49m \x1b[1mexecute_shell_command\x1b[22m");
     }
   });
 

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -411,7 +411,7 @@ function externalToolBadgeColor(kind: ExternalToolFrameKind, text: string): stri
     external: [178, 190, 210],
   };
   const [badgeR, badgeG, badgeB] = bgColors[kind];
-  return `\x1b[38;2;3;8;12m\x1b[48;2;${badgeR};${badgeG};${badgeB}m${text}\x1b[39m\x1b[49m`;
+  return `\x1b[38;2;3;8;12m\x1b[48;2;${badgeR};${badgeG};${badgeB}m ${text} \x1b[39m\x1b[49m`;
 }
 
 export function collapsedExternalToolLines(contentLines: string[], expanded: boolean): string[] {

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -341,7 +341,7 @@ type PatchableToolExecutionComponent = {
 type ExternalToolFrameKind = "serena" | "gitnexus" | "structured" | "process" | "external";
 
 const PATCHED_EXTERNAL_TOOL_FRAME = "__xtrmUiExternalToolFrame";
-const EXTERNAL_TOOL_FRAME_PATCH_VERSION = 20;
+const EXTERNAL_TOOL_FRAME_PATCH_VERSION = 21;
 const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
 
 function stripAnsi(text: string): string {
@@ -402,28 +402,16 @@ function trimRenderedToolLines(lines: string[]): string[] {
   return lines.slice(start, end).map((line) => line.replace(/\s+$/u, ""));
 }
 
-type ExternalToolState = "running" | "success" | "failure";
-
-function externalToolKindColor(kind: ExternalToolFrameKind, text: string): string {
-  const fgColors: Record<ExternalToolFrameKind, [number, number, number]> = {
+function externalToolBadgeColor(kind: ExternalToolFrameKind, text: string): string {
+  const bgColors: Record<ExternalToolFrameKind, [number, number, number]> = {
     serena: [82, 210, 255],
     gitnexus: [178, 154, 255],
     structured: [205, 166, 255],
     process: [92, 226, 255],
     external: [178, 190, 210],
   };
-  const [fgR, fgG, fgB] = fgColors[kind];
-  return `\x1b[38;2;${fgR};${fgG};${fgB}m${text}\x1b[39m`;
-}
-
-function externalToolStateBgToken(state: ExternalToolState): string {
-  if (state === "running") return "toolPendingBg";
-  return state === "failure" ? "toolErrorBg" : "toolSuccessBg";
-}
-
-function padToRenderWidth(line: string, width: number): string {
-  const fitted = truncateToWidth(line, width);
-  return fitted + " ".repeat(Math.max(0, width - visibleWidth(fitted)));
+  const [badgeR, badgeG, badgeB] = bgColors[kind];
+  return `\x1b[38;2;3;8;12m\x1b[48;2;${badgeR};${badgeG};${badgeB}m${text}\x1b[39m\x1b[49m`;
 }
 
 export function collapsedExternalToolLines(contentLines: string[], expanded: boolean): string[] {
@@ -473,8 +461,6 @@ export function renderExternalToolBackgroundLines(
   expanded: boolean,
   toolName?: string,
   durationMs?: number,
-  state: ExternalToolState = "success",
-  themeLike?: { bg: (token: string, text: string) => string },
 ): string[] {
   let displayLines = contentLines;
   const raw = contentLines.length === 1 ? contentLines[0]?.trim() : undefined;
@@ -491,10 +477,8 @@ export function renderExternalToolBackgroundLines(
     || /^[•›]\s+\S+/u.test(firstLine);
   const header = externalToolHeader(kind, toolName, firstLine);
   const payloadLines = hasHeader ? displayLines.slice(1) : displayLines;
-  const action = header.action
-    ? ` ${state === "failure" ? `\x1b[2m${header.action}\x1b[22m` : `\x1b[1m${header.action}\x1b[22m`}`
-    : "";
-  const headerLine = `${externalToolKindColor(kind, `• ${header.provider}`)}${action}`;
+  const action = header.action ? ` \x1b[1m${header.action}\x1b[22m` : "";
+  const headerLine = `${TOOL_ROW_MARKER} ${externalToolBadgeColor(kind, header.provider)}${action}`;
   displayLines = [headerLine, ...payloadLines];
 
   const renderedHeader = displayLines[0] ?? "";
@@ -514,12 +498,9 @@ export function renderExternalToolBackgroundLines(
     truncateToWidth(renderedHeader, renderWidth),
     ...visiblePayload.map((rawLine) => truncateToWidth(rawLine, renderWidth)),
   ];
-  const bgFn = themeLike
-    ? (line: string) => themeLike.bg(externalToolStateBgToken(state), padToRenderWidth(line, renderWidth))
-    : (line: string) => line;
   return footerMeta
-    ? [...body.map(bgFn), bgFn(`\x1b[2m${truncateToWidth(`└─ ${footerMeta}`, renderWidth)}\x1b[22m`)]
-    : body.map(bgFn);
+    ? [...body, `\x1b[2m${truncateToWidth(`└─ ${footerMeta}`, renderWidth)}\x1b[22m`]
+    : body;
 }
 
 function renderExternalToolLines(
@@ -529,12 +510,10 @@ function renderExternalToolLines(
   expanded = false,
   toolName?: string,
   durationMs?: number,
-  state: ExternalToolState = "success",
-  themeLike?: { bg: (token: string, text: string) => string },
 ): string[] {
   const contentLines = trimRenderedToolLines(lines).filter((line) => !isBlankRenderedLine(line));
   return contentLines.length > 0
-    ? renderExternalToolBackgroundLines(contentLines, width, kind, expanded, toolName, durationMs, state, themeLike)
+    ? renderExternalToolBackgroundLines(contentLines, width, kind, expanded, toolName, durationMs)
     : [];
 }
 
@@ -543,14 +522,6 @@ async function installExternalToolFramePatch(): Promise<void> {
   const componentPath = join(dirname(entryPath), "modes", "interactive", "components", "tool-execution.js");
   const mod = await import(pathToFileURL(componentPath).href) as {
     ToolExecutionComponent?: ToolExecutionComponentCtor;
-  };
-  const themeMod = await import(pathToFileURL(join(dirname(entryPath), "modes", "interactive", "theme", "theme.js")).href) as {
-    theme: { bg: (token: string, text: string) => string };
-  };
-  const themeLike = {
-    // Keep the call through the proxy: theme.bg reads this.bgColors off the
-    // Theme instance, so a detached method reference crashes (this = caller).
-    bg: (token: string, text: string) => themeMod.theme.bg(token, text),
   };
   const proto = mod.ToolExecutionComponent?.prototype as
     | (ToolExecutionComponentCtor["prototype"] & { [PATCHED_EXTERNAL_TOOL_FRAME]?: number })
@@ -577,9 +548,6 @@ async function installExternalToolFramePatch(): Promise<void> {
     }
     const firstContentIndex = rendered.findIndex((line) => !isBlankRenderedLine(line));
     const leading = firstContentIndex > 0 ? rendered.slice(0, firstContentIndex) : [];
-    const state: ExternalToolState = this.isPartial
-      ? "running"
-      : this.result?.isError ? "failure" : "success";
     const content = extractResultTextLines(this) ?? rendered;
     let styled: string[];
     try {
@@ -590,8 +558,6 @@ async function installExternalToolFramePatch(): Promise<void> {
         Boolean(this.expanded),
         this.toolName,
         this.__xtrmExternalDurationMs,
-        state,
-        themeLike,
       );
     } catch {
       // A patched renderer must never take the interactive mode down.


### PR DESCRIPTION
## Clarified requirement

The "background" requested was the **badge chip behind the tool name** exactly as it was before any modifications: dark text (`\x1b[38;2;3;8;12m`) on the static per-kind colored background (serena cyan, gitnexus purple, structured/process/external tints). No phase color changing — plain, static — only the new layout (no `[]` brackets).

## Change

- Restore `externalToolBadgeColor` (the exact pre-change chip: dark text on kind-colored bg).
- Header becomes `› <chip>Provider</chip> <action>` — no brackets, chip identical in running/success/failure.
- Remove the phase machinery added in #552/#556: `ExternalToolState`, row backgrounds (`toolPendingBg/SuccessBg/ErrorBg`), `padToRenderWidth`, the theme import/themeLike plumbing. The try/catch render guard stays.
- Patch version 20 → 21.

## Verification

- 45/45 xtrm-ui tests (chip-format assertions, static across lifecycle inputs).
- tsc: 15 pre-existing errors, unchanged.