### PR TITLE
fix(pi-extensions): restore blank line after thinking row before agent response (xtrm-2z1t0)

### DIFF
--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -136,7 +136,7 @@ type PatchableAssistantMessage = {
 	updateContent?: (message: AssistantMessageLike) => void;
 };
 
-const PATCHED_ASSISTANT_MESSAGE = "__xtrmUiThinkingPreview";
+const PATCHED_ASSISTANT_MESSAGE = "__xtrmUiThinkingPreview2";
 
 const THINKING_RECAP_MAX = 120;
 
@@ -306,9 +306,12 @@ async function installThinkingPreviewPatch(): Promise<void> {
 				const compact = this.hideThinkingBlock === true || !thinkingFollowsToggle;
 				const content = message.content.map((block) => {
 					if (block.type !== "thinking" || !block.thinking?.trim()) return block;
-					return compact
-						? { type: "text", text: buildCollapsedThinkingRow(buildThinkingRecap(block.thinking), style) }
-						: { type: "text", text: buildExpandedThinkingBlock(block.thinking, style) };
+					const row = compact
+						? buildCollapsedThinkingRow(buildThinkingRecap(block.thinking), style)
+						: buildExpandedThinkingBlock(block.thinking, style);
+					// Keep type "thinking" so pi's assistant-message layout adds its
+					// Spacer(1) after the thinking run when a visible block follows.
+					return { ...block, thinking: row };
 				});
 				updateContent.call(this, { ...message, content });
 				return;
@@ -1475,9 +1478,11 @@ export default function xtrmUiExtension(pi: ExtensionAPI): void {
   void installExternalToolFramePatch().catch(() => undefined);
 
   // Keep collapsed thinking rows to one line: the recap is truncated to the
-  // render width so the expand hint never wraps or disappears.
+  // render width so the expand hint never wraps or disappears. Runs for both
+  // plain assistant text and 'assistant-thinking' blocks (the collapsed row is
+  // a thinking block again so pi can add its post-thinking spacer).
   pi.registerMarkdownTransformer((markdown, context) => {
-    if (context.messageType !== "assistant" || !markdown.includes("Thinking...")) return markdown;
+    if (!markdown.includes("Thinking...")) return markdown;
     return fitThinkingRowToWidth(markdown, context.availableWidth);
   });
 


### PR DESCRIPTION
## Problem

The thinking preview patch (from #553) replaces thinking blocks with `{ type: 'text', text: buildCollapsedThinkingRow(...) }`. pi's `assistant-message` component adds a `Spacer(1)` after a thinking run **only when the block keeps `type: 'thinking'`**; text blocks get no spacer, and `content.text.trim()` strips any trailing whitespace, so a blank cannot be faked inside the text. Result: ` Thinking... · recap (Ctrl+T to expand)` is glued to the following agent response.

## Fix

- Keep `type: 'thinking'` in the patch and set `block.thinking` to the styled row — pi's own spacer logic then inserts the blank line after the thinking run when a visible block follows, and still none before tool-call blocks.
- `theme.italic` is a chalk no-op (verified at runtime), so the thinking-markdown color/italic wrapper does not change the row's look; the row's inner SGRs override the outer fg.
- Markdown transformer: drop the `messageType === 'assistant'` gate so `fitThinkingRowToWidth` also runs for `assistant-thinking` blocks (the `Thinking...` includes-gate stays).
- Bump patch marker `__xtrmUiThinkingPreview` → `__xtrmUiThinkingPreview2` so reloads re-apply the patch.

## Verification

- 45/45 xtrm-ui tests (build*/fit* assertions unchanged).
- tsc: 15 pre-existing errors, unchanged.