### PR TITLE
fix(pi-extensions): restore thinking-row visibility; blank line via invisible spacer (xtrm-2z1t0)

### DIFF
--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -136,7 +136,7 @@ type PatchableAssistantMessage = {
 	updateContent?: (message: AssistantMessageLike) => void;
 };
 
-const PATCHED_ASSISTANT_MESSAGE = "__xtrmUiThinkingPreview2";
+const PATCHED_ASSISTANT_MESSAGE = "__xtrmUiThinkingPreview3";
 
 const THINKING_RECAP_MAX = 120;
 
@@ -304,14 +304,23 @@ async function installThinkingPreviewPatch(): Promise<void> {
 			if (hasThinking) {
 				if (this.hideThinkingBlock) thinkingFollowsToggle = true;
 				const compact = this.hideThinkingBlock === true || !thinkingFollowsToggle;
-				const content = message.content.map((block) => {
-					if (block.type !== "thinking" || !block.thinking?.trim()) return block;
+				const content = message.content.flatMap((block, index) => {
+					if (block.type !== "thinking" || !block.thinking?.trim()) return [block];
 					const row = compact
 						? buildCollapsedThinkingRow(buildThinkingRecap(block.thinking), style)
 						: buildExpandedThinkingBlock(block.thinking, style);
-					// Keep type "thinking" so pi's assistant-message layout adds its
-					// Spacer(1) after the thinking run when a visible block follows.
-					return { ...block, thinking: row };
+					// Text blocks render even when pi's hideThinkingBlock branch is
+					// active (a "thinking" block would be swallowed and replaced by the
+					// empty hidden label). Append an invisible single-line block (a
+					// zero-width space survives pi's text trim and renders as a blank
+					// line) when a visible text/thinking block follows — mirroring pi's
+					// Spacer(1) after thinking runs; none before tool-call blocks.
+					const hasVisibleAfter = message.content
+						.slice(index + 1)
+						.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
+					return hasVisibleAfter
+						? [{ type: "text", text: row }, { type: "text", text: "\u200b" }]
+						: [{ type: "text", text: row }];
 				});
 				updateContent.call(this, { ...message, content });
 				return;


### PR DESCRIPTION
## Problem

#558 kept the thinking row as `type: 'thinking'` to get pi's `Spacer(1)`, but pi's `hideThinkingBlock` branch **swallows thinking blocks entirely** and renders only the hidden label — which the extension sets to `""`. The thinking rows disappeared.

## Fix

- Rows are **text blocks again** (they render regardless of `hideThinkingBlock`).
- Blank line: append a separate text block containing a single **zero-width space** (`\u200b`). It survives pi's `content.text.trim()` (ZWSP is not JS whitespace — verified) and renders as one invisible line, mirroring pi's `Spacer(1)` after thinking runs.
- The spacer is conditional: only when a visible text/thinking block follows; none before tool-call blocks (pi's own behavior).
- Marker bumped `__xtrmUiThinkingPreview2` → `__xtrmUiThinkingPreview3` so reloads re-apply.

Verified with marked (pi's parser): `\u200b` tokenizes as a paragraph with an invisible char; `\u200b`.trim() !== ''.

## Verification

- 45/45 xtrm-ui tests; tsc: 15 pre-existing errors, unchanged.