### PR TITLE
fix(pi-extensions): match desired flat row shape — └ on first output, bold command (xtrm-sqzv6)

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -352,7 +352,7 @@ describe("xtrm-ui built-in tool rendering", () => {
       context(args, { executionStarted: true, isPartial: true }),
     );
 
-    expect(pending.render(200).join("\n")).toBe("• Ran echo context-label");
+    expect(pending.render(200).join("\n")).toBe("• Ran \x1b[1mecho context-label\x1b[22m");
     expect(running.render(200).join("\n")).toBe("");
   });
 
@@ -368,9 +368,9 @@ describe("xtrm-ui built-in tool rendering", () => {
 
     const lines = component.render(200);
     expect(lines.slice(0, 3)).toEqual([
-      "• Ran echo one",
-      "echo two",
-      "line 3",
+      "• Ran \x1b[1mecho one\x1b[22m",
+      "\x1b[1mecho two\x1b[22m",
+      "└ line 3",
     ]);
     expect(lines.at(-1)).toContain("showing 6/8 lines (ctrl+o expand)");
   });
@@ -427,8 +427,8 @@ describe("xtrm-ui built-in tool rendering", () => {
 
     const lines = component.render(200);
     expect(lines[0]).toBe(`• ${name} ${subject}`);
-    expect(lines[1]).toBe("line 1");
-    expect(lines[6]).toBe("line 6");
+    expect(lines[1]).toBe("└ line 1");
+    expect(lines[6]).toBe("  line 6");
     expect(lines.at(-1)).toContain(`showing 6/8 ${noun}s (ctrl+o expand)`);
   });
 
@@ -443,8 +443,8 @@ describe("xtrm-ui built-in tool rendering", () => {
 
     expect(lines).toEqual([
       "• find *.ts",
-      "only.ts",
-      "└ 1 match · 7B",
+      "└ only.ts",
+      "1 match · 7B",
     ]);
     expect(lines.join("\n")).not.toContain("ctrl+o expand");
   });
@@ -470,7 +470,7 @@ describe("xtrm-ui built-in tool rendering", () => {
     ).render(200);
 
     expect(write[0]).toBe(`• write ${path}`);
-    expect(write[1]).toBe("line 1");
+    expect(write[1]).toBe("└ line 1");
     expect(write.at(-1)).toContain("showing 6/8 lines (ctrl+o expand)");
     expect(edit[0]).toBe(`• edit ${path}`);
     expect(edit[1]).toMatch(/│ /); // diff line-number gutter, not the tool tree

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -973,8 +973,12 @@ function appendToolTree(
   outputLines: string[],
   meta?: string,
 ): string {
-  outputLines.forEach((line) => lines.push(theme.fg("toolOutput", line)));
-  if (meta) lines.push(`${theme.fg("muted", "└")} ${theme.fg("dim", meta)}`);
+  outputLines.forEach((line, index) => {
+    lines.push(index === 0
+      ? `${theme.fg("muted", "└")} ${theme.fg("toolOutput", line)}`
+      : `  ${theme.fg("toolOutput", line)}`);
+  });
+  if (meta) lines.push(theme.fg("dim", meta));
   return lines.join("\n");
 }
 
@@ -987,9 +991,11 @@ function renderBashTree(
 ): string {
   const commandColor = statusColor === "success" ? "text" : "dim";
   const [firstCommand = "", ...continuedCommands] = command.split("\n");
+  // theme.bold is a chalk no-op in pi's runtime; emit the SGR escape directly.
+  const boldCommand = (text: string) => `\x1b[1m${text}\x1b[22m`;
   return appendToolTree(theme, [
-    `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold("Ran"))} ${theme.fg(commandColor, firstCommand)}`,
-    ...continuedCommands.map((line) => theme.fg(commandColor, line)),
+    `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold("Ran"))} ${boldCommand(theme.fg(commandColor, firstCommand))}`,
+    ...continuedCommands.map((line) => boldCommand(theme.fg(commandColor, line))),
   ], outputLines, meta);
 }
 


### PR DESCRIPTION
Corrects #560 to the user-confirmed rendering:

```
• Ran **cd … && bd remember …**      ← command bold (raw SGR; theme.bold is a chalk no-op)
**corner; renderVerticalPreview flat; …**   ← continuations flat + bold
└ Remembered […]: flat tool rows …    ← └ on FIRST output line, column 0
  output flush-lef…                   ← continuation indented 2
  Set memory-acked:… = …
  ✓ Closed xtrm-sqzv6 — … (409bf45e); 45/45 tests
3 lines · 5.2s · 417B                 ← meta flush, no └
```

- `appendToolTree`: `└ <first output>` / `  <rest>` / meta flush.
- `renderBashTree`: command + continuations bold (\x1b[1m…\x1b[22m).
- 45/45 tests; tsc unchanged.