### PR TITLE
feat(pi-extensions): raw char count on collapsed thinking row (xtrm-ib5lm)

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -302,9 +302,9 @@ describe("xtrm-ui thinking chrome", () => {
     expect(buildThinkingRecap("   \n\t\n")).toBe("Thinking...");
   });
 
-  it("builds the collapsed row with bold label, dim recap and expand hint", () => {
-    const row = buildCollapsedThinkingRow("PR #522 queued", thinkingStyle);
-    expect(row).toBe(" B[Thinking...] · D[PR #522 queued] H[(Ctrl+T to expand)]");
+  it("builds the collapsed row with bold label, dim recap, char count and expand hint", () => {
+    const row = buildCollapsedThinkingRow("PR #522 queued", 14, thinkingStyle);
+    expect(row).toBe(" B[Thinking...] · D[PR #522 queued] · D[14] H[(Ctrl+T to expand)]");
   });
 
   it("builds the expanded block with collapse hint and full dimmed trace", () => {

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -136,7 +136,7 @@ type PatchableAssistantMessage = {
 	updateContent?: (message: AssistantMessageLike) => void;
 };
 
-const PATCHED_ASSISTANT_MESSAGE = "__xtrmUiThinkingPreview3";
+const PATCHED_ASSISTANT_MESSAGE = "__xtrmUiThinkingPreview4";
 
 const THINKING_RECAP_MAX = 120;
 
@@ -178,9 +178,9 @@ export function buildThinkingRecap(thinking: string, fallback = "Thinking..."): 
 	return source.length > THINKING_RECAP_MAX ? source.slice(0, THINKING_RECAP_MAX - 3) + "..." : source;
 }
 
-/** Collapsed row: bold label, dim separator, dimmed recap, expand hint. */
-export function buildCollapsedThinkingRow(recap: string, style: ThinkingRowStyle): string {
-	return ` ${style.label("Thinking...")}${style.sep}${style.recap(recap)} ${style.hint("(Ctrl+T to expand)")}`;
+/** Collapsed row: bold label, dim separator, dimmed recap, raw char count, expand hint. */
+export function buildCollapsedThinkingRow(recap: string, charCount: number, style: ThinkingRowStyle): string {
+	return ` ${style.label("Thinking...")}${style.sep}${style.recap(recap)}${style.sep}${style.recap(String(charCount))} ${style.hint("(Ctrl+T to expand)")}`;
 }
 
 /** Expanded block: bold label row with collapse hint, then the full dimmed trace. */
@@ -307,7 +307,7 @@ async function installThinkingPreviewPatch(): Promise<void> {
 				const content = message.content.flatMap((block, index) => {
 					if (block.type !== "thinking" || !block.thinking?.trim()) return [block];
 					const row = compact
-						? buildCollapsedThinkingRow(buildThinkingRecap(block.thinking), style)
+						? buildCollapsedThinkingRow(buildThinkingRecap(block.thinking), block.thinking.length, style)
 						: buildExpandedThinkingBlock(block.thinking, style);
 					// Text blocks render even when pi's hideThinkingBlock branch is
 					// active (a "thinking" block would be swallowed and replaced by the


### PR DESCRIPTION
Collapsed thinking row now shows the thinking block's character count: ` Thinking... · <recap> · <count> (Ctrl+T to expand)`.

- Raw integer (no k-abbreviation), from `block.thinking.length`.
- Cost: one string length at message-update time — the per-render fit path is unchanged.
- `buildCollapsedThinkingRow` signature gains `charCount`; marker bumped to `__xtrmUiThinkingPreview4`.
- 45/45 tests; tsc unchanged.