### PR TITLE
feat(pi-extensions): paint bash command separators light magenta (xtrm-2bgmu)

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -375,6 +375,21 @@ describe("xtrm-ui built-in tool rendering", () => {
     expect(lines.at(-1)).toContain("showing 6/8 lines (ctrl+o expand)");
   });
 
+  it("paints command separators light magenta inside the bold command", () => {
+    const { tools } = loadExtension();
+    const component = tools.bash.renderResult(
+      { content: [{ type: "text", text: "" }], details: {} },
+      { expanded: false, isPartial: false },
+      theme,
+      context({ command: "echo a && echo b | grep c; echo d" }),
+    );
+
+    const line = component.render(200)[0];
+    expect(line).toBe(
+      "• Ran \x1b[1mecho a \x1b[38;2;255;170;255m&&\x1b[39m echo b \x1b[38;2;255;170;255m|\x1b[39m grep c\x1b[38;2;255;170;255m;\x1b[39m echo d\x1b[22m",
+    );
+  });
+
   it("colors only the Ran prefix with phase status and dims the command unless success", () => {
     const { tools } = loadExtension();
     const colors: string[] = [];

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -993,9 +993,24 @@ function renderBashTree(
   const [firstCommand = "", ...continuedCommands] = command.split("\n");
   // theme.bold is a chalk no-op in pi's runtime; emit the SGR escape directly.
   const boldCommand = (text: string) => `\x1b[1m${text}\x1b[22m`;
+  // Command divisors (; && | || &) are hard to spot in long commands; paint them
+  // light magenta (no magenta theme token — swap the RGB for "warning" to get
+  // yellow). Regex split is cosmetic; separators inside quoted strings are
+  // colored too, which is acceptable.
+  const TOOL_SEPARATOR_FG = "\x1b[38;2;255;170;255m";
+  const SEPARATOR_PATTERN = /&&|\|\||[|;&]/;
+  const colorCommand = (text: string): string => text
+    .split(/(&&|\|\||[|;&])/)
+    .map((part) => {
+      if (!part) return "";
+      return SEPARATOR_PATTERN.test(part)
+        ? `${TOOL_SEPARATOR_FG}${part}\x1b[39m`
+        : theme.fg(commandColor, part);
+    })
+    .join("");
   return appendToolTree(theme, [
-    `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold("Ran"))} ${boldCommand(theme.fg(commandColor, firstCommand))}`,
-    ...continuedCommands.map((line) => boldCommand(theme.fg(commandColor, line))),
+    `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold("Ran"))} ${boldCommand(colorCommand(firstCommand))}`,
+    ...continuedCommands.map((line) => boldCommand(colorCommand(line))),
   ], outputLines, meta);
 }
 


### PR DESCRIPTION
In long commands `; && | || &` are hard to distinguish. `renderBashTree` now paints them **light magenta** (raw RGB `255,170,255` — no magenta theme token; one constant to swap for `warning`/yellow), inside the existing bold wrap, on the command and its continuation lines.

- Regex split is cosmetic: separators inside quoted strings (e.g. `"a;b"`) and `2>&1`'s `&` are colored too — acceptable.
- New test; 46/46 green; tsc unchanged.