### PR TITLE
fix(pi-extensions): separator coloring — exclude bare & (xtrm-3s2bd)

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -381,12 +381,12 @@ describe("xtrm-ui built-in tool rendering", () => {
       { content: [{ type: "text", text: "" }], details: {} },
       { expanded: false, isPartial: false },
       theme,
-      context({ command: "echo a && echo b | grep c; echo d" }),
+      context({ command: "echo a && echo b 2>&1 | grep c; echo d" }),
     );
 
     const line = component.render(200)[0];
     expect(line).toBe(
-      "• Ran \x1b[1mecho a \x1b[38;2;255;170;255m&&\x1b[39m echo b \x1b[38;2;255;170;255m|\x1b[39m grep c\x1b[38;2;255;170;255m;\x1b[39m echo d\x1b[22m",
+      "• Ran \x1b[1mecho a \x1b[38;2;255;170;255m&&\x1b[39m echo b 2>&1 \x1b[38;2;255;170;255m|\x1b[39m grep c\x1b[38;2;255;170;255m;\x1b[39m echo d\x1b[22m",
     );
   });
 

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -993,14 +993,15 @@ function renderBashTree(
   const [firstCommand = "", ...continuedCommands] = command.split("\n");
   // theme.bold is a chalk no-op in pi's runtime; emit the SGR escape directly.
   const boldCommand = (text: string) => `\x1b[1m${text}\x1b[22m`;
-  // Command divisors (; && | || &) are hard to spot in long commands; paint them
+  // Command divisors (; && | ||) are hard to spot in long commands; paint them
   // light magenta (no magenta theme token — swap the RGB for "warning" to get
-  // yellow). Regex split is cosmetic; separators inside quoted strings are
-  // colored too, which is acceptable.
+  // yellow). Single & is deliberately excluded so redirections like 2>&1 and
+  // backgrounding & stay plain. Regex split is cosmetic; separators inside
+  // quoted strings are colored too, which is acceptable.
   const TOOL_SEPARATOR_FG = "\x1b[38;2;255;170;255m";
-  const SEPARATOR_PATTERN = /&&|\|\||[|;&]/;
+  const SEPARATOR_PATTERN = /&&|\|\||[|;]/;
   const colorCommand = (text: string): string => text
-    .split(/(&&|\|\||[|;&])/)
+    .split(/(&&|\|\||[|;])/)
     .map((part) => {
       if (!part) return "";
       return SEPARATOR_PATTERN.test(part)


### PR DESCRIPTION
Follow-up to #563: `2>&1` / `1>&2` and backgrounding `&` no longer get painted. Only `&&` (plus `; | ||`) are light magenta.

- Patterns: `/&&|\|\||[|;]/` for both split and test.
- Test now asserts `echo b 2>&1 |` — the `2>&1` stays uncolored.
- 46/46 green; tsc unchanged.