### PR TITLE
fix(pi-extensions): color separators only when whitespace-adjacent (xtrm-s8d5d)

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -390,6 +390,19 @@ describe("xtrm-ui built-in tool rendering", () => {
     );
   });
 
+  it("skips separators without adjacent whitespace", () => {
+    const { tools } = loadExtension();
+    const component = tools.bash.renderResult(
+      { content: [{ type: "text", text: "" }], details: {} },
+      { expanded: false, isPartial: false },
+      theme,
+      context({ command: "echo a&&echo b|c;echo d 2>&1" }),
+    );
+
+    const line = component.render(200)[0];
+    expect(line).toBe("• Ran \x1b[1mecho a&&echo b|c;echo d 2>&1\x1b[22m");
+  });
+
   it("colors only the Ran prefix with phase status and dims the command unless success", () => {
     const { tools } = loadExtension();
     const colors: string[] = [];

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -995,20 +995,36 @@ function renderBashTree(
   const boldCommand = (text: string) => `\x1b[1m${text}\x1b[22m`;
   // Command divisors (; && | ||) are hard to spot in long commands; paint them
   // light magenta (no magenta theme token — swap the RGB for "warning" to get
-  // yellow). Single & is deliberately excluded so redirections like 2>&1 and
-  // backgrounding & stay plain. Regex split is cosmetic; separators inside
-  // quoted strings are colored too, which is acceptable.
+  // yellow) only when adjacent to whitespace: | && || need a space before or
+  // after; ; needs a space after (so "cmd;echo" and "2>&1" stay plain).
+  // Uncolored separators still render in commandColor to avoid a default-color
+  // glitch. Regex split is cosmetic; quoted separators with surrounding spaces
+  // are colored too, which is acceptable.
   const TOOL_SEPARATOR_FG = "\x1b[38;2;255;170;255m";
   const SEPARATOR_PATTERN = /&&|\|\||[|;]/;
-  const colorCommand = (text: string): string => text
-    .split(/(&&|\|\||[|;])/)
-    .map((part) => {
-      if (!part) return "";
-      return SEPARATOR_PATTERN.test(part)
+  const hasSpaceBefore = (part: string) => /\s$/.test(part);
+  const hasSpaceAfter = (part: string) => /^\s/.test(part);
+  const colorCommand = (text: string): string => {
+    const parts = text.split(/(&&|\|\||[|;])/);
+    let result = "";
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (!part) continue;
+      if (!SEPARATOR_PATTERN.test(part)) {
+        result += theme.fg(commandColor, part);
+        continue;
+      }
+      const before = i > 0 ? parts[i - 1] : "";
+      const after = i < parts.length - 1 ? parts[i + 1] : "";
+      const color = part === ";"
+        ? hasSpaceAfter(after)
+        : hasSpaceBefore(before) || hasSpaceAfter(after);
+      result += color
         ? `${TOOL_SEPARATOR_FG}${part}\x1b[39m`
         : theme.fg(commandColor, part);
-    })
-    .join("");
+    }
+    return result;
+  };
   return appendToolTree(theme, [
     `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold("Ran"))} ${boldCommand(colorCommand(firstCommand))}`,
     ...continuedCommands.map((line) => boldCommand(colorCommand(line))),


### PR DESCRIPTION
Refines #563/#564: a separator is painted light magenta only when adjacent to whitespace.

- `| && ||`: space before **or** after.
- `;`: space after only — `cmd;echo`, trailing `;`, and `2>&1` stay plain.
- Uncolored separators still render in commandColor (no default-color glitch).
- New test: `echo a&&echo b|c;echo d 2>&1` — nothing colored. 47/47 green; tsc unchanged.