### PR TITLE
feat(pi-extensions): accent the command name of each bash segment (xtrm-50gq5)

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -403,6 +403,30 @@ describe("xtrm-ui built-in tool rendering", () => {
     expect(line).toBe("• Ran \x1b[1mecho a&&echo b|c;echo d 2>&1\x1b[22m");
   });
 
+  it("accents the command name of each segment after colored divisors", () => {
+    const { tools } = loadExtension();
+    const colors: string[] = [];
+    const spyTheme = {
+      ...theme,
+      fg: (color: string, text: string) => {
+        colors.push(color);
+        return text;
+      },
+    };
+    const result = { content: [{ type: "text", text: "" }], details: {} };
+    const renderOptions = { expanded: false, isPartial: false };
+
+    colors.length = 0;
+    tools.bash.renderResult(
+      result,
+      renderOptions,
+      spyTheme,
+      context({ command: "cd /tmp && python x.py; ls" }),
+    );
+    // cd (line start), python (after &&), ls (after ;) each use the accent token.
+    expect(colors.filter((c) => c === "accent")).toEqual(["accent", "accent", "accent"]);
+  });
+
   it("colors only the Ran prefix with phase status and dims the command unless success", () => {
     const { tools } = loadExtension();
     const colors: string[] = [];
@@ -435,7 +459,7 @@ describe("xtrm-ui built-in tool rendering", () => {
       spyTheme,
       context({ command: "echo pending" }, { executionStarted: false, isPartial: true }),
     );
-    expect(colors).toEqual(["accent", "accent", "dim"]); // • , Ran, command
+    expect(colors).toEqual(["accent", "accent", "dim", "accent", "dim"]); // •, Ran, ws, cmd name, rest
   });
 
   it.each([

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -1004,24 +1004,43 @@ function renderBashTree(
   const SEPARATOR_PATTERN = /&&|\|\||[|;]/;
   const hasSpaceBefore = (part: string) => /\s$/.test(part);
   const hasSpaceAfter = (part: string) => /^\s/.test(part);
+  // First word of a segment (line start, or after a colored divisor) is the
+  // command name — paint it with the accent token; the rest stays commandColor.
+  // False positive: a --flag leading a backslash-continuation line also gets
+  // accent, which is acceptable.
+  const colorFirstWord = (part: string): string => {
+    const match = part.match(/^(\s*)(\S+)/);
+    if (!match) return theme.fg(commandColor, part);
+    const [, whitespace, word] = match;
+    return (
+      theme.fg(commandColor, whitespace) +
+      theme.fg("accent", word) +
+      theme.fg(commandColor, part.slice(match[0].length))
+    );
+  };
   const colorCommand = (text: string): string => {
     const parts = text.split(/(&&|\|\||[|;])/);
     let result = "";
+    let lastWasColoredDivisor = false;
     for (let i = 0; i < parts.length; i++) {
       const part = parts[i];
       if (!part) continue;
-      if (!SEPARATOR_PATTERN.test(part)) {
-        result += theme.fg(commandColor, part);
-        continue;
+      if (SEPARATOR_PATTERN.test(part)) {
+        const before = i > 0 ? parts[i - 1] : "";
+        const after = i < parts.length - 1 ? parts[i + 1] : "";
+        const color = part === ";"
+          ? hasSpaceAfter(after)
+          : hasSpaceBefore(before) || hasSpaceAfter(after);
+        result += color
+          ? `${TOOL_SEPARATOR_FG}${part}\x1b[39m`
+          : theme.fg(commandColor, part);
+        lastWasColoredDivisor = color;
+      } else {
+        result += (i === 0 || lastWasColoredDivisor)
+          ? colorFirstWord(part)
+          : theme.fg(commandColor, part);
+        lastWasColoredDivisor = false;
       }
-      const before = i > 0 ? parts[i - 1] : "";
-      const after = i < parts.length - 1 ? parts[i + 1] : "";
-      const color = part === ";"
-        ? hasSpaceAfter(after)
-        : hasSpaceBefore(before) || hasSpaceAfter(after);
-      result += color
-        ? `${TOOL_SEPARATOR_FG}${part}\x1b[39m`
-        : theme.fg(commandColor, part);
     }
     return result;
   };


### PR DESCRIPTION
Classic shell-highlighting pattern: the command name is painted with the `accent` token, arguments stay `commandColor`.

- First word of each segment: line start, or right after a colored `; && | ||` divisor.
- `cd /tmp && python x.py; ls` → `cd`, `python`, `ls` accent.
- False positive (acceptable): a `--flag` leading a backslash-continuation line also gets accent.
- Uses `theme.fg("accent")` so it adapts to the active theme; one-token switch.
- New test; 48/48 green; tsc unchanged.