### PR TITLE
revert(pi-extensions): drop divisor + command-name coloring — plain command (xtrm-oj0ll)

### DIFF
--- a/cli/test/extensions/xtrm-ui.test.ts
+++ b/cli/test/extensions/xtrm-ui.test.ts
@@ -375,58 +375,6 @@ describe("xtrm-ui built-in tool rendering", () => {
     expect(lines.at(-1)).toContain("showing 6/8 lines (ctrl+o expand)");
   });
 
-  it("paints command separators light magenta inside the bold command", () => {
-    const { tools } = loadExtension();
-    const component = tools.bash.renderResult(
-      { content: [{ type: "text", text: "" }], details: {} },
-      { expanded: false, isPartial: false },
-      theme,
-      context({ command: "echo a && echo b 2>&1 | grep c; echo d" }),
-    );
-
-    const line = component.render(200)[0];
-    expect(line).toBe(
-      "• Ran \x1b[1mecho a \x1b[38;2;255;170;255m&&\x1b[39m echo b 2>&1 \x1b[38;2;255;170;255m|\x1b[39m grep c\x1b[38;2;255;170;255m;\x1b[39m echo d\x1b[22m",
-    );
-  });
-
-  it("skips separators without adjacent whitespace", () => {
-    const { tools } = loadExtension();
-    const component = tools.bash.renderResult(
-      { content: [{ type: "text", text: "" }], details: {} },
-      { expanded: false, isPartial: false },
-      theme,
-      context({ command: "echo a&&echo b|c;echo d 2>&1" }),
-    );
-
-    const line = component.render(200)[0];
-    expect(line).toBe("• Ran \x1b[1mecho a&&echo b|c;echo d 2>&1\x1b[22m");
-  });
-
-  it("accents the command name of each segment after colored divisors", () => {
-    const { tools } = loadExtension();
-    const colors: string[] = [];
-    const spyTheme = {
-      ...theme,
-      fg: (color: string, text: string) => {
-        colors.push(color);
-        return text;
-      },
-    };
-    const result = { content: [{ type: "text", text: "" }], details: {} };
-    const renderOptions = { expanded: false, isPartial: false };
-
-    colors.length = 0;
-    tools.bash.renderResult(
-      result,
-      renderOptions,
-      spyTheme,
-      context({ command: "cd /tmp && python x.py; ls" }),
-    );
-    // cd (line start), python (after &&), ls (after ;) each use the accent token.
-    expect(colors.filter((c) => c === "accent")).toEqual(["accent", "accent", "accent"]);
-  });
-
   it("colors only the Ran prefix with phase status and dims the command unless success", () => {
     const { tools } = loadExtension();
     const colors: string[] = [];
@@ -459,7 +407,7 @@ describe("xtrm-ui built-in tool rendering", () => {
       spyTheme,
       context({ command: "echo pending" }, { executionStarted: false, isPartial: true }),
     );
-    expect(colors).toEqual(["accent", "accent", "dim", "accent", "dim"]); // •, Ran, ws, cmd name, rest
+    expect(colors).toEqual(["accent", "accent", "dim"]); // •, Ran, command
   });
 
   it.each([

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -993,60 +993,9 @@ function renderBashTree(
   const [firstCommand = "", ...continuedCommands] = command.split("\n");
   // theme.bold is a chalk no-op in pi's runtime; emit the SGR escape directly.
   const boldCommand = (text: string) => `\x1b[1m${text}\x1b[22m`;
-  // Command divisors (; && | ||) are hard to spot in long commands; paint them
-  // light magenta (no magenta theme token — swap the RGB for "warning" to get
-  // yellow) only when adjacent to whitespace: | && || need a space before or
-  // after; ; needs a space after (so "cmd;echo" and "2>&1" stay plain).
-  // Uncolored separators still render in commandColor to avoid a default-color
-  // glitch. Regex split is cosmetic; quoted separators with surrounding spaces
-  // are colored too, which is acceptable.
-  const TOOL_SEPARATOR_FG = "\x1b[38;2;255;170;255m";
-  const SEPARATOR_PATTERN = /&&|\|\||[|;]/;
-  const hasSpaceBefore = (part: string) => /\s$/.test(part);
-  const hasSpaceAfter = (part: string) => /^\s/.test(part);
-  // First word of a segment (line start, or after a colored divisor) is the
-  // command name — paint it with the accent token; the rest stays commandColor.
-  // False positive: a --flag leading a backslash-continuation line also gets
-  // accent, which is acceptable.
-  const colorFirstWord = (part: string): string => {
-    const match = part.match(/^(\s*)(\S+)/);
-    if (!match) return theme.fg(commandColor, part);
-    const [, whitespace, word] = match;
-    return (
-      theme.fg(commandColor, whitespace) +
-      theme.fg("accent", word) +
-      theme.fg(commandColor, part.slice(match[0].length))
-    );
-  };
-  const colorCommand = (text: string): string => {
-    const parts = text.split(/(&&|\|\||[|;])/);
-    let result = "";
-    let lastWasColoredDivisor = false;
-    for (let i = 0; i < parts.length; i++) {
-      const part = parts[i];
-      if (!part) continue;
-      if (SEPARATOR_PATTERN.test(part)) {
-        const before = i > 0 ? parts[i - 1] : "";
-        const after = i < parts.length - 1 ? parts[i + 1] : "";
-        const color = part === ";"
-          ? hasSpaceAfter(after)
-          : hasSpaceBefore(before) || hasSpaceAfter(after);
-        result += color
-          ? `${TOOL_SEPARATOR_FG}${part}\x1b[39m`
-          : theme.fg(commandColor, part);
-        lastWasColoredDivisor = color;
-      } else {
-        result += (i === 0 || lastWasColoredDivisor)
-          ? colorFirstWord(part)
-          : theme.fg(commandColor, part);
-        lastWasColoredDivisor = false;
-      }
-    }
-    return result;
-  };
   return appendToolTree(theme, [
-    `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold("Ran"))} ${boldCommand(colorCommand(firstCommand))}`,
-    ...continuedCommands.map((line) => boldCommand(colorCommand(line))),
+    `${theme.fg(statusColor, "•")} ${theme.fg(statusColor, theme.bold("Ran"))} ${boldCommand(theme.fg(commandColor, firstCommand))}`,
+    ...continuedCommands.map((line) => boldCommand(theme.fg(commandColor, line))),
   ], outputLines, meta);
 }
 


### PR DESCRIPTION
Reverts #563/#564/#565/#566. `renderBashTree` is back to the pre-coloring state: plain bold command (from #561), no light-magenta separators, no accent command names.

- Removes the separator, whitespace-adjacency, and command-name accent tests; pending assertion reverted.
- 45/45 green; tsc unchanged.