### PR TITLE
fix(pi-extensions): thinking row never rendered — remove dead hiddenThinkingLabel gate (xtrm-d4wfh)

### DIFF
--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -136,7 +136,7 @@ type PatchableAssistantMessage = {
 	updateContent?: (message: AssistantMessageLike) => void;
 };
 
-const PATCHED_ASSISTANT_MESSAGE = "__xtrmUiThinkingPreview4";
+const PATCHED_ASSISTANT_MESSAGE = "__xtrmUiThinkingPreview5";
 
 const THINKING_RECAP_MAX = 120;
 
@@ -299,7 +299,7 @@ async function installThinkingPreviewPatch(): Promise<void> {
 
 	const updateContent = proto.updateContent;
 	proto.updateContent = function patchedUpdateContent(this: PatchableAssistantMessage, message: AssistantMessageLike) {
-		if (this.hiddenThinkingLabel === "" && Array.isArray(message.content)) {
+		if (Array.isArray(message.content)) {
 			const hasThinking = message.content.some((block) => block.type === "thinking" && block.thinking?.trim());
 			if (hasThinking) {
 				if (this.hideThinkingBlock) thinkingFollowsToggle = true;


### PR DESCRIPTION
**Why the thinking line was missing in a fresh session:** `installThinkingPreviewPatch` gated on `this.hiddenThinkingLabel === ""`, but pi's `AssistantMessageComponent` constructor and `setHiddenThinkingLabel()` always default to `"Thinking..."` and nothing ever passes `""`. The gate could never fire, so thinking blocks always fell through to pi's own handling (expanded markdown, or its static label when hidden) — the collapsed row has never rendered live.

**Fix:** remove the gate; convert thinking blocks unconditionally. Default stays collapsed on the first run (`thinkingFollowsToggle` starts `false` → compact). Marker bumped to `__xtrmUiThinkingPreview5`.

- 45/45 tests; tsc unchanged.