### PR TITLE
beads: sync Beads/Dolt via GitHub origin on push/merge (refs/dolt/data)

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,5 +1,6 @@
 dolt.shared-server: true
 dolt:
-  shared-server: true
-
+    shared-server: true
 export.git-add: false
+sync:
+    remote: "git+ssh://git@github.com/xtrm-dev/core.git"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.5 ---
+# --- BEGIN BEADS INTEGRATION v1.1.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -30,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.5 ---
+# --- END BEADS INTEGRATION v1.1.0 ---

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,5 +1,21 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.5 ---
+# --- BEGIN custom: beads/dolt pull after merge ---
+# Outside bd's managed markers (bd hooks install/upgrade won't clobber).
+# Pulls the Dolt remote (refs/dolt/data on the GitHub origin) after a
+# Git pull/merge. Reports failure loudly via a non-zero exit.
+if [ -x "$(dirname "$0")/post-merge.bd-sync" ]; then
+    _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$_bd_timeout" "$(dirname "$0")/post-merge.bd-sync" "$@"
+    else
+        "$(dirname "$0")/post-merge.bd-sync" "$@"
+    fi
+    rc=$?
+    [ $rc -ne 0 ] && exit $rc
+fi
+# --- END custom ---
+
+# --- BEGIN BEADS INTEGRATION v1.1.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -30,4 +46,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.5 ---
+# --- END BEADS INTEGRATION v1.1.0 ---

--- a/.githooks/post-merge.bd-sync
+++ b/.githooks/post-merge.bd-sync
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Beads/Dolt sync chained from .githooks/post-merge (see that file).
+#
+# Pulls Beads data from the GitHub-backed Dolt remote (refs/dolt/data) after a
+# Git pull/merge. A failed pull is reported loudly: the Git pull/merge command
+# reports failure (post-merge exit code) and the operator sees the message.
+set -uo pipefail
+
+# Skip when beads is unavailable or this checkout has no beads database.
+if ! command -v bd >/dev/null 2>&1 || ! bd where >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "beads-sync: pull Dolt remote"
+if ! bd dolt pull; then
+  echo "beads-sync: ERROR: 'bd dolt pull' failed after Git merge." >&2
+  echo "beads-sync: Beads data may be stale. Run 'bd dolt pull' manually." >&2
+  exit 1
+fi
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,9 +17,10 @@ else
     echo "pre-commit not installed or .pre-commit-config.yaml missing — skipping local commit security checks"
 fi
 
-exit 0
+# Beads-managed section below runs after the security checks above
+# (refreshes the JSONL export; the custom block after it stages the export).
 
-# --- BEGIN BEADS INTEGRATION v1.0.5 ---
+# --- BEGIN BEADS INTEGRATION v1.1.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -50,7 +51,7 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.5 ---
+# --- END BEADS INTEGRATION v1.1.0 ---
 
 # --- BEGIN custom: stage freshly-exported JSONL into the commit ---
 # Lives OUTSIDE bd's managed markers so bd hooks install/upgrade won't clobber.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -19,9 +19,24 @@ if [ -x "$HOOKS_DIR/pre-push.local" ]; then
     [ $rc -ne 0 ] && exit $rc
 fi
 
-exit 0
+# --- BEGIN custom: beads/dolt sync before push ---
+# Outside bd's managed markers (bd hooks install/upgrade won't clobber).
+# Commits pending Beads changes, then pulls and pushes the Dolt remote
+# (refs/dolt/data on the GitHub origin). Fails the Git push on sync failure.
+if [ -x "$HOOKS_DIR/pre-push.bd-sync" ]; then
+    _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+    if command -v timeout >/dev/null 2>&1; then
+        echo "$REFS" | timeout "$_bd_timeout" "$HOOKS_DIR/pre-push.bd-sync" "$@"
+    else
+        echo "$REFS" | "$HOOKS_DIR/pre-push.bd-sync" "$@"
+    fi
+    rc=$?
+    [ $rc -ne 0 ] && exit $rc
+fi
+# --- END custom ---
 
-# --- BEGIN BEADS INTEGRATION v1.0.5 ---
+# Beads-managed section below runs after the security checks and Dolt sync.
+# --- BEGIN BEADS INTEGRATION v1.1.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -52,4 +67,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.5 ---
+# --- END BEADS INTEGRATION v1.1.0 ---

--- a/.githooks/pre-push.bd-sync
+++ b/.githooks/pre-push.bd-sync
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Beads/Dolt sync chained from .githooks/pre-push (see that file).
+#
+# Synchronizes Beads data with the GitHub-backed Dolt remote (refs/dolt/data):
+#   1. commit pending Beads changes (idempotent)
+#   2. pull the Dolt remote (pull before push, per Beads concurrency policy)
+#   3. push the Dolt remote
+#
+# A non-zero exit aborts the Git push, so the push cannot succeed while Beads
+# state is unsynced. See XTRM/beads sync migration notes for the contract.
+set -uo pipefail
+
+# Skip when beads is unavailable or this checkout has no beads database.
+if ! command -v bd >/dev/null 2>&1 || ! bd where >/dev/null 2>&1; then
+  echo "beads-sync: no beads database in this checkout — skipping Dolt sync" >&2
+  exit 0
+fi
+
+echo "beads-sync: commit pending Beads changes"
+if ! bd dolt commit; then
+  echo "beads-sync: ERROR: 'bd dolt commit' failed — aborting Git push" >&2
+  exit 1
+fi
+
+echo "beads-sync: pull Dolt remote"
+if ! bd dolt pull; then
+  echo "beads-sync: ERROR: 'bd dolt pull' failed — aborting Git push" >&2
+  echo "beads-sync: Beads and code would be out of sync; fix the Dolt remote state and retry" >&2
+  exit 1
+fi
+
+echo "beads-sync: push Dolt remote"
+if ! bd dolt push; then
+  echo "beads-sync: ERROR: 'bd dolt push' failed — aborting Git push" >&2
+  exit 1
+fi
+
+echo "beads-sync: Dolt sync OK"
+exit 0

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.5 ---
+# --- BEGIN BEADS INTEGRATION v1.1.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -30,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.5 ---
+# --- END BEADS INTEGRATION v1.1.0 ---


### PR DESCRIPTION
## Summary
Make GitHub the canonical Dolt remote for Beads (refs/dolt/data), replacing the self-hosted DoltLab remote.

## Changes
- Dolt remote `origin` -> `git+ssh://git@github.com/xtrm-dev/core.git`; `sync.remote` set in .beads/config.yaml.
- Beads hooks refreshed to shim 1.1.0 (security-pipeline wrappers + custom blocks preserved).
- pre-push: chains `pre-push.bd-sync` (bd dolt commit -> pull -> push; fails the Git push on sync error); fixes the premature `exit 0` that made the bd-managed section dead code.
- post-merge: chains `post-merge.bd-sync` (bd dolt pull; reports failure loudly).
- pre-commit: removes the premature `exit 0` so the bd-managed JSONL section and the existing JSONL staging block actually run.
- dolt.auto-push NOT enabled (intentionally opt-in).
- Repo fingerprint updated (`bd migrate --update-repo-id`).

## Proof (local -> GitHub -> server, both directions)
- Proof bead xtrm-j403m created locally; reached GitHub via normal git push (pre-push hook) and the server checkout via normal git pull (post-merge hook); closed on the server and the closure reached the local checkout via normal pull. See PR commit history (labeled empty commits are proof vehicles, squash-merged away).