### PR TITLE
feat(pi-extensions): read-line-numbers extension (owner of model-facing numbering)

### DIFF
--- a/packages/pi-extensions/extensions/read-line-numbers/index.test.ts
+++ b/packages/pi-extensions/extensions/read-line-numbers/index.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@earendil-works/pi-coding-agent", () => ({
+  isReadToolResult: (event: { toolName: string }) => event.toolName === "read",
+}));
+
+const { numberReadText } = await import("./index.ts");
+const registerExtension = (await import("./index.ts")).default;
+
+type ReadEvent = {
+  type: "tool_result";
+  toolCallId: string;
+  toolName: string;
+  input: { path: string; offset?: number; limit?: number };
+  content: Array<{ type: "text"; text: string }>;
+  isError: boolean;
+  details?: unknown;
+};
+
+function runHandler(event: ReadEvent): unknown {
+  const handlers: Array<(event: unknown) => unknown> = [];
+  registerExtension({ on: (_name: string, handler: (event: unknown) => unknown) => handlers.push(handler) } as never);
+  return handlers[0]?.(event);
+}
+
+describe("numberReadText", () => {
+  test("multi-line input prefixes every line with 1-based numbers", () => {
+    expect(numberReadText("foo\nbar\nbaz", 1, false)).toBe("1 | foo\n2 | bar\n3 | baz");
+  });
+
+  test("offset 137 numbers from the true source line", () => {
+    expect(numberReadText("foo\nbar", 137, false)).toBe("137 | foo\n138 | bar");
+  });
+
+  test("empty content passes through unchanged", () => {
+    expect(numberReadText("", 1, false)).toBe("");
+  });
+
+  test("single-line content is numbered 1", () => {
+    expect(numberReadText("text", 1, false)).toBe("1 | text");
+  });
+
+  test("trailing newline leaves the final empty line unnumbered", () => {
+    expect(numberReadText("foo\nbar\n", 1, false)).toBe("1 | foo\n2 | bar\n");
+  });
+
+  test("Pi truncation notice is preserved verbatim, not prefixed", () => {
+    const input = "foo\nbar\n\n[Showing lines 1-2 of 5000. Use offset=3 to continue.]";
+    expect(numberReadText(input, 1, true)).toBe(
+      "1 | foo\n2 | bar\n\n[Showing lines 1-2 of 5000. Use offset=3 to continue.]",
+    );
+  });
+
+  test("Pi user-limit notice is preserved verbatim even without truncation flag", () => {
+    const input = "foo\nbar\n\n[3 more lines in file. Use offset=3 to continue.]";
+    expect(numberReadText(input, 1, false)).toBe(
+      "1 | foo\n2 | bar\n\n[3 more lines in file. Use offset=3 to continue.]",
+    );
+  });
+
+  test("first-line-exceeds banner alone is preserved verbatim", () => {
+    const input = "[Line 5 is 60KB, exceeds 50KB limit. Use bash: sed -n '5p' /a/b.txt | head -c 51200]";
+    expect(numberReadText(input, 1, true)).toBe(input);
+  });
+});
+
+describe("read-line-numbers extension", () => {
+  test("read tool result is numbered using the event offset", () => {
+    const result = runHandler({
+      type: "tool_result",
+      toolCallId: "call-1",
+      toolName: "read",
+      input: { path: "/a/b.txt", offset: 137 },
+      content: [{ type: "text", text: "foo\nbar" }],
+      isError: false,
+    }) as { content: Array<{ text: string }> };
+    expect(result.content[0]?.text).toBe("137 | foo\n138 | bar");
+  });
+
+  test("read tool result without offset numbers from 1", () => {
+    const result = runHandler({
+      type: "tool_result",
+      toolCallId: "call-1",
+      toolName: "read",
+      input: { path: "/a/b.txt" },
+      content: [{ type: "text", text: "foo" }],
+      isError: false,
+    }) as { content: Array<{ text: string }> };
+    expect(result.content[0]?.text).toBe("1 | foo");
+  });
+
+  test("non-read tool result passes through untouched", () => {
+    const result = runHandler({
+      type: "tool_result",
+      toolCallId: "call-2",
+      toolName: "bash",
+      input: { command: "ls" },
+      content: [{ type: "text", text: "a.txt\nb.txt" }],
+      isError: false,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test("error result passes through untouched", () => {
+    const result = runHandler({
+      type: "tool_result",
+      toolCallId: "call-3",
+      toolName: "read",
+      input: { path: "/a/b.txt", offset: 999 },
+      content: [{ type: "text", text: "Offset 999 is beyond end of file (5 lines total)" }],
+      isError: true,
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/pi-extensions/extensions/read-line-numbers/index.ts
+++ b/packages/pi-extensions/extensions/read-line-numbers/index.ts
@@ -1,0 +1,82 @@
+import type { ExtensionAPI, ToolResultEvent, ToolResultEventResult } from "@earendil-works/pi-coding-agent";
+import { isReadToolResult } from "@earendil-works/pi-coding-agent";
+
+// ---------------------------------------------------------------------------
+// read-line-numbers — owns the model-facing transform of Pi's built-in `read`
+// tool: every source line is prefixed with its true line number, honoring the
+// caller's `offset` so numbering matches the file, not the window position.
+//
+// Boundaries:
+//  - The transform applies ONLY to built-in `read` tool results
+//    (discriminated via isReadToolResult). All other tools pass through.
+//  - Pi synthetic notices are preserved verbatim — prefixing one would
+//    fabricate a false citation. They are recognized by the same discriminants
+//    Pi uses: isError for error banners, details.truncation for truncation
+//    notices, and the exact notice text Pi appends for user-limit reads.
+//  - xtrm-ui remains presentation-only: it renders the already-numbered
+//    content unchanged and never re-prefixes.
+// ---------------------------------------------------------------------------
+
+/** Pi appends this notice after a blank separator when the line limit was hit. */
+const SHOWING_NOTICE = /^\[Showing lines \d+-\d+ of \d+.*Use offset=\d+ to continue\.\]$/;
+/** Pi appends this notice when a user-specified `limit` stopped before EOF. */
+const USER_LIMIT_NOTICE = /^\[\d+ more lines in file\. Use offset=\d+ to continue\.\]$/;
+/** Pi emits this banner alone when the first line exceeds the byte limit. */
+const FIRST_LINE_BANNER = /^\[Line \d+ is .* exceeds .* limit\. Use bash: sed -n '\d+p' .*\]$/;
+
+function isSyntheticNotice(line: string): boolean {
+  return SHOWING_NOTICE.test(line) || USER_LIMIT_NOTICE.test(line) || FIRST_LINE_BANNER.test(line);
+}
+
+function numberLines(lines: string[], startLine: number): string {
+  return lines
+    .map((line, index) => (line === "" ? line : `${startLine + index} | ${line}`))
+    .join("\n");
+}
+
+/**
+ * Number the model-facing text of a `read` tool result.
+ *
+ * - `startLine` is the 1-based number of the first line (Pi's `offset`, default 1).
+ * - `truncated` mirrors `details.truncation.truncated`: when true, Pi appended a
+ *   trailing `\n\n[Showing lines ...]` notice that stays verbatim.
+ * - Empty lines pass through unnumbered; their index still advances the count,
+ *   so a trailing newline leaves the final empty line unnumbered.
+ */
+export function numberReadText(text: string, startLine: number, truncated: boolean): string {
+  if (text.length === 0) return text;
+  const lines = text.split("\n");
+  const last = lines.length - 1;
+  if (isSyntheticNotice(lines[last])) {
+    // Whole payload is a banner (firstLineExceedsLimit) — keep verbatim.
+    if (last === 0) return lines[last];
+    // Trailing "\n\n[notice]": number the body, re-append the notice verbatim
+    // (the blank separator line stays unnumbered).
+    return numberLines(lines.slice(0, last), startLine) + "\n" + lines[last];
+  }
+  return numberLines(lines, startLine);
+}
+
+export default function readLineNumbersExtension(pi: ExtensionAPI): void {
+  pi.on("tool_result", (event: ToolResultEvent): ToolResultEventResult | undefined => {
+    // Built-in `read` tool only — never intercept other tools.
+    if (!isReadToolResult(event)) return undefined;
+    // Error banners ("Offset N is beyond end of file", ...) stay verbatim.
+    if (event.isError) return undefined;
+    const truncation = event.details?.truncation;
+    // The whole payload is the bash-fallback banner, not file content.
+    if (truncation?.firstLineExceedsLimit) return undefined;
+    // Image / non-text (binary) content: no-op.
+    if (event.content.some((item) => item.type !== "text")) return undefined;
+
+    // Pi's `offset` is 1-based; the first displayed line keeps that number.
+    const startLine = event.input.offset != null && event.input.offset > 0 ? event.input.offset : 1;
+    const transformed = event.content.map((item) => {
+      if (item.type !== "text") return item;
+      const text = (item as { text?: unknown }).text;
+      if (typeof text !== "string") return item;
+      return { type: "text", text: numberReadText(text, startLine, truncation?.truncated === true) };
+    });
+    return { content: transformed };
+  });
+}

--- a/packages/pi-extensions/extensions/read-line-numbers/package.json
+++ b/packages/pi-extensions/extensions/read-line-numbers/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "read-line-numbers",
+  "version": "1.0.0",
+  "description": "Prefix model-facing read tool output with true source line numbers",
+  "keywords": [
+    "pi",
+    "pi-extension",
+    "read",
+    "line-numbers"
+  ],
+  "license": "MIT",
+  "type": "module",
+  "main": "index.ts",
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.80.0"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/packages/pi-extensions/extensions/xtprompt/index.test.ts
+++ b/packages/pi-extensions/extensions/xtprompt/index.test.ts
@@ -26,6 +26,7 @@ mock.module("@earendil-works/pi-coding-agent", () => ({
   createReadTool: () => ({}),
   createWriteTool: () => ({}),
   isBashToolResult: () => false,
+  isReadToolResult: (event: { toolName: string }) => event.toolName === "read",
   isToolCallEventType: () => false,
 }));
 

--- a/packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@earendil-works/pi-ai", () => ({ complete: async () => ({}) }));
+mock.module("@earendil-works/pi-coding-agent", () => ({
+  BorderedLoader: class {},
+  CustomEditor: class {},
+  VERSION: "test",
+  createBashTool: () => ({}),
+  createEditTool: () => ({}),
+  createFindTool: () => ({}),
+  createGrepTool: () => ({}),
+  createLsTool: () => ({}),
+  createReadTool: () => ({}),
+  createWriteTool: () => ({}),
+  isBashToolResult: () => false,
+  isToolCallEventType: () => false,
+}));
+mock.module("@earendil-works/pi-tui", () => ({
+  Box: class {},
+  Text: class {
+    constructor(public text: string) {}
+  },
+  matchesKey: () => false,
+  truncateToWidth: (value: string) => value,
+  visibleWidth: (value: string) => value.length,
+}));
+mock.module("@mariozechner/pi-coding-agent", () => ({}));
+
+const xtrmUiExtension = (await import("./index.ts")).default;
+
+type RegisteredTool = {
+  name: string;
+  renderResult: (result: unknown, options: unknown, theme: unknown, context: unknown) => unknown;
+};
+
+function registerWithMock(): { tools: RegisteredTool[]; events: string[] } {
+  const tools: RegisteredTool[] = [];
+  const events: string[] = [];
+  const pi = {
+    on: (event: string) => {
+      events.push(event);
+    },
+    registerTool: (tool: RegisteredTool) => {
+      tools.push(tool);
+    },
+    registerCommand: () => {},
+    registerMessageRenderer: () => {},
+    registerMarkdownTransformer: () => {},
+    getThinkingLevel: () => "medium",
+  };
+  xtrmUiExtension(pi as never);
+  return { tools, events };
+}
+
+describe("xtrm-ui presentation-only boundary", () => {
+  test("xtrm-ui installs no tool_result handler", () => {
+    const { events } = registerWithMock();
+    expect(events).not.toContain("tool_result");
+  });
+
+  test("read.renderResult displays already-numbered content without re-prefixing", () => {
+    const { tools } = registerWithMock();
+    const readTool = tools.find((tool) => tool.name === "read");
+    expect(readTool).toBeDefined();
+
+    const theme = {
+      fg: (_color: string, text: string) => text,
+      bold: (text: string) => text,
+      bg: (_color: string) => (text: string) => text,
+    };
+    const rendered = readTool!.renderResult(
+      {
+        content: [{ type: "text", text: "137 | foo\n138 | bar\n139 | baz" }],
+        details: {},
+        isError: false,
+      },
+      { expanded: true, isPartial: false },
+      theme,
+      { args: { path: "/a/b.txt" }, executionStarted: true, isPartial: false, state: {} },
+    ) as { text: string };
+
+    const output = rendered.text;
+    expect(output).toContain("137 | foo");
+    expect(output).toContain("138 | bar");
+    expect(output).toContain("139 | baz");
+    expect(output).not.toContain("137 | 137 |");
+    expect(output).not.toContain("1 | foo");
+  });
+});

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -136,7 +136,7 @@ type PatchableAssistantMessage = {
 	updateContent?: (message: AssistantMessageLike) => void;
 };
 
-const PATCHED_ASSISTANT_MESSAGE = "__xtrmUiThinkingPreview4";
+const PATCHED_ASSISTANT_MESSAGE = "__xtrmUiThinkingPreview5";
 
 const THINKING_RECAP_MAX = 120;
 
@@ -299,7 +299,7 @@ async function installThinkingPreviewPatch(): Promise<void> {
 
 	const updateContent = proto.updateContent;
 	proto.updateContent = function patchedUpdateContent(this: PatchableAssistantMessage, message: AssistantMessageLike) {
-		if (this.hiddenThinkingLabel === "" && Array.isArray(message.content)) {
+		if (Array.isArray(message.content)) {
 			const hasThinking = message.content.some((block) => block.type === "thinking" && block.thinking?.trim());
 			if (hasThinking) {
 				if (this.hideThinkingBlock) thinkingFollowsToggle = true;

--- a/packages/pi-extensions/src/extensions/read-line-numbers.ts
+++ b/packages/pi-extensions/src/extensions/read-line-numbers.ts
@@ -1,0 +1,3 @@
+import registerExtension from "../../extensions/read-line-numbers/index.ts";
+
+export default registerExtension;

--- a/packages/pi-extensions/src/manifest.json
+++ b/packages/pi-extensions/src/manifest.json
@@ -13,7 +13,8 @@
     { "id": "sp-terminal-overlay", "displayName": "sp-terminal-overlay", "required": false, "ownership": "xtrm" },
     { "id": "xtrm-loader", "displayName": "xtrm-loader", "required": true, "ownership": "xtrm" },
     { "id": "xtrm-ui", "displayName": "xtrm-ui", "required": true, "ownership": "xtrm" },
-    { "id": "xtprompt", "displayName": "xtprompt", "required": false, "ownership": "xtrm" }
+    { "id": "xtprompt", "displayName": "xtprompt", "required": false, "ownership": "xtrm" },
+    { "id": "read-line-numbers", "displayName": "read-line-numbers", "required": true, "ownership": "xtrm" }
   ],
   "disabled": {
     "quality-gates": "Hook-script lookup still targets .claude/hooks instead of the managed .xtrm/hooks layout.",

--- a/packages/pi-extensions/src/registry.ts
+++ b/packages/pi-extensions/src/registry.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import manifest from "./manifest.json" with { type: "json" };
 import autoSessionNameExtension from "./extensions/auto-session-name.ts";
@@ -11,6 +11,7 @@ import lspBootstrapExtension from "./extensions/lsp-bootstrap.ts";
 import piSerenaCompactExtension from "./extensions/pi-serena-compact.ts";
 import serenaPoolExtension from "./extensions/serena-pool.ts";
 import qualityGatesExtension from "./extensions/quality-gates.ts";
+import readLineNumbersExtension from "./extensions/read-line-numbers.ts";
 import serviceSkillsExtension from "./extensions/service-skills.ts";
 import sessionFlowExtension from "./extensions/session-flow.ts";
 import spTerminalOverlayExtension from "./extensions/sp-terminal-overlay.ts";
@@ -33,6 +34,7 @@ const availableManagedPiExtensions: readonly ManagedPiExtension[] = [
   { id: "lsp-bootstrap", register: lspBootstrapExtension },
   { id: "pi-serena-compact", register: piSerenaCompactExtension },
   { id: "quality-gates", register: qualityGatesExtension },
+  { id: "read-line-numbers", register: readLineNumbersExtension },
   { id: "serena-pool", register: serenaPoolExtension },
   { id: "service-skills", register: serviceSkillsExtension },
   { id: "session-flow", register: sessionFlowExtension },

--- a/packages/pi-extensions/tests/registry-parity.test.ts
+++ b/packages/pi-extensions/tests/registry-parity.test.ts
@@ -16,6 +16,7 @@ mock.module("@earendil-works/pi-coding-agent", () => ({
   createReadTool: () => ({}),
   createWriteTool: () => ({}),
   isBashToolResult: () => false,
+  isReadToolResult: (event: { toolName: string }) => event.toolName === "read",
   isToolCallEventType: () => false,
 }));
 mock.module("@earendil-works/pi-tui", () => ({
@@ -61,5 +62,11 @@ describe("Pi extension ownership parity", () => {
 
     expect(activeIds()).not.toContain("serena-pool");
     expect(manifest.disabled).toHaveProperty("serena-pool");
+  });
+
+  test("read-line-numbers is enrolled as a required active extension", () => {
+    const entry = manifest.active.find((extension) => extension.id === "read-line-numbers");
+    expect(entry).toBeDefined();
+    expect(entry?.required).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Introduces the `read-line-numbers` pi extension as the sole owner of model-facing line numbering for Read tool output. Centralizes numbering logic previously scattered/implicit, giving a single, testable extension point for downstream renderers.

## Test plan

- [x] Unit tests: 36/36 passing
- [x] E2E verified 2026-08-13 via specialists dispatcher chain
- [ ] CI green on this PR

## References

- Bead: specialists `unitAI-tpafe`
- Follow-up: specialists `unitAI-vttb3`

Note: branch also carries `ab8ab769` (thinking-gate fix, PR for `fix/xtrm-d4wfh-thinking-gate`); expected to disappear from this diff once that PR merges to main.