### PR TITLE
fix(pi-extensions): number REAL blank source lines (xtrm-oi5sg)

### DIFF
--- a/packages/pi-extensions/extensions/read-line-numbers/index.test.ts
+++ b/packages/pi-extensions/extensions/read-line-numbers/index.test.ts
@@ -62,6 +62,50 @@ describe("numberReadText", () => {
     const input = "[Line 5 is 60KB, exceeds 50KB limit. Use bash: sed -n '5p' /a/b.txt | head -c 51200]";
     expect(numberReadText(input, 1, true)).toBe(input);
   });
+
+  // --- Mandate Section 4 correctness: REAL blank source lines must be numbered ---
+
+  test("interior blank source line is numbered (case 3)", () => {
+    expect(numberReadText("foo\n\nbar", 1, false)).toBe("1 | foo\n2 | \n3 | bar");
+  });
+
+  test("multiple consecutive blank source lines are all numbered (case 4)", () => {
+    expect(numberReadText("foo\n\n\nbar", 1, false)).toBe("1 | foo\n2 | \n3 | \n4 | bar");
+  });
+
+  test("first selected line is blank at offset 137 (case 5)", () => {
+    expect(numberReadText("\nfoo", 137, false)).toBe("137 | \n138 | foo");
+  });
+
+  test("genuine last blank source line is numbered (case 6)", () => {
+    // File content "foo\n\n" — a blank last line followed by the trailing
+    // newline artifact. The blank line at row 2 must arrive numbered.
+    expect(numberReadText("foo\n\n", 1, false)).toBe("1 | foo\n2 | \n");
+  });
+
+  test("synthetic blank separator before a notice stays unnumbered (case 11)", () => {
+    const input = "foo\nbar\n\n[Showing lines 1-2 of 5000. Use offset=3 to continue.]";
+    const output = numberReadText(input, 1, true);
+    expect(output).toBe("1 | foo\n2 | bar\n\n[Showing lines 1-2 of 5000. Use offset=3 to continue.]");
+    // The separator must not carry a "3 |" prefix.
+    expect(output).not.toContain("3 | ");
+  });
+});
+
+describe("read-line-numbers extension (integration)", () => {
+  test("registered handler numbers a REAL interior blank line (case 16)", () => {
+    // Exercise the extension entry point end-to-end: registerExtension →
+    // tool_result dispatch → numberReadText. This is the same path Pi runs.
+    const result = runHandler({
+      type: "tool_result",
+      toolCallId: "call-blank",
+      toolName: "read",
+      input: { path: "/a/b.txt", offset: 10 },
+      content: [{ type: "text", text: "alpha\n\nbeta" }],
+      isError: false,
+    }) as { content: Array<{ text: string }> };
+    expect(result.content[0]?.text).toBe("10 | alpha\n11 | \n12 | beta");
+  });
 });
 
 describe("read-line-numbers extension", () => {

--- a/packages/pi-extensions/extensions/read-line-numbers/index.ts
+++ b/packages/pi-extensions/extensions/read-line-numbers/index.ts
@@ -29,9 +29,7 @@ function isSyntheticNotice(line: string): boolean {
 }
 
 function numberLines(lines: string[], startLine: number): string {
-  return lines
-    .map((line, index) => (line === "" ? line : `${startLine + index} | ${line}`))
-    .join("\n");
+  return lines.map((line, index) => `${startLine + index} | ${line}`).join("\n");
 }
 
 /**
@@ -40,8 +38,9 @@ function numberLines(lines: string[], startLine: number): string {
  * - `startLine` is the 1-based number of the first line (Pi's `offset`, default 1).
  * - `truncated` mirrors `details.truncation.truncated`: when true, Pi appended a
  *   trailing `\n\n[Showing lines ...]` notice that stays verbatim.
- * - Empty lines pass through unnumbered; their index still advances the count,
- *   so a trailing newline leaves the final empty line unnumbered.
+ * - Every REAL source line is numbered, including empty lines inside the range.
+ *   Only two structural blanks stay unnumbered: the trailing-newline artifact
+ *   (text ending in "\n") and the "\n\n" separator that precedes a Pi notice.
  */
 export function numberReadText(text: string, startLine: number, truncated: boolean): string {
   if (text.length === 0) return text;
@@ -50,9 +49,17 @@ export function numberReadText(text: string, startLine: number, truncated: boole
   if (isSyntheticNotice(lines[last])) {
     // Whole payload is a banner (firstLineExceedsLimit) — keep verbatim.
     if (last === 0) return lines[last];
-    // Trailing "\n\n[notice]": number the body, re-append the notice verbatim
-    // (the blank separator line stays unnumbered).
-    return numberLines(lines.slice(0, last), startLine) + "\n" + lines[last];
+    // Trailing "\n\n[notice]": lines[last-1] is the synthetic blank separator.
+    // Number lines[0..last-2] and re-append "\n\n" + notice verbatim so the
+    // separator stays unnumbered.
+    const body = lines.slice(0, last - 1);
+    return (body.length === 0 ? "" : numberLines(body, startLine)) + "\n\n" + lines[last];
+  }
+  if (lines[last] === "") {
+    // Trailing-newline artifact: the final "" is the terminator, not a line.
+    // Number lines[0..last-1] and re-append the trailing "\n".
+    const body = lines.slice(0, last);
+    return (body.length === 0 ? "" : numberLines(body, startLine)) + "\n";
   }
   return numberLines(lines, startLine);
 }


### PR DESCRIPTION
## Summary

Fixes a correctness bug in `packages/pi-extensions/extensions/read-line-numbers/index.ts` where `numberLines()` skipped numbering for any empty line. Under the mandate's **Section 4** correctness contract every REAL source line — including blanks inside the read window — must arrive at the model with its 1-based coordinate. Today, a mid-file blank source line reaches the model without a `N |` prefix, breaking citations and edit anchors.

**Before:** `source "foo\n\nbar"` -> model `1 | foo\n\n3 | bar` (mid blank missing)
**After:**  `source "foo\n\nbar"` -> model `1 | foo\n2 | \n3 | bar` ✓

### Scope

- Only `numberLines()` (line 31) and `numberReadText()` (line 46) changed.
- `isSyntheticNotice` and the notice-preservation path at line 46 are untouched — `SHOWING_NOTICE`, `USER_LIMIT_NOTICE`, and `FIRST_LINE_BANNER` still pass through verbatim.
- Two blanks stay structural and unnumbered by design:
  - the trailing-newline artifact (text ends in `"\n"`)
  - the `"\n\n"` separator that precedes a Pi notice
- No caller-side changes required; `numberReadText` now owns both artifact handlers.

### New tests (mandate Section 6)

| # | Case | Assertion |
|---|------|-----------|
| 3 | interior blank source line | `"foo\n\nbar"` -> `"1 | foo\n2 | \n3 | bar"` |
| 4 | multiple consecutive blanks | `"foo\n\n\nbar"` -> `"1 | foo\n2 | \n3 | \n4 | bar"` |
| 5 | first line blank at offset 137 | `"\nfoo"` -> `"137 | \n138 | foo"` |
| 6 | genuine last blank source line | `"foo\n\n"` -> `"1 | foo\n2 | \n"` |
| 11 | notice separator stays unnumbered | `"foo\nbar\n\n[Showing ...]"` -> body numbered, separator untouched |
| 16 | end-to-end via registered handler | `runHandler({ toolName: "read", offset: 10, text: "alpha\n\nbeta" })` -> `"10 | alpha\n11 | \n12 | beta"` |

### Regression proof

Reverting `index.ts` to the pre-fix `numberLines()` fails **5 of the 6 new tests** (cases 3, 4, 5, 6, 16). Case 11 renders identically under both implementations and now locks in the notice-separator behavior against future regressions.

Full local run:
```
bun test packages/pi-extensions/extensions/read-line-numbers/index.test.ts
 18 pass
 0 fail
 19 expect() calls
```

## Test plan

- [x] `bun test packages/pi-extensions/extensions/read-line-numbers/index.test.ts` — 18/18 pass
- [x] Regression: revert the numberLines fix -> 5 new tests fail; reapply -> all pass
- [x] `git diff --check` — clean
- [ ] CI green on `pr-review-gate`

## References

- Bead: xtrm-oi5sg
- Mandate: read-line-numbers Section 4 (correctness contract) and Section 6 (test cases 3, 4, 5, 6, 11, 16)
- File: `packages/pi-extensions/extensions/read-line-numbers/index.ts`