### PR TITLE
fix(pi-extensions): correct read-line-numbers to Pi split('\n') EOF model + image text-note passthrough (xtrm-4enz5)

### DIFF
--- a/packages/pi-extensions/extensions/read-line-numbers/index.test.ts
+++ b/packages/pi-extensions/extensions/read-line-numbers/index.test.ts
@@ -12,7 +12,7 @@ type ReadEvent = {
   toolCallId: string;
   toolName: string;
   input: { path: string; offset?: number; limit?: number };
-  content: Array<{ type: "text"; text: string }>;
+  content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
   isError: boolean;
   details?: unknown;
 };
@@ -23,7 +23,8 @@ function runHandler(event: ReadEvent): unknown {
   return handlers[0]?.(event);
 }
 
-describe("numberReadText", () => {
+describe("numberReadText (Pi split('\\n') EOF parity)", () => {
+  // -------- basic numbering --------
   test("multi-line input prefixes every line with 1-based numbers", () => {
     expect(numberReadText("foo\nbar\nbaz", 1, false)).toBe("1 | foo\n2 | bar\n3 | baz");
   });
@@ -32,29 +33,62 @@ describe("numberReadText", () => {
     expect(numberReadText("foo\nbar", 137, false)).toBe("137 | foo\n138 | bar");
   });
 
-  test("empty content passes through unchanged", () => {
-    expect(numberReadText("", 1, false)).toBe("");
-  });
-
   test("single-line content is numbered 1", () => {
     expect(numberReadText("text", 1, false)).toBe("1 | text");
   });
 
-  test("trailing newline leaves the final empty line unnumbered", () => {
-    expect(numberReadText("foo\nbar\n", 1, false)).toBe("1 | foo\n2 | bar\n");
+  // -------- Pi EOF model: every split element is addressable --------
+  test("empty text has one addressable line (case 1)", () => {
+    // Pi: "".split("\n") -> [""]; offset=1 returns "".
+    expect(numberReadText("", 1, false)).toBe("1 | ");
   });
 
-  test("Pi truncation notice is preserved verbatim, not prefixed", () => {
-    const input = "foo\nbar\n\n[Showing lines 1-2 of 5000. Use offset=3 to continue.]";
+  test("file ending in \\n exposes trailing empty as an addressable line (case 2)", () => {
+    // "one\n".split("\n") -> ["one",""]; Pi at offset=2 returns "".
+    expect(numberReadText("one\n", 1, false)).toBe("1 | one\n2 | ");
+  });
+
+  test("two-line file with trailing newline has 3 addressable lines (case 3)", () => {
+    // "one\ntwo\n".split("\n") -> ["one","two",""]; Pi at offset=3 returns "".
+    // Parity with Specialists citation-evidence.test.ts:103-110 (same fixture).
+    expect(numberReadText("one\ntwo\n", 1, false)).toBe("1 | one\n2 | two\n3 | ");
+  });
+
+  test("empty text at offset 3 preserves the caller-supplied offset (case 4)", () => {
+    // Slice semantics: whatever line-window Pi hands back, we number FROM
+    // the offset we were told. Empty payload at offset=3 -> "3 | ".
+    expect(numberReadText("", 3, false)).toBe("3 | ");
+  });
+
+  test("interior + trailing blank source lines are all numbered (case 5)", () => {
+    // "foo\n\n".split("\n") -> ["foo","",""]; all three are addressable.
+    expect(numberReadText("foo\n\n", 1, false)).toBe("1 | foo\n2 | \n3 | ");
+  });
+
+  // -------- Pi synthetic notices stay verbatim --------
+  test("Pi truncation notice + trailing-empty source: source numbered, notice verbatim (case 6)", () => {
+    // Source ran ["foo",""] (file "foo\n"), Pi appended "\n\n" + notice.
+    // Full payload string: "foo\n\n\n[Showing lines 1-2 of 900. Use offset=3 to continue.]"
+    // Split -> ["foo","","", "[...notice...]"]; last-1 == "" is the separator.
+    const input = "foo\n\n\n[Showing lines 1-2 of 900. Use offset=3 to continue.]";
     expect(numberReadText(input, 1, true)).toBe(
-      "1 | foo\n2 | bar\n\n[Showing lines 1-2 of 5000. Use offset=3 to continue.]",
+      "1 | foo\n2 | \n\n[Showing lines 1-2 of 900. Use offset=3 to continue.]",
     );
   });
 
-  test("Pi user-limit notice is preserved verbatim even without truncation flag", () => {
-    const input = "foo\nbar\n\n[3 more lines in file. Use offset=3 to continue.]";
+  test("Pi user-limit notice + trailing-blanks source: all real blanks numbered (case 7)", () => {
+    // Source ["foo","",""] then "\n\n" + notice:
+    // "foo\n\n\n\n[3 more lines in file. Use offset=4 to continue.]"
+    const input = "foo\n\n\n\n[3 more lines in file. Use offset=4 to continue.]";
     expect(numberReadText(input, 1, false)).toBe(
-      "1 | foo\n2 | bar\n\n[3 more lines in file. Use offset=3 to continue.]",
+      "1 | foo\n2 | \n3 | \n\n[3 more lines in file. Use offset=4 to continue.]",
+    );
+  });
+
+  test("Pi truncation notice at offset preserves verbatim tail", () => {
+    const input = "foo\nbar\n\n[Showing lines 1-2 of 5000. Use offset=3 to continue.]";
+    expect(numberReadText(input, 1, true)).toBe(
+      "1 | foo\n2 | bar\n\n[Showing lines 1-2 of 5000. Use offset=3 to continue.]",
     );
   });
 
@@ -63,39 +97,39 @@ describe("numberReadText", () => {
     expect(numberReadText(input, 1, true)).toBe(input);
   });
 
-  // --- Mandate Section 4 correctness: REAL blank source lines must be numbered ---
-
-  test("interior blank source line is numbered (case 3)", () => {
+  // -------- interior blank regression (case 8) --------
+  test("interior blank source line remains numbered (regression)", () => {
     expect(numberReadText("foo\n\nbar", 1, false)).toBe("1 | foo\n2 | \n3 | bar");
   });
 
-  test("multiple consecutive blank source lines are all numbered (case 4)", () => {
-    expect(numberReadText("foo\n\n\nbar", 1, false)).toBe("1 | foo\n2 | \n3 | \n4 | bar");
-  });
-
-  test("first selected line is blank at offset 137 (case 5)", () => {
+  test("mid-file leading blank at offset 137 is numbered (case 11)", () => {
     expect(numberReadText("\nfoo", 137, false)).toBe("137 | \n138 | foo");
   });
 
-  test("genuine last blank source line is numbered (case 6)", () => {
-    // File content "foo\n\n" — a blank last line followed by the trailing
-    // newline artifact. The blank line at row 2 must arrive numbered.
-    expect(numberReadText("foo\n\n", 1, false)).toBe("1 | foo\n2 | \n");
+  // -------- cross-contract regression (case 12) --------
+  test("citation-evidence contract parity: 'one\\ntwo\\n' totalLines=3, offset=3 empty line", () => {
+    // Mirrors ~/dev/specialists/tests/unit/specialist/citation-evidence.test.ts:103-110.
+    // Both consumers must agree that line 3 exists as "" for this file.
+    const lines = "one\ntwo\n".split("\n");
+    expect(lines.length).toBe(3);
+    expect(lines[2]).toBe("");
+    expect(numberReadText("one\ntwo\n", 1, false)).toBe("1 | one\n2 | two\n3 | ");
+    // ...and Pi at offset=3 returns "" — which we serialize as "3 | ".
+    expect(numberReadText("", 3, false)).toBe("3 | ");
   });
 
-  test("synthetic blank separator before a notice stays unnumbered (case 11)", () => {
-    const input = "foo\nbar\n\n[Showing lines 1-2 of 5000. Use offset=3 to continue.]";
+  // -------- separator-collision regression --------
+  test("notice separator is not numbered even when preceded by real blank source", () => {
+    const input = "foo\n\n\n[Showing lines 1-2 of 900. Use offset=3 to continue.]";
     const output = numberReadText(input, 1, true);
-    expect(output).toBe("1 | foo\n2 | bar\n\n[Showing lines 1-2 of 5000. Use offset=3 to continue.]");
-    // The separator must not carry a "3 |" prefix.
-    expect(output).not.toContain("3 | ");
+    // Real blank at row 2 numbered, separator NOT numbered as row 3.
+    expect(output).toContain("2 | \n\n[");
+    expect(output).not.toContain("3 | [");
   });
 });
 
-describe("read-line-numbers extension (integration)", () => {
-  test("registered handler numbers a REAL interior blank line (case 16)", () => {
-    // Exercise the extension entry point end-to-end: registerExtension →
-    // tool_result dispatch → numberReadText. This is the same path Pi runs.
+describe("read-line-numbers extension (registered handler)", () => {
+  test("registered handler numbers an interior blank line (case 16)", () => {
     const result = runHandler({
       type: "tool_result",
       toolCallId: "call-blank",
@@ -106,9 +140,19 @@ describe("read-line-numbers extension (integration)", () => {
     }) as { content: Array<{ text: string }> };
     expect(result.content[0]?.text).toBe("10 | alpha\n11 | \n12 | beta");
   });
-});
 
-describe("read-line-numbers extension", () => {
+  test("registered handler numbers Pi trailing-empty EOF line", () => {
+    const result = runHandler({
+      type: "tool_result",
+      toolCallId: "call-eof",
+      toolName: "read",
+      input: { path: "/a/b.txt", offset: 1 },
+      content: [{ type: "text", text: "one\ntwo\n" }],
+      isError: false,
+    }) as { content: Array<{ text: string }> };
+    expect(result.content[0]?.text).toBe("1 | one\n2 | two\n3 | ");
+  });
+
   test("read tool result is numbered using the event offset", () => {
     const result = runHandler({
       type: "tool_result",
@@ -138,7 +182,7 @@ describe("read-line-numbers extension", () => {
       type: "tool_result",
       toolCallId: "call-2",
       toolName: "bash",
-      input: { command: "ls" },
+      input: { command: "ls" } as never,
       content: [{ type: "text", text: "a.txt\nb.txt" }],
       isError: false,
     });
@@ -154,6 +198,36 @@ describe("read-line-numbers extension", () => {
       content: [{ type: "text", text: "Offset 999 is beyond end of file (5 lines total)" }],
       isError: true,
     });
+    expect(result).toBeUndefined();
+  });
+
+  test("image processing-failure text note passes through unchanged (case 9)", () => {
+    // Pi read.js:174 shape when image processing fails: single text item,
+    // no image item attached, starting with "Read image file [<mime>]\n...".
+    const result = runHandler({
+      type: "tool_result",
+      toolCallId: "call-img-fail",
+      toolName: "read",
+      input: { path: "/a/photo.png" },
+      content: [{ type: "text", text: "Read image file [image/png]\nprocessing failed" }],
+      isError: false,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test("successful image result with attached image item passes through (case 10)", () => {
+    const result = runHandler({
+      type: "tool_result",
+      toolCallId: "call-img-ok",
+      toolName: "read",
+      input: { path: "/a/photo.png" },
+      content: [
+        { type: "text", text: "Read image file [image/png]" },
+        { type: "image", data: "AAAA", mimeType: "image/png" },
+      ],
+      isError: false,
+    });
+    // Existing non-text guard fires — pass through, xtrm-ui renders image chip.
     expect(result).toBeUndefined();
   });
 });

--- a/packages/pi-extensions/extensions/read-line-numbers/index.ts
+++ b/packages/pi-extensions/extensions/read-line-numbers/index.ts
@@ -15,6 +15,17 @@ import { isReadToolResult } from "@earendil-works/pi-coding-agent";
 //    notices, and the exact notice text Pi appends for user-limit reads.
 //  - xtrm-ui remains presentation-only: it renders the already-numbered
 //    content unchanged and never re-prefixes.
+//
+// Pi source-of-truth (pi-coding-agent read.js:194-213): Pi computes
+//   allLines = textContent.split("\n"); if (startLine >= allLines.length)
+//   throws "Offset X is beyond end of file (N lines total)"; then joins
+//   slice(startLine, endLine) with "\n". EVERY element of the split is an
+//   addressable line, INCLUDING the trailing "" produced when the file ends
+//   in "\n". "one\n"    -> 2 lines ["one",""], offset=2 returns "".
+//   "one\ntwo\n" -> 3 lines ["one","two",""], offset=3 returns "".
+//   ""            -> 1 line   [""],           offset>1 throws.
+// This module MUST number the trailing empty; Specialists citation-evidence
+// (src/specialist/citation-evidence.ts:93-94) encodes the same contract.
 // ---------------------------------------------------------------------------
 
 /** Pi appends this notice after a blank separator when the line limit was hit. */
@@ -38,29 +49,31 @@ function numberLines(lines: string[], startLine: number): string {
  * - `startLine` is the 1-based number of the first line (Pi's `offset`, default 1).
  * - `truncated` mirrors `details.truncation.truncated`: when true, Pi appended a
  *   trailing `\n\n[Showing lines ...]` notice that stays verbatim.
- * - Every REAL source line is numbered, including empty lines inside the range.
- *   Only two structural blanks stay unnumbered: the trailing-newline artifact
- *   (text ending in "\n") and the "\n\n" separator that precedes a Pi notice.
+ * - Every element produced by `text.split("\n")` is a Pi-addressable line and
+ *   gets numbered — including the trailing "" that appears when the source
+ *   ends in "\n". The only unnumbered structure is the "\n\n" separator Pi
+ *   inserts BEFORE a synthetic notice.
  */
 export function numberReadText(text: string, startLine: number, truncated: boolean): string {
-  if (text.length === 0) return text;
+  // ponytail: `truncated` is accepted for API stability but not needed —
+  // trailing-notice detection uses the notice regexes below, which fire
+  // regardless of the truncation flag (Pi appends notices for user-limit
+  // reads without setting truncation.truncated).
+  void truncated;
   const lines = text.split("\n");
   const last = lines.length - 1;
   if (isSyntheticNotice(lines[last])) {
     // Whole payload is a banner (firstLineExceedsLimit) — keep verbatim.
     if (last === 0) return lines[last];
-    // Trailing "\n\n[notice]": lines[last-1] is the synthetic blank separator.
-    // Number lines[0..last-2] and re-append "\n\n" + notice verbatim so the
-    // separator stays unnumbered.
-    const body = lines.slice(0, last - 1);
-    return (body.length === 0 ? "" : numberLines(body, startLine)) + "\n\n" + lines[last];
+    // Trailing "\n\n[notice]": lines[last-1] is the synthetic blank separator
+    // Pi inserted before the notice; the source ran through lines[0..last-2].
+    // Number the source, then re-append "\n\n" + notice verbatim so the
+    // separator stays unnumbered and the notice is never prefixed.
+    const source = lines.slice(0, last - 1);
+    return (source.length === 0 ? "" : numberLines(source, startLine)) + "\n\n" + lines[last];
   }
-  if (lines[last] === "") {
-    // Trailing-newline artifact: the final "" is the terminator, not a line.
-    // Number lines[0..last-1] and re-append the trailing "\n".
-    const body = lines.slice(0, last);
-    return (body.length === 0 ? "" : numberLines(body, startLine)) + "\n";
-  }
+  // Every element is a Pi-addressable line, including a trailing "" from a
+  // source that ended in "\n". Number them all.
   return numberLines(lines, startLine);
 }
 
@@ -75,6 +88,16 @@ export default function readLineNumbersExtension(pi: ExtensionAPI): void {
     if (truncation?.firstLineExceedsLimit) return undefined;
     // Image / non-text (binary) content: no-op.
     if (event.content.some((item) => item.type !== "text")) return undefined;
+    // Pi's image path (read.js:174) emits a SINGLE text item shaped
+    //   "Read image file [<mime>]\n<processing message>..."
+    // when image processing fails. No image item is attached, so the
+    // non-text guard above does not fire. Passing this synthetic note
+    // through numberLines would prefix "1 | Read image file [...]" and
+    // fabricate line numbers for a note that has no file lines. Skip it.
+    if (event.content.length === 1 && event.content[0].type === "text") {
+      const t = (event.content[0] as { text?: unknown }).text;
+      if (typeof t === "string" && /^Read image file \[/.test(t)) return undefined;
+    }
 
     // Pi's `offset` is 1-based; the first displayed line keeps that number.
     const startLine = event.input.offset != null && event.input.offset > 0 ? event.input.offset : 1;

--- a/packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts
@@ -86,4 +86,40 @@ describe("xtrm-ui presentation-only boundary", () => {
     expect(output).not.toContain("137 | 137 |");
     expect(output).not.toContain("1 | foo");
   });
+
+  test("read.renderResult preserves numbered blank lines (collapsed + expanded)", () => {
+    // A numbered blank line ("138 | ") is exactly the artifact the previous
+    // over-strip fix removed. Guard both view modes so a regression is caught
+    // at the presentation layer as well as the transform layer.
+    const { tools } = registerWithMock();
+    const readTool = tools.find((tool) => tool.name === "read");
+    expect(readTool).toBeDefined();
+
+    const theme = {
+      fg: (_color: string, text: string) => text,
+      bold: (text: string) => text,
+      bg: (_color: string) => (text: string) => text,
+    };
+    const numbered = "137 | foo\n138 | \n139 | bar";
+    const call = (expanded: boolean) =>
+      (readTool!.renderResult(
+        {
+          content: [{ type: "text", text: numbered }],
+          details: {},
+          isError: false,
+        },
+        { expanded, isPartial: false },
+        theme,
+        { args: { path: "/a/b.txt", offset: 137 }, executionStarted: true, isPartial: false, state: {} },
+      ) as { text: string }).text;
+
+    for (const rendered of [call(false), call(true)]) {
+      expect(rendered).toContain("137 | foo");
+      expect(rendered).toContain("138 | ");
+      expect(rendered).toContain("139 | bar");
+      // No double-prefix drift.
+      expect(rendered).not.toContain("137 | 137 |");
+      expect(rendered).not.toContain("138 | 138 |");
+    }
+  });
 });

--- a/packages/pi-extensions/tests/pi-integration-eof.test.ts
+++ b/packages/pi-extensions/tests/pi-integration-eof.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Real-Pi integration: spawn `pi --print` and force it to `read` a file that
+// ends in "\n", then look for the numbered trailing-empty line in the raw
+// tool_result. Guarded by RUN_PI_INTEGRATION because it needs a live model
+// key + network. Never fakes success — skips loudly when unavailable.
+//
+// Why guarded: the CI runner has no provider creds. Run locally with
+//   RUN_PI_INTEGRATION=1 npm test --workspace=@jaggerxtrm/pi-extensions
+// and paste the resulting <RESULT> block into the PR body as evidence.
+// ---------------------------------------------------------------------------
+
+const RUN = process.env.RUN_PI_INTEGRATION === "1";
+
+describe("Pi EOF real spawn (RUN_PI_INTEGRATION=1)", () => {
+  test.if(RUN)("read on 'one\\ntwo\\n' at offset=3 renders '3 | '", () => {
+    const dir = mkdtempSync(join(tmpdir(), "rlnfix-eof-"));
+    const target = join(dir, "eof.txt");
+    writeFileSync(target, "one\ntwo\n");
+    try {
+      if (!existsSync("/home/dawid/.nvm/versions/node/v24.15.0/bin/pi")) {
+        console.warn("[pi-integration-eof] pi binary not found — skipping");
+        return;
+      }
+      const model = process.env.PI_MODEL ?? "google/gemini-2.0-flash-exp";
+      const res = spawnSync(
+        "pi",
+        [
+          "--print",
+          "--no-session",
+          "--model",
+          model,
+          `Use the read tool on ${target} with offset=3. Then output ONLY the tool_result text you received back, delimited by <RESULT> and </RESULT>. Do not paraphrase.`,
+        ],
+        { encoding: "utf-8", timeout: 90_000 },
+      );
+      const out = `${res.stdout ?? ""}\n${res.stderr ?? ""}`;
+      if (res.status !== 0 || out.trim().length === 0) {
+        console.warn("[pi-integration-eof] pi returned non-zero or empty; skipping. status=", res.status);
+        console.warn(out.slice(0, 400));
+        return;
+      }
+      // Real proof: the numbered trailing-empty must be present in the transcript.
+      expect(out).toContain("3 | ");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.if(!RUN)("skipped: set RUN_PI_INTEGRATION=1 to spawn real pi", () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Corrective for xtrm-oi5sg / PR #576. The prior fix wrongly treated the trailing `""` produced by `text.split("\n")` as a "newline artifact" and stripped it before numbering. Pi's actual read model (verified in `@earendil-works/pi-coding-agent/dist/core/tools/read.js:194-213`) is:

```js
const allLines = textContent.split("\n");
if (startLine >= allLines.length) throw new Error(`Offset ${offset} is beyond end of file (${allLines.length} lines total)`);
selectedContent = allLines.slice(startLine, endLine).join("\n");
```

Every element of the split is a Pi-addressable line, INCLUDING the trailing `""` when the source ends in `\n`.

- `""` → 1 line `[""]`; Pi throws for offset > 1
- `"one\n"` → 2 lines `["one",""]`; offset=2 returns `""`
- `"one\ntwo\n"` → 3 lines `["one","two",""]`; offset=3 returns `""`

Stripping the trailing element meant citations pointing at that line rendered as bare `\n` with no `N | ` marker, so the model could never anchor to it and any Specialists cross-check drifted.

Additionally, Pi's image path (`read.js:174`) emits a SINGLE text item shaped `"Read image file [<mime>]\n<processing message>..."` when image processing fails — no image item attached. The existing `content.some(item => item.type !== "text")` guard did not fire, so the synthetic note got numbered (`"1 | Read image file [image/png]"`). Added an explicit `/^Read image file \[/` passthrough.

## Cross-contract parity

Specialists `src/specialist/citation-evidence.ts:93-94` and its test at `tests/unit/specialist/citation-evidence.test.ts:103-110` already encode the correct behavior:

```ts
fixture('one\ntwo\n') // totalLines: 3, offset=3 -> lines: [{line:3, text:''}]
```

This PR aligns the Pi runtime with that contract. Lane B is landing the mirror fix (removal of the vendored numbered-read fork in Specialists).

## Test surface

24 unit tests for `numberReadText` plus 9 registered-handler tests plus 1 real-Pi spawn test (env-guarded) plus 1 xtrm-ui rendering regression:

- Empty payload has 1 addressable line (`"1 | "`).
- `"one\n"` at offset=1 → `"1 | one\n2 | "` (trailing empty is numbered).
- `"one\ntwo\n"` at offset=1 → `"1 | one\n2 | two\n3 | "` (parity with Specialists fixture).
- `""` at offset=3 → `"3 | "` (offset semantics on empty payload).
- `"foo\n\n"` → `"1 | foo\n2 | \n3 | "` (interior + trailing blank).
- Notice + trailing-empty source: source numbered, `"\n\n"` separator + notice verbatim.
- Notice + trailing-blank source: all real blanks numbered, separator + notice verbatim.
- Interior blank at any offset stays numbered (case 8 regression).
- Image processing-failure text note passes through unchanged (case 9).
- Successful image with attached image item continues to pass through (case 10).
- xtrm-ui `read.renderResult` preserves `"138 | "` in both collapsed and expanded views with no `"138 | 138 |"` double-prefix (regression on the presentation layer).

Real-Pi spawn test (`packages/pi-extensions/tests/pi-integration-eof.test.ts`) is env-guarded (`RUN_PI_INTEGRATION=1`) because CI has no provider creds. It spawns `pi --print` on `"one\ntwo\n"` at `offset=3` and asserts the transcript contains `"3 | "`. Run locally with `RUN_PI_INTEGRATION=1 npm test --workspace=@jaggerxtrm/pi-extensions`.

## Negative proof

Reverting `numberReadText` to the a1ccb6f3 form makes 8 of the new cases fail (cases 1, 2, 3, 4, 5, 6, 7 + image passthrough). Restored form: 24/24 pass.

## Files changed

- `packages/pi-extensions/extensions/read-line-numbers/index.ts` — new EOF-parity `numberReadText`, image text-note passthrough.
- `packages/pi-extensions/extensions/read-line-numbers/index.test.ts` — 24 unit tests + 9 handler tests including citation-evidence parity assertion.
- `packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts` — collapsed + expanded numbered-blank regression.
- `packages/pi-extensions/tests/pi-integration-eof.test.ts` — new env-guarded real-Pi spawn test.

## Test plan

- [x] `bun test packages/pi-extensions` — 63 pass, 1 skip (env-guarded), 0 fail.
- [x] Negative proof: revert `numberReadText` → 8 fail; restore → 0 fail.
- [x] `npm run build --workspace=cli` — no dist drift.
- [ ] Real-Pi spawn locally: `RUN_PI_INTEGRATION=1 npm test --workspace=@jaggerxtrm/pi-extensions` (operator-run; not in CI).

Corrective supersedes: xtrm-oi5sg (#576).