### PR TITLE
fix(pi-extensions): reset thinking follow-toggle latch per session (xtrm-6ggil)

### DIFF
--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -1513,6 +1513,12 @@ export default function xtrmUiExtension(pi: ExtensionAPI): void {
   };
 
   pi.on("session_start", async (_event, ctx) => {
+    // thinkingFollowsToggle is process-lifetime module state (the extension
+    // factory is cached per process and the prototype patch installs once).
+    // Reset it per session so a stale latch from an earlier session cannot
+    // flip the first thinking block of a fresh session to the expanded raw
+    // trace (xtrm-6ggil).
+    thinkingFollowsToggle = false;
     setPrefs(loadPrefs(ctx.sessionManager.getEntries() as Array<MaybeCustomEntry>));
     refresh(ctx);
   });


### PR DESCRIPTION
## Root cause

`thinkingFollowsToggle` (packages/pi-extensions/extensions/xtrm-ui/index.ts) is **process-lifetime** module state, not per-session state:

- pi caches the extension factory per process (core/extensions/loader.js `extensionCache`, keyed by cwd+generation) and the `PATCHED_ASSISTANT_MESSAGE` marker on the shared `AssistantMessageComponent` prototype prevents re-patching, so the module-level latch is evaluated once per process.
- Once ANY session in the process renders a thinking block with `hideThinkingBlock === true` (persisted Ctrl+T hide), the patch latches `thinkingFollowsToggle = true` forever.
- A later in-process session boundary (`/new`, resume, fork) whose `hideThinkingBlock` is `false` then computes `compact = hideThinkingBlock === true || !thinkingFollowsToggle = false` and renders the FIRST thinking block via `buildExpandedThinkingBlock` — the full raw trace dumped into the transcript.
- Reload (kill + reattach / new pi launch) re-evaluates the module in a fresh process → latch `false` → compact rows. That is exactly why the render "fixes itself" after reload.

Verified with a repro that runs the real patch closure and the real `AssistantMessageComponent` from the installed pi dist (script: /tmp/xtrm-think-repro/repro.ts): session A with hide=true → collapsed; toggle show; in-process session B with hide=false → **EXPANDED raw trace** (bug); after this fix → **collapsed**.

## Fix

Reset `thinkingFollowsToggle = false` in the `session_start` handler. pi emits `session_start` for startup/new/resume/fork/reload — every session boundary — restoring the documented intent: compact previews per session until the user toggles.

## Verification

- bun test extensions/xtrm-ui/handlers.test.ts: 3 pass
- Full package suite: 62 pass / 1 skip; the single failure (xtprompt legacy-branding check) is a pre-existing cwd-dependent path bug, reproduced on the clean tree
- Repro script flips from BUG REPRODUCED → no after the fix

## Non-goals (per bead)

- No numbering changes (read-line-numbers untouched)
- No release/tag/version bump
- No scope expansion beyond xtrm-ui rendering