### PR TITLE
fix(pi-extensions): re-render existing thinking rows on Ctrl+T toggle (xtrm-5vi8u)

### DIFF
--- a/packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts
@@ -27,6 +27,8 @@ mock.module("@earendil-works/pi-tui", () => ({
 mock.module("@mariozechner/pi-coding-agent", () => ({}));
 
 const xtrmUiExtension = (await import("./index.ts")).default;
+const { createPatchedUpdateContent } = await import("./index.ts");
+const { buildThinkingRecap } = await import("./index.ts");
 
 type RegisteredTool = {
   name: string;
@@ -121,5 +123,120 @@ describe("xtrm-ui presentation-only boundary", () => {
       expect(rendered).not.toContain("137 | 137 |");
       expect(rendered).not.toContain("138 | 138 |");
     }
+  });
+
+  test("thinking toggle re-renders existing thinking rows (xtrm-5vi8u)", () => {
+    // Simulates pi's AssistantMessageComponent: updateContent stores the
+    // message as lastMessage, and setHideThinkingBlock re-renders from it.
+    type ContentBlock = { type: string; text?: string; thinking?: string };
+    const latch = { followsToggle: false };
+    const rendered: Array<{ hide: boolean; content: ContentBlock[] }> = [];
+    const component = {
+      hideThinkingBlock: false,
+      lastMessage: undefined as { content: ContentBlock[] } | undefined,
+      updateContent(message: { content: ContentBlock[] }) {
+        this.lastMessage = message;
+        rendered.push({ hide: this.hideThinkingBlock, content: message.content });
+      },
+    };
+    component.updateContent = createPatchedUpdateContent(
+      component.updateContent as never,
+      {
+        label: (text: string) => text,
+        recap: (text: string) => text,
+        hint: (text: string) => text,
+        sep: " · ",
+      },
+      latch,
+    );
+    const setHideThinkingBlock = (hide: boolean) => {
+      component.hideThinkingBlock = hide;
+      if (component.lastMessage) component.updateContent(component.lastMessage as never);
+    };
+    const trace = "First line of the thinking trace\nDEEP_SECRET_DETAIL_XYZ not in recap";
+    const message = { content: [{ type: "thinking", thinking: trace }] };
+
+    // First render with pi's initial hideThinkingBlock=false: compact preview
+    // until the user toggles (xtrm-6ggil latch behavior). The recap shows the
+    // first substantive line only; the deep detail must stay hidden.
+    component.updateContent(message as never);
+    expect(rendered.at(-1)!.content[0]).toMatchObject({ type: "text" });
+    const first = rendered.at(-1)!.content[0].text!;
+    expect(first).toContain("(Ctrl+T to expand)");
+    expect(first).not.toContain("DEEP_SECRET_DETAIL_XYZ");
+
+    // Toggle ON: rows stay collapsed (still following pi's hide state).
+    setHideThinkingBlock(true);
+    expect(rendered.at(-1)!.content[0].text!).toContain("(Ctrl+T to expand)");
+
+    // Toggle OFF: the EXISTING thinking row must flip to the expanded trace.
+    setHideThinkingBlock(false);
+    const expanded = rendered.at(-1)!.content[0].text!;
+    expect(expanded).toContain("(Ctrl+T to collapse)");
+    expect(expanded).toContain("DEEP_SECRET_DETAIL_XYZ");
+
+    // Toggle ON again: collapses back.
+    setHideThinkingBlock(true);
+    expect(rendered.at(-1)!.content[0].text!).toContain("(Ctrl+T to expand)");
+
+    // lastMessage must keep the RAW thinking block so every toggle re-enters
+    // the patch with original content (the bug: it held the converted rows).
+    expect(component.lastMessage!.content[0]).toMatchObject({ type: "thinking", thinking: trace });
+  });
+
+  test("thinking first-render latch: fresh session stays compact until a real toggle (xtrm-6ggil)", () => {
+    type ContentBlock = { type: string; text?: string; thinking?: string };
+    const trace = "A long trace line that must not leak on the first render";
+    const plainStyle = {
+      label: (text: string) => text,
+      recap: (text: string) => text,
+      hint: (text: string) => text,
+      sep: " · ",
+    };
+    const run = (hideThinkingBlock: boolean, latch: { followsToggle: boolean }) => {
+      const rendered: ContentBlock[][] = [];
+      const component = {
+        hideThinkingBlock,
+        lastMessage: undefined as { content: ContentBlock[] } | undefined,
+        updateContent(message: { content: ContentBlock[] }) {
+          this.lastMessage = message;
+          rendered.push(message.content);
+        },
+      };
+      component.updateContent = createPatchedUpdateContent(component.updateContent as never, plainStyle, latch);
+      component.updateContent({ content: [{ type: "thinking", thinking: trace }] } as never);
+      return rendered[0]![0].text ?? "";
+    };
+
+    // Fresh session latch (followsToggle=false): first thinking block renders
+    // compact even when pi's hide state is false.
+    expect(run(false, { followsToggle: false })).toContain("(Ctrl+T to expand)");
+    // ...and stays compact when pi's hide state is true.
+    expect(run(true, { followsToggle: false })).toContain("(Ctrl+T to expand)");
+  });
+
+  test("thinking patch passes non-thinking messages through untouched", () => {
+    type ContentBlock = { type: string; text?: string };
+    const plainStyle = {
+      label: (text: string) => text,
+      recap: (text: string) => text,
+      hint: (text: string) => text,
+      sep: " · ",
+    };
+    const seen: Array<{ content: ContentBlock[] }> = [];
+    const component = {
+      hideThinkingBlock: false,
+      lastMessage: undefined as { content: ContentBlock[] } | undefined,
+      updateContent(message: { content: ContentBlock[] }) {
+        this.lastMessage = message;
+        seen.push(message);
+      },
+    };
+    component.updateContent = createPatchedUpdateContent(component.updateContent as never, plainStyle, {
+      followsToggle: false,
+    });
+    const message = { content: [{ type: "text", text: "plain reply" }] };
+    component.updateContent(message as never);
+    expect(seen).toEqual([message]);
   });
 });

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -133,6 +133,7 @@ type AssistantMessageLike = { content?: AssistantContentBlock[] };
 type PatchableAssistantMessage = {
 	hideThinkingBlock?: boolean;
 	hiddenThinkingLabel?: string;
+	lastMessage?: AssistantMessageLike;
 	updateContent?: (message: AssistantMessageLike) => void;
 };
 
@@ -272,7 +273,59 @@ function resolvePiCodingAgentEntryPath(): string {
 // Pi's initial hideThinkingBlock is false (thinking expanded). We default to
 // compact previews until the user toggles; once a real toggle is visible
 // (a component with hideThinkingBlock === true), follow pi's toggle exactly.
-let thinkingFollowsToggle = false;
+// The latch is process-lifetime module state (pi caches the extension factory
+// per process); session_start resets it per session (xtrm-6ggil). The patch
+// factory takes the holder as a parameter so tests run with an isolated latch.
+export type ThinkingToggleLatch = { followsToggle: boolean };
+const thinkingToggleLatch: ThinkingToggleLatch = { followsToggle: false };
+
+/**
+ * Wraps AssistantMessageComponent.updateContent so thinking blocks render as
+ * XTRM preview rows. Exported for unit tests: pass the original updateContent,
+ * a style, and (optionally) an isolated latch.
+ */
+export function createPatchedUpdateContent(
+	updateContent: (message: AssistantMessageLike) => void,
+	style: ThinkingRowStyle,
+	latch: ThinkingToggleLatch = thinkingToggleLatch,
+): (this: PatchableAssistantMessage, message: AssistantMessageLike) => void {
+	return function patchedUpdateContent(this: PatchableAssistantMessage, message: AssistantMessageLike) {
+		if (Array.isArray(message.content)) {
+			const hasThinking = message.content.some((block) => block.type === "thinking" && block.thinking?.trim());
+			if (hasThinking) {
+				if (this.hideThinkingBlock) latch.followsToggle = true;
+				const compact = this.hideThinkingBlock === true || !latch.followsToggle;
+				const content = message.content.flatMap((block, index) => {
+					if (block.type !== "thinking" || !block.thinking?.trim()) return [block];
+					const row = compact
+						? buildCollapsedThinkingRow(buildThinkingRecap(block.thinking), block.thinking.length, style)
+						: buildExpandedThinkingBlock(block.thinking, style);
+					// Text blocks render even when pi's hideThinkingBlock branch is
+					// active (a "thinking" block would be swallowed and replaced by the
+					// empty hidden label). Append an invisible single-line block (a
+					// zero-width space survives pi's text trim and renders as a blank
+					// line) when a visible text/thinking block follows — mirroring pi's
+					// Spacer(1) after thinking runs; none before tool-call blocks.
+					const hasVisibleAfter = message.content
+						.slice(index + 1)
+						.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
+					return hasVisibleAfter
+						? [{ type: "text", text: row }, { type: "text", text: "\u200b" }]
+						: [{ type: "text", text: row }];
+				});
+				updateContent.call(this, { ...message, content });
+				// Pi stores lastMessage and re-renders from it in
+				// setHideThinkingBlock()/invalidate()/setHiddenThinkingLabel().
+				// Restore the RAW message so those re-renders re-enter this patch
+				// with the original thinking blocks; otherwise the toggle renders
+				// the already-converted rows and existing thinking rows never flip.
+				this.lastMessage = message;
+				return;
+			}
+		}
+		updateContent.call(this, message);
+	};
+}
 
 async function installThinkingPreviewPatch(): Promise<void> {
 	const entryPath = resolvePiCodingAgentEntryPath();
@@ -298,36 +351,7 @@ async function installThinkingPreviewPatch(): Promise<void> {
 	if (!proto?.updateContent || proto[PATCHED_ASSISTANT_MESSAGE]) return;
 
 	const updateContent = proto.updateContent;
-	proto.updateContent = function patchedUpdateContent(this: PatchableAssistantMessage, message: AssistantMessageLike) {
-		if (Array.isArray(message.content)) {
-			const hasThinking = message.content.some((block) => block.type === "thinking" && block.thinking?.trim());
-			if (hasThinking) {
-				if (this.hideThinkingBlock) thinkingFollowsToggle = true;
-				const compact = this.hideThinkingBlock === true || !thinkingFollowsToggle;
-				const content = message.content.flatMap((block, index) => {
-					if (block.type !== "thinking" || !block.thinking?.trim()) return [block];
-					const row = compact
-						? buildCollapsedThinkingRow(buildThinkingRecap(block.thinking), block.thinking.length, style)
-						: buildExpandedThinkingBlock(block.thinking, style);
-					// Text blocks render even when pi's hideThinkingBlock branch is
-					// active (a "thinking" block would be swallowed and replaced by the
-					// empty hidden label). Append an invisible single-line block (a
-					// zero-width space survives pi's text trim and renders as a blank
-					// line) when a visible text/thinking block follows — mirroring pi's
-					// Spacer(1) after thinking runs; none before tool-call blocks.
-					const hasVisibleAfter = message.content
-						.slice(index + 1)
-						.some((c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
-					return hasVisibleAfter
-						? [{ type: "text", text: row }, { type: "text", text: "\u200b" }]
-						: [{ type: "text", text: row }];
-				});
-				updateContent.call(this, { ...message, content });
-				return;
-			}
-		}
-		updateContent.call(this, message);
-	};
+	proto.updateContent = createPatchedUpdateContent(updateContent, style);
 	proto[PATCHED_ASSISTANT_MESSAGE] = true;
 }
 
@@ -1513,12 +1537,12 @@ export default function xtrmUiExtension(pi: ExtensionAPI): void {
   };
 
   pi.on("session_start", async (_event, ctx) => {
-    // thinkingFollowsToggle is process-lifetime module state (the extension
+    // thinkingToggleLatch is process-lifetime module state (the extension
     // factory is cached per process and the prototype patch installs once).
     // Reset it per session so a stale latch from an earlier session cannot
     // flip the first thinking block of a fresh session to the expanded raw
     // trace (xtrm-6ggil).
-    thinkingFollowsToggle = false;
+    thinkingToggleLatch.followsToggle = false;
     setPrefs(loadPrefs(ctx.sessionManager.getEntries() as Array<MaybeCustomEntry>));
     refresh(ctx);
   });


### PR DESCRIPTION
## Problem

`setHideThinkingBlock` never re-renders existing thinking rows. `installThinkingPreviewPatch` wraps `AssistantMessageComponent.updateContent`: it converts thinking blocks to text rows and calls pi's original `updateContent` with the **converted** content. Pi stores `this.lastMessage = <converted>`; its `setHideThinkingBlock()` / `invalidate()` / `setHiddenThinkingLabel()` re-render from `lastMessage`, so the patch sees no thinking blocks and passes through unchanged. Result: Ctrl+T toggles only affect **future** thinking blocks, never already-rendered rows.

## Root cause

The patch's conversion pollutes `lastMessage`, pi's re-render source of truth, with the converted content. The latch (per-session reset, xtrm-6ggil/eefbdd0f) only fires on a component's first raw `updateContent`, which is why toggles appeared dead.

## Fix (smallest correct)

After calling the original `updateContent` with converted content, restore `this.lastMessage = <raw message>`. Every pi-driven re-render (`setHideThinkingBlock`, `invalidate`, `setHiddenThinkingLabel`, `setOutputPad`) then re-enters the patch with original thinking blocks and re-converts per the current hide state. Toggle behavior for existing rows is now: collapse ↔ expand, round-trippable.

The latch semantics are unchanged: first thinking render of a session stays compact until a real toggle (xtrm-6ggil).

## Testability

Extracted the inline patch into an exported `createPatchedUpdateContent(updateContent, style, latch)` factory (the latch is a holder object so tests run with an isolated latch). No pi dist imports needed in tests.

## Tests (handlers.test.ts)

- **xtrm-5vi8u toggle re-render**: first render collapsed (recap only, deep detail hidden) → toggle ON stays collapsed → toggle OFF flips the EXISTING row to the expanded trace → toggle ON collapses again; `lastMessage` keeps the raw thinking block throughout.
- **first-render latch (xtrm-6ggil guard)**: fresh latch renders compact with both pi hide states.
- **passthrough**: non-thinking messages are passed through untouched.

## Verification

- Repro test failed on pre-fix code (toggle OFF rendered the collapsed row), passes post-fix.
- `bun test packages/pi-extensions/tests/ packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts`: 24 pass / 1 skip / 0 fail.
- tsc error count vs main: 9 == 9 (all pre-existing module-resolution noise; deps not installed in worktree).
- Scope: only `packages/pi-extensions/extensions/xtrm-ui/{index.ts, handlers.test.ts}`. No version bump, no release, no numbering changes.