### PR TITLE
fix(hooks): pre-push chain exit status on success

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,13 +10,15 @@ HOOKS_DIR=$(dirname "$0")
 if [ -x "$HOOKS_DIR/.security-pipeline-baseline" ]; then
     echo "$REFS" | "$HOOKS_DIR/.security-pipeline-baseline" "$@"
     rc=$?
-    [ $rc -ne 0 ] && exit $rc
+
+    if [ $rc -ne 0 ]; then exit $rc; fi
 fi
 
 if [ -x "$HOOKS_DIR/pre-push.local" ]; then
     echo "$REFS" | "$HOOKS_DIR/pre-push.local" "$@"
     rc=$?
-    [ $rc -ne 0 ] && exit $rc
+
+    if [ $rc -ne 0 ]; then exit $rc; fi
 fi
 
 # --- BEGIN custom: beads/dolt sync before push ---
@@ -31,7 +33,8 @@ if [ -x "$HOOKS_DIR/pre-push.bd-sync" ]; then
         echo "$REFS" | "$HOOKS_DIR/pre-push.bd-sync" "$@"
     fi
     rc=$?
-    [ $rc -ne 0 ] && exit $rc
+
+    if [ $rc -ne 0 ]; then exit $rc; fi
 fi
 # --- END custom ---
 


### PR DESCRIPTION
The custom hook chain ended with `[ $rc -ne 0 ] && exit $rc` — on success the false `[` test becomes the script's last command, so the hook exits 1 and **every push fails**. Replaced with the `if` idiom (`if [ $rc -ne 0 ]; then exit $rc; fi`), which returns 0 on success and still aborts on sync failure. Same latent pattern existed in xtrm/.beads hooks (fixed there too); this is the versioned source.