### PR TITLE
fix(pi-extensions): resolve xtrm-ui hidden-thinking empty-row on session start (xtrm-3tus9)

### DIFF
--- a/packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts
@@ -29,6 +29,7 @@ mock.module("@mariozechner/pi-coding-agent", () => ({}));
 const xtrmUiExtension = (await import("./index.ts")).default;
 const { createPatchedUpdateContent } = await import("./index.ts");
 const { buildThinkingRecap } = await import("./index.ts");
+const { createThinkingPreviewInstallState } = await import("./index.ts");
 
 type RegisteredTool = {
   name: string;
@@ -238,5 +239,87 @@ describe("xtrm-ui presentation-only boundary", () => {
     const message = { content: [{ type: "text", text: "plain reply" }] };
     component.updateContent(message as never);
     expect(seen).toEqual([message]);
+  });
+
+  test("thinking preview install retries on session start after factory-time failure (xtrm-3tus9)", async () => {
+    // The extension factory runs during Pi resource loading, before the TUI
+    // controller constructor calls initTheme(); reading theme.js's theme proxy
+    // then throws "Theme not initialized". The install must be retried from
+    // session_start (which fires after initTheme) before the first message.
+    let attempts = 0;
+    const state = createThinkingPreviewInstallState(async () => {
+      attempts++;
+      if (attempts === 1) throw new Error("Theme not initialized. Call initTheme() first.");
+    });
+
+    // Factory-time warm-up fails: patch is NOT installed.
+    await state.ensureInstalled().catch(() => undefined);
+    expect(state.isInstalled()).toBe(false);
+    expect(attempts).toBe(1);
+
+    // session_start retry (post-initTheme) succeeds.
+    await state.ensureInstalled();
+    expect(state.isInstalled()).toBe(true);
+    expect(attempts).toBe(2);
+
+    // Subsequent session starts no-op; no double patch install.
+    await state.ensureInstalled();
+    expect(attempts).toBe(2);
+  });
+
+  test("first message with thinking renders collapsed row once install completes (xtrm-3tus9)", async () => {
+    // Covers the reported state: patch not yet installed when the session
+    // starts (factory-time attempt failed), then session_start ensures the
+    // install; the FIRST thinking-emitting message must render the collapsed
+    // row instead of Pi's unpatched empty hidden label.
+    type ContentBlock = { type: string; text?: string; thinking?: string };
+    const plainStyle = {
+      label: (text: string) => text,
+      recap: (text: string) => text,
+      hint: (text: string) => text,
+      sep: " · ",
+    };
+    let installs = 0;
+    const state = createThinkingPreviewInstallState(async () => {
+      installs++;
+      if (installs === 1) throw new Error("Theme not initialized. Call initTheme() first.");
+    });
+
+    // Factory-time warm-up fails (theme not initialized yet).
+    await state.ensureInstalled().catch(() => undefined);
+    expect(state.isInstalled()).toBe(false);
+
+    // session_start: ensure the patch before the first message renders.
+    await state.ensureInstalled();
+    expect(state.isInstalled()).toBe(true);
+
+    // First assistant message carries a thinking block: hideThinkingBlock is
+    // true (settings), latch follows pi's hide state only after a real toggle,
+    // so the message must render the compact collapsed row.
+    const rendered: ContentBlock[][] = [];
+    const latch = { followsToggle: false };
+    const component = {
+      hideThinkingBlock: true,
+      lastMessage: undefined as { content: ContentBlock[] } | undefined,
+      updateContent(message: { content: ContentBlock[] }) {
+        this.lastMessage = message;
+        rendered.push(message.content);
+      },
+    };
+    component.updateContent = createPatchedUpdateContent(component.updateContent as never, plainStyle, latch);
+    component.updateContent({
+      content: [{ type: "thinking", thinking: "First line of the thinking trace\nDEEP_SECRET_DETAIL_XYZ not in recap" }],
+    } as never);
+
+    const row = rendered[0]![0].text ?? "";
+    expect(row).toContain("Thinking...");
+    expect(row).toContain("(Ctrl+T to expand)");
+    expect(row).not.toContain("DEEP_SECRET_DETAIL_XYZ");
+    // lastMessage keeps the RAW thinking block so toggle re-renders re-enter
+    // the patch with original content (xtrm-5vi8u).
+    expect(component.lastMessage!.content[0]).toMatchObject({
+      type: "thinking",
+      thinking: "First line of the thinking trace\nDEEP_SECRET_DETAIL_XYZ not in recap",
+    });
   });
 });

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -355,6 +355,42 @@ async function installThinkingPreviewPatch(): Promise<void> {
 	proto[PATCHED_ASSISTANT_MESSAGE] = true;
 }
 
+/**
+ * Single-flight wrapper around the thinking-preview prototype patch install.
+ * The extension factory runs during Pi's resource loading, BEFORE the TUI
+ * controller constructor calls initTheme(); the theme module (theme.js)
+ * exports a Proxy that throws "Theme not initialized" until then, so the
+ * factory-time attempt can fail. session_start fires after the controller is
+ * constructed, so awaiting ensureInstalled() there retries a failed install
+ * before the first assistant message renders (xtrm-3tus9). Exported for unit
+ * tests: pass an install function and an isolated state holder.
+ */
+export function createThinkingPreviewInstallState(install: () => Promise<void>): {
+  ensureInstalled: () => Promise<void>;
+  isInstalled: () => boolean;
+} {
+  let installed = false;
+  let current: Promise<void> | null = null;
+  return {
+    ensureInstalled() {
+      if (installed) return Promise.resolve();
+      if (current) return current;
+      current = install().then(
+        () => {
+          installed = true;
+          current = null;
+        },
+        (error: unknown) => {
+          current = null;
+          throw error;
+        },
+      );
+      return current;
+    },
+    isInstalled: () => installed,
+  };
+}
+
 type ToolExecutionComponentCtor = {
   prototype: {
     getRenderShell?: () => "default" | "self";
@@ -1509,7 +1545,11 @@ function registerXtrmUiTools(pi: ExtensionAPI, getPrefs: () => XtrmUiPrefs): voi
 // ============================================================================
 
 export default function xtrmUiExtension(pi: ExtensionAPI): void {
-  void installThinkingPreviewPatch().catch(() => undefined);
+  const thinkingPreviewInstall = createThinkingPreviewInstallState(installThinkingPreviewPatch);
+  // Warm-up attempt. It can fail while Pi's theme is not initialized yet (the
+  // factory runs during resource loading, before initTheme()); session_start
+  // below retries via ensureInstalled() before the first message renders.
+  void thinkingPreviewInstall.ensureInstalled().catch(() => undefined);
   void installExternalToolFramePatch().catch(() => undefined);
 
   // Keep collapsed thinking rows to one line: the recap is truncated to the
@@ -1544,6 +1584,12 @@ export default function xtrmUiExtension(pi: ExtensionAPI): void {
     // trace (xtrm-6ggil).
     thinkingToggleLatch.followsToggle = false;
     setPrefs(loadPrefs(ctx.sessionManager.getEntries() as Array<MaybeCustomEntry>));
+    // Await the prototype patch BEFORE the first message can render: a
+    // factory-time install failure (theme not initialized yet) must be
+    // retried here, after Pi's theme controller has run initTheme(), or the
+    // first thinking block renders through Pi's unpatched empty hidden label
+    // (xtrm-3tus9). No-op once installed.
+    await thinkingPreviewInstall.ensureInstalled().catch(() => undefined);
     refresh(ctx);
   });
 

--- a/packages/pi-extensions/extensions/xtrm-ui/index.ts
+++ b/packages/pi-extensions/extensions/xtrm-ui/index.ts
@@ -355,6 +355,17 @@ async function installThinkingPreviewPatch(): Promise<void> {
 	proto[PATCHED_ASSISTANT_MESSAGE] = true;
 }
 
+let retryFailureWarned = false;
+function warnRetryFailedOnce(error: unknown): void {
+  if (retryFailureWarned) return;
+  retryFailureWarned = true;
+  const message = error instanceof Error ? error.message : String(error);
+  // stderr so it surfaces even when Pi's UI eats stdout.
+  process.stderr.write(
+    `[xtrm-ui] thinking-preview install still failing at session_start: ${message.slice(0, 300)}\n`,
+  );
+}
+
 /**
  * Single-flight wrapper around the thinking-preview prototype patch install.
  * The extension factory runs during Pi's resource loading, BEFORE the TUI
@@ -364,6 +375,12 @@ async function installThinkingPreviewPatch(): Promise<void> {
  * constructed, so awaiting ensureInstalled() there retries a failed install
  * before the first assistant message renders (xtrm-3tus9). Exported for unit
  * tests: pass an install function and an isolated state holder.
+ *
+ * @internal — factored out and exported for unit-test isolation only.
+ * `handlers.test.ts` constructs isolated install states per test to avoid
+ * process-lifetime state bleed. Not part of the public extension API and
+ * not intended for use outside this package's tests. Do not import from
+ * downstream extensions.
  */
 export function createThinkingPreviewInstallState(install: () => Promise<void>): {
   ensureInstalled: () => Promise<void>;
@@ -1589,7 +1606,17 @@ export default function xtrmUiExtension(pi: ExtensionAPI): void {
     // retried here, after Pi's theme controller has run initTheme(), or the
     // first thinking block renders through Pi's unpatched empty hidden label
     // (xtrm-3tus9). No-op once installed.
-    await thinkingPreviewInstall.ensureInstalled().catch(() => undefined);
+    await thinkingPreviewInstall.ensureInstalled().catch((error: unknown) => {
+      // If BOTH the factory warm-up AND this session_start retry fail, the
+      // prototype patch never installs and Pi's own hideThinkingBlock branch
+      // renders an empty label instead of the collapsed one-liner. Surface
+      // once per process so the operator sees a signal (silent .catch() is
+      // exactly the regression this whole PR closes) — never throw here,
+      // session_start must not fail because of this.
+      if (!thinkingPreviewInstall.isInstalled()) {
+        warnRetryFailedOnce(error);
+      }
+    });
     refresh(ctx);
   });
 


### PR DESCRIPTION
## Symptom

On a fresh Pi session with `hideThinkingBlock: true` (settings.json), the FIRST assistant message containing `thinking` blocks renders as blank rows where the XTRM collapsed one-liner (`Thinking... · <recap> · (Ctrl+T to expand)`) must appear. Reload / session switch self-heals; subsequent sessions render correctly. Regression blocks v0.11.5 patch release (PR #580/#581 claim "thinking-block renders correctly on session start" — same code path, still broken).

## Root cause (confirmed by live repro + instrumentation on this host)

Pi's extension loader runs the xtrm-ui **factory during resource loading** (`dist/core/resource-loader.js:411` → `loadExtensionsCached` → jiti `loadExtensionModule`), which happens **before** the interactive-mode constructor calls `initTheme()` (`dist/modes/interactive/interactive-mode.js:393` → `dist/modes/interactive/theme/theme.js:666`). The theme module exports `theme` as a **Proxy** (`theme.js:640-650`) that throws `Theme not initialized. Call initTheme() first.` until `globalThis[Symbol.for("@earendil-works/pi-coding-agent:theme")]` is set.

`xtrmUiExtension` fired `void installThinkingPreviewPatch().catch(() => undefined)` (index.ts:1512): the two dynamic imports resolve (4–32 ms, jiti-cache dependent), then `themeMod.theme` access throws while the theme is not yet initialized. The `.catch(() => undefined)` swallows it → the `AssistantMessageComponent.prototype.updateContent` patch is **never installed for the process lifetime** → every thinking block renders through Pi's unpatched `hideThinkingBlock` branch, which shows `hiddenThinkingLabel` — and `applyThinkingChrome` sets it to `""` (index.ts:608-610) → **empty line**.

Instrumented runs (temp agent dir, worktree package):
```
[DEBUG-XTRM3] t0=... themeKey=false
[DEBUG-XTRM3] theme import ok in 4ms themeKey=false
[DEBUG-XTRM3] install FAILED: Error: Theme not initialized. Call initTheme() first.
```
Deterministic with the operator's full package set (warm jiti cache makes the import beat `initTheme`); my minimal-config repro passed only when the import happened to take >initTheme time (32 ms).

## Fix (candidate A)

Hoist install behind a single-flight `createThinkingPreviewInstallState` wrapper (module scope) and **await it in the `session_start` handler before `refresh(ctx)`**:

- Factory keeps the warm-up attempt (`void ensureInstalled().catch(...)` — succeeds when the theme is already initialized, e.g. warm module caches).
- `session_start` fires **after** the TUI controller constructor has run `initTheme()` (`bindExtensions` is invoked from `rebindCurrentSession`, post-construction), so a factory-time failure is retried here — guaranteed before the first assistant message renders.
- Idempotent: `ensureInstalled()` no-ops once installed; concurrent calls share the in-flight promise.

Why not candidate B (message transformer): the patch target is the component prototype; the empty row is produced by Pi's own `updateContent` before the patch exists — a transformer can't retrofit already-created components. The awaited `session_start` handler is safe: Pi's `ExtensionRunner.emit` awaits handlers (`dist/core/extensions/runner.js:586`).

## Preservation

- **#580 (xtrm-6ggil)**: `thinkingToggleLatch.followsToggle = false` remains the first statement of `session_start`.
- **#581 (xtrm-5vi8u)**: `createPatchedUpdateContent` untouched (lastMessage raw restore intact). Verified live: Ctrl+T → expanded trace, Ctrl+T → collapsed row.

## Tests

Two new tests in `handlers.test.ts`:
1. `thinking preview install retries on session start after factory-time failure (xtrm-3tus9)` — install fails once (theme not initialized), session_start retry succeeds, subsequent calls no-op.
2. `first message with thinking renders collapsed row once install completes (xtrm-3tus9)` — factory-time failure → install ensured → first thinking message renders `Thinking... · recap · (Ctrl+T to expand)`, deep detail hidden, raw `lastMessage` preserved.

Both **fail on `main` HEAD** (function does not exist) and **pass on this branch**.

## Live smoke (this host, worktree package via `PI_CODING_AGENT_DIR` temp agent dir — settings.json untouched)

Fresh session, `hideThinkingBlock: true`, `deepseek-v4-flash --thinking high`, first prompt "think about foo, then output DONE":
```
 › think about foo, then output DONE
 Thinking... · The user wants me to "think about foo" and then output DONE. This seems like a trivial request. Let me think about it... · 294 (Ctrl+T to expand)
 DONE
```
Repeated on a second fresh session — same correct output. Pre-fix, both runs showed blank rows instead.

## Validation

- `bun test packages/pi-extensions/extensions/xtrm-ui/handlers.test.ts` — 8 pass (2 new).
- `bun test packages/pi-extensions/` — 68 pass, 1 skip, 0 fail.
- `bun test cli/` — fail-set identical to `main` (248 pre-existing env failures, zero new, zero fixed; `xtrm-ui built-in tool rendering` failure pre-exists on main).
- Live smoke above.

Refs: xtrm-6ggil (#580), xtrm-5vi8u (#581).