### PR TITLE
docs(skills/starting-and-resuming-work): cross-ref keep-alive monitor recipe (xtrm-lf4ri)

### DIFF
--- a/.xtrm/skills/default/starting-and-resuming-work/SKILL.md
+++ b/.xtrm/skills/default/starting-and-resuming-work/SKILL.md
@@ -149,6 +149,17 @@ deliberately excludes your own panes, keeps you responsive without burning turns
 scheduled wakeup keeps firing with nothing to do, the monitor is misconfigured — fix the
 signal rather than raising the frequency.
 
+For a delegated **specialist** job — especially `--keep-alive` roles where
+`sp result --wait` hangs on the `waiting` state — compose `Monitor` around the live
+follow stream (`sp log --job <id> -f --json` or `sp feed <id> --json`, never
+`sp forensic` which is post-hoc only) and filter for every terminal matcher:
+`done | error | stale | complete | completed | waiting | failed | cancelled | crashed`
+plus `event_family=error`. Deduplicate on transition so a chatty job does not fill
+your inbox. Full recipe with a runnable filter and the "silence is not success"
+alternation lives in
+`using-specialists/references/monitoring.md` § *Event-Driven Monitoring For
+Keep-Alive Specialists*.
+
 ## Rulings and reviews: state the constraint, not the mechanism
 
 When you direct another agent, describe the invariant to satisfy and the failure to


### PR DESCRIPTION
## Summary

11-line pointer in \`starting-and-resuming-work\` skill naming the recipe location and \"silence is not success\" alternation for coordinators hitting the \"\`sp result --wait\` hangs on \`waiting\`\" pattern.

Recipe itself stays in \`using-specialists/references/monitoring.md\` § \"Event-Driven Monitoring For Keep-Alive Specialists\" (landed via specialists PR #269 + core PR #586). No content duplication.

## Test plan

- [x] grep confirms new paragraph present
- [x] Referenced section exists in target skill (verified: landed in PR #586, now in main)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)