### PR TITLE
feat(hooks): board-audit — bd exporter + PR-checkpoint adapter (xtrm-7yj7h) [design review]

### DIFF
--- a/.githooks/board-audit-core
+++ b/.githooks/board-audit-core
@@ -1,0 +1,753 @@
+#!/usr/bin/env bash
+# board-audit — bd board/work-package exporter + merged-PR audit bundle.
+#
+# Audit mode (backwards compatible):
+#   board-audit [--no-pr] [--epic <id>]
+#
+# Structured export mode:
+#   board-audit --export (--open | --all | --epic <id> | --bead <id>)
+#
+# Export mode performs exactly one canonical `bd export --all` acquisition and
+# derives deterministic, lossless work-package projections from that snapshot.
+# User-visible artifacts default to the repository-local `.xtrm/board-audit/`
+# tree so they can be versioned and shared through GitHub.
+
+set -euo pipefail
+
+NO_PR=0
+EPIC=""
+BEAD=""
+EXPORT_MODE=0
+EXPORT_SCOPE=""
+OUTPUT_DIR=""
+FROM_RAW=""
+
+_usage() {
+  cat <<'EOF'
+board-audit — Beads work-package export and board audit bundle
+
+Audit mode:
+  board-audit [--no-pr] [--epic <id>]
+
+Structured export mode:
+  board-audit --export --open
+  board-audit --export --all
+  board-audit --export --epic <id>
+  board-audit --export --bead <id>
+
+Flags:
+  --no-pr             Audit mode only: skip merged-PR export.
+  --epic <id>         Audit mode: scope audit to epic subtree.
+                      Export mode: export the selected epic/subtree as one package.
+  --bead <id>         Export mode only: export selected bead/subtree as one package.
+  --export            Emit structured JSON snapshot projections; no audit prompt/PRs.
+  --open              Export mode: all non-terminal work packages.
+  --all               Export mode: all work packages, including closed-only packages.
+  --output-dir <path> Override artifact root. Relative paths resolve from repo root.
+                      Default: .xtrm/board-audit (or BOARD_AUDIT_OUTDIR).
+  --from-raw <path>   Export mode only: derive packages from an existing
+                      bd export --all acquisition instead of acquiring a new
+                      one. Keeps one canonical acquisition per snapshot when
+                      multiple derivations share it.
+  -h, --help          Show this help.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-pr) NO_PR=1; shift ;;
+    --export) EXPORT_MODE=1; shift ;;
+    --open) EXPORT_SCOPE="open"; shift ;;
+    --all) EXPORT_SCOPE="all"; shift ;;
+    --epic)
+      [ $# -ge 2 ] || { echo "error: --epic needs a bead id" >&2; exit 2; }
+      EPIC="$2"; shift 2 ;;
+    --epic=*) EPIC="${1#--epic=}"; shift ;;
+    --bead)
+      [ $# -ge 2 ] || { echo "error: --bead needs a bead id" >&2; exit 2; }
+      BEAD="$2"; shift 2 ;;
+    --bead=*) BEAD="${1#--bead=}"; shift ;;
+    --output-dir)
+      [ $# -ge 2 ] || { echo "error: --output-dir needs a path" >&2; exit 2; }
+      OUTPUT_DIR="$2"; shift 2 ;;
+    --output-dir=*) OUTPUT_DIR="${1#--output-dir=}"; shift ;;
+    --from-raw)
+      [ $# -ge 2 ] || { echo "error: --from-raw needs a path" >&2; exit 2; }
+      FROM_RAW="$2"; shift 2 ;;
+    --from-raw=*) FROM_RAW="${1#--from-raw=}"; shift ;;
+    -h|--help) _usage; exit 0 ;;
+    *) echo "error: unknown arg '$1'" >&2; _usage >&2; exit 2 ;;
+  esac
+done
+
+if [ "$EXPORT_MODE" -eq 1 ]; then
+  [ "$NO_PR" -eq 0 ] || { echo "error: --no-pr is audit-mode only" >&2; exit 2; }
+  [ -z "$EPIC" ] || [ -z "$BEAD" ] || { echo "error: --epic and --bead are mutually exclusive" >&2; exit 2; }
+  if [ -n "$FROM_RAW" ] && [ ! -f "$FROM_RAW" ]; then
+    echo "error: --from-raw acquisition not found: $FROM_RAW" >&2
+    exit 2
+  fi
+  if [ -n "$EPIC" ]; then
+    [ -z "$EXPORT_SCOPE" ] || { echo "error: --epic cannot be combined with --open/--all" >&2; exit 2; }
+    EXPORT_SCOPE="epic"
+  elif [ -n "$BEAD" ]; then
+    [ -z "$EXPORT_SCOPE" ] || { echo "error: --bead cannot be combined with --open/--all" >&2; exit 2; }
+    EXPORT_SCOPE="bead"
+  fi
+  [ -n "$EXPORT_SCOPE" ] || EXPORT_SCOPE="open"
+else
+  [ -z "$BEAD" ] || { echo "error: --bead requires --export" >&2; exit 2; }
+  [ -z "$EXPORT_SCOPE" ] || { echo "error: --open/--all require --export" >&2; exit 2; }
+  [ -z "$FROM_RAW" ] || { echo "error: --from-raw requires --export" >&2; exit 2; }
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: not inside a git working tree" >&2
+  exit 1
+fi
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+REPO_SLUG="$(basename "$REPO_ROOT")"
+GH_REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+[ -n "$GH_REPO" ] || GH_REPO="$REPO_SLUG"
+
+for cmd in bd python3; do
+  command -v "$cmd" >/dev/null || { echo "error: '$cmd' not on PATH" >&2; exit 1; }
+done
+if [ "$EXPORT_MODE" -eq 0 ]; then
+  command -v gh >/dev/null || { echo "error: 'gh' not on PATH" >&2; exit 1; }
+fi
+
+ARTIFACT_ROOT="$OUTPUT_DIR"
+[ -n "$ARTIFACT_ROOT" ] || ARTIFACT_ROOT="${BOARD_AUDIT_OUTDIR:-.xtrm/board-audit}"
+case "$ARTIFACT_ROOT" in
+  /*) OUTDIR="$ARTIFACT_ROOT" ;;
+  *) OUTDIR="$REPO_ROOT/$ARTIFACT_ROOT" ;;
+esac
+mkdir -p "$OUTDIR"
+TODAY="$(date +%Y-%m-%d)"
+
+_export_all() {
+  local out="$1"
+  bd export --all -o "$out" >/dev/null 2>&1 || bd export --all > "$out"
+}
+
+# ----------------------------------------------------------------------
+# Structured export mode
+# ----------------------------------------------------------------------
+if [ "$EXPORT_MODE" -eq 1 ]; then
+  SNAPSHOT_DIR="$OUTDIR/exports/export-$(date +%Y%m%dT%H%M%S)"
+  RAW_OUT="$SNAPSHOT_DIR/raw-beads.jsonl"
+  PACKAGES_DIR="$SNAPSHOT_DIR/work-packages"
+  MANIFEST_OUT="$SNAPSHOT_DIR/manifest.json"
+  mkdir -p "$PACKAGES_DIR"
+
+  echo "→ acquiring canonical Beads snapshot with bd export --all..."
+  if [ -n "$FROM_RAW" ]; then
+    cp -f "$FROM_RAW" "$RAW_OUT"
+    echo "→ reusing provided acquisition: $FROM_RAW"
+  else
+    _export_all "$RAW_OUT"
+  fi
+  [ -s "$RAW_OUT" ] || echo "warning: Beads export is empty" >&2
+  BD_VERSION="$(bd version 2>/dev/null | head -n1 || true)"
+
+  python3 - "$RAW_OUT" "$PACKAGES_DIR" "$MANIFEST_OUT" "$GH_REPO" "$EXPORT_SCOPE" "$EPIC" "$BEAD" "$BD_VERSION" <<'PY'
+import hashlib
+import json
+import os
+import re
+import sys
+import unicodedata
+from collections import defaultdict
+from datetime import datetime, timezone
+
+raw_path, packages_dir, manifest_path, repo, scope, epic_id, bead_id, bd_version = sys.argv[1:]
+TERMINAL = {"closed", "done", "completed", "cancelled", "canceled", "tombstone", "deleted"}
+PARENT_TYPES = {"parent-child", "parent", "child-of"}
+
+
+def read_rows(path):
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read().strip()
+    if not text:
+        return []
+    if text.startswith("[") or text.startswith("{"):
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, list):
+                return [r for r in parsed if isinstance(r, dict)]
+            if isinstance(parsed, dict):
+                for key in ("issues", "beads", "records"):
+                    if isinstance(parsed.get(key), list):
+                        return [r for r in parsed[key] if isinstance(r, dict)]
+                return [parsed]
+        except json.JSONDecodeError:
+            pass
+    rows = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def entity_id(value):
+    """ID of an issue-like value, used for explicit parent/discovery fields."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("id", "issue_id", "bead_id", "parent_id", "target_id", "target"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    return None
+
+
+def dependency_target(value):
+    """Target of a Beads dependency record.
+
+    Current Beads Dependency has its own surrogate row `id`; the target is
+    `depends_on_id`. Never interpret the edge row ID as the issue target.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("depends_on_id", "depends_on_issue_id", "target_id", "target", "parent_id", "bead_id"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    return None
+
+
+def relation_type(value):
+    if not isinstance(value, dict):
+        return "unknown"
+    return str(value.get("type") or value.get("dependency_type") or value.get("relation_type") or value.get("kind") or "unknown")
+
+
+def collect_relations(row):
+    rid = str(row.get("id"))
+    out = []
+    for key in ("deps", "dependencies", "relations"):
+        vals = row.get(key)
+        if not isinstance(vals, list):
+            continue
+        for value in vals:
+            target = dependency_target(value)
+            if target:
+                out.append({
+                    "source": rid,
+                    "target": target,
+                    "type": relation_type(value),
+                    "source_field": key,
+                    "raw": value,
+                })
+    for key in ("parents", "parent"):
+        vals = row.get(key)
+        if vals is None:
+            continue
+        if not isinstance(vals, list):
+            vals = [vals]
+        for value in vals:
+            target = entity_id(value)
+            if target:
+                typ = relation_type(value)
+                if typ == "unknown":
+                    typ = "parent-child"
+                out.append({"source": rid, "target": target, "type": typ, "source_field": key, "raw": value})
+    discovered = row.get("discovered_from")
+    if discovered:
+        vals = discovered if isinstance(discovered, list) else [discovered]
+        for value in vals:
+            target = entity_id(value)
+            if target:
+                out.append({"source": rid, "target": target, "type": "discovered-from", "source_field": "discovered_from", "raw": value})
+    return out
+
+
+def explicit_parent_ids(row, relations):
+    rid = str(row.get("id"))
+    out = []
+    for key in ("parents", "parent"):
+        vals = row.get(key)
+        if vals is None:
+            continue
+        if not isinstance(vals, list):
+            vals = [vals]
+        for value in vals:
+            parent = entity_id(value)
+            if parent and parent not in out:
+                out.append(parent)
+    for rel in relations:
+        if rel["source"] == rid and rel["type"] in PARENT_TYPES and rel["target"] not in out:
+            out.append(rel["target"])
+    return out
+
+
+def slug(title):
+    value = unicodedata.normalize("NFKD", str(title or "untitled"))
+    value = value.encode("ascii", "ignore").decode("ascii").lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value).strip("-")
+    return value[:96].rstrip("-") or "untitled"
+
+
+def canonical_bytes(obj):
+    return (json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+rows = read_rows(raw_path)
+by_id = {str(row["id"]): row for row in rows if row.get("id") is not None}
+all_relations = []
+for row in by_id.values():
+    all_relations.extend(collect_relations(row))
+
+# Match Beads' own tree semantics: explicit parent-child edges first; if an
+# issue has no known explicit parent, fall back to immediate dotted-ID ancestry
+# (`parent.1`, `parent.1.2`) when that parent exists in the snapshot.
+parents = {}
+children = defaultdict(list)
+derived_dotted_links = []
+for rid, row in by_id.items():
+    ps = [p for p in explicit_parent_ids(row, all_relations) if p != rid]
+    known_explicit = [p for p in ps if p in by_id]
+    if not known_explicit and "." in rid:
+        dotted_parent = rid.rsplit(".", 1)[0]
+        if dotted_parent in by_id and dotted_parent != rid and dotted_parent not in ps:
+            ps.append(dotted_parent)
+            derived_dotted_links.append({"child": rid, "parent": dotted_parent})
+    parents[rid] = ps
+    for parent in ps:
+        children[parent].append(rid)
+for parent in children:
+    children[parent] = sorted(set(children[parent]))
+
+
+def is_terminal(row):
+    return str(row.get("status", "")).lower() in TERMINAL
+
+
+def ancestors(rid):
+    seen = set()
+    stack = list(parents.get(rid, []))
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        stack.extend(parents.get(current, []))
+    return seen
+
+
+def descendants(rid):
+    seen = set()
+    stack = list(children.get(rid, []))
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        stack.extend(children.get(current, []))
+    return seen
+
+
+def highest_known_root(rid):
+    current = rid
+    seen = {rid}
+    while True:
+        known = sorted(p for p in parents.get(current, []) if p in by_id and p not in seen)
+        if not known:
+            return current
+        current = known[0]
+        seen.add(current)
+
+
+if scope in {"epic", "bead"}:
+    requested = epic_id if scope == "epic" else bead_id
+    if requested not in by_id:
+        raise SystemExit(f"error: bead '{requested}' not found in bd export --all snapshot")
+    roots = [requested]
+    selected = {requested} | descendants(requested)
+    context_only = ancestors(requested)
+elif scope == "all":
+    selected = set(by_id)
+    context_only = set()
+    roots = sorted({highest_known_root(rid) for rid in selected})
+else:
+    active = {rid for rid, row in by_id.items() if not is_terminal(row)}
+    selected = set(active)
+    context_only = set()
+    for rid in active:
+        context_only |= {a for a in ancestors(rid) if a in by_id and a not in active}
+    selected |= context_only
+    roots = sorted({highest_known_root(rid) for rid in active})
+
+package_entries = []
+written_ids = set()
+
+
+def build_hierarchy(rid, package_ids, trail=None):
+    trail = set(trail or ())
+    if rid in trail:
+        return {"id": rid, "cycle": True, "children": []}
+    trail.add(rid)
+    kids = [child for child in children.get(rid, []) if child in package_ids]
+    return {"id": rid, "children": [build_hierarchy(child, package_ids, trail) for child in sorted(kids)]}
+
+
+for root in roots:
+    if scope in {"epic", "bead"}:
+        package_ids = {root} | {d for d in descendants(root) if d in selected}
+        package_ids |= {a for a in context_only if a in by_id}
+    else:
+        package_ids = ({root} | descendants(root)) & selected
+    if not package_ids:
+        continue
+
+    package_relations = []
+    external_relations = []
+    dangling = []
+    for rel in all_relations:
+        if rel["source"] not in package_ids:
+            continue
+        if rel["target"] in package_ids:
+            package_relations.append(rel)
+        else:
+            enriched = dict(rel)
+            enriched["target_present_in_snapshot"] = rel["target"] in by_id
+            if rel["target"] in by_id:
+                enriched["target_title"] = by_id[rel["target"]].get("title")
+            else:
+                dangling.append({"source": rel["source"], "target": rel["target"], "type": rel["type"]})
+            external_relations.append(enriched)
+
+    multiple_parents = [
+        {"id": rid, "parents": sorted(p for p in parents.get(rid, []) if p in by_id)}
+        for rid in sorted(package_ids)
+        if len([p for p in parents.get(rid, []) if p in by_id]) > 1
+    ]
+    issue_map = {
+        rid: {
+            "selection_state": "context-only" if rid in context_only else "selected",
+            "source": by_id[rid],
+        }
+        for rid in sorted(package_ids)
+    }
+    package_dotted_links = [
+        link for link in derived_dotted_links
+        if link["child"] in package_ids and link["parent"] in package_ids
+    ]
+
+    payload = {
+        "schema_version": "xtrm.board-audit.work-package.v1",
+        "repository": repo,
+        "scope": scope,
+        "root_id": root,
+        "root_title": by_id.get(root, {}).get("title"),
+        "issues": issue_map,
+        "hierarchy": build_hierarchy(root, package_ids),
+        "relations": sorted(package_relations, key=lambda r: (str(r["source"]), str(r["type"]), str(r["target"]))),
+        "external_relations": sorted(external_relations, key=lambda r: (str(r["source"]), str(r["type"]), str(r["target"]))),
+        "diagnostics": {
+            "dangling_relations": sorted(dangling, key=lambda r: (r["source"], r["type"], r["target"])),
+            "multiple_parent_nodes": multiple_parents,
+            "derived_dotted_parent_links": sorted(package_dotted_links, key=lambda x: (x["parent"], x["child"])),
+        },
+    }
+    digest = hashlib.sha256(canonical_bytes(payload)).hexdigest()
+    payload["content_sha256"] = digest
+    filename = f"{root}__{slug(by_id.get(root, {}).get('title'))}.json"
+    path = os.path.join(packages_dir, filename)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2, sort_keys=True)
+        f.write("\n")
+    written_ids |= package_ids
+    package_entries.append({
+        "root_id": root,
+        "title": by_id.get(root, {}).get("title"),
+        "file": f"work-packages/{filename}",
+        "issue_count": len(package_ids),
+        "selected_issue_count": sum(1 for rid in package_ids if rid not in context_only),
+        "context_only_issue_count": sum(1 for rid in package_ids if rid in context_only),
+        "content_sha256": digest,
+    })
+
+raw_sha = hashlib.sha256(open(raw_path, "rb").read()).hexdigest()
+manifest = {
+    "schema_version": "xtrm.board-audit.snapshot-manifest.v1",
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "repository": repo,
+    "bd_version": bd_version,
+    "source": {
+        "command": "bd export --all",
+        "raw_file": "raw-beads.jsonl",
+        "raw_sha256": raw_sha,
+        "raw_record_count": len(by_id),
+    },
+    "selection": {
+        "scope": scope,
+        "requested_id": epic_id or bead_id or None,
+        "selected_record_count": len(selected - context_only),
+        "context_only_record_count": len(context_only),
+    },
+    "packages": sorted(package_entries, key=lambda p: p["root_id"]),
+    "diagnostics": {
+        "unpackaged_selected_ids": sorted(selected - written_ids),
+        "unknown_parent_refs": sorted({p for rid in by_id for p in parents.get(rid, []) if p not in by_id}),
+        "derived_dotted_parent_links": sorted(derived_dotted_links, key=lambda x: (x["parent"], x["child"])),
+    },
+}
+with open(manifest_path, "w", encoding="utf-8") as f:
+    json.dump(manifest, f, ensure_ascii=False, indent=2, sort_keys=True)
+    f.write("\n")
+print(f"exported {len(package_entries)} work package(s), {len(selected - context_only)} selected bead(s), {len(context_only)} context-only ancestor(s)")
+PY
+
+  echo "✓ structured export: $SNAPSHOT_DIR"
+  echo "  raw:      $RAW_OUT"
+  echo "  manifest: $MANIFEST_OUT"
+  echo "  packages: $PACKAGES_DIR"
+  if [[ "$SNAPSHOT_DIR" == "$REPO_ROOT/"* ]]; then
+    echo "  git add:  ${SNAPSHOT_DIR#$REPO_ROOT/}"
+  fi
+  exit 0
+fi
+
+# ----------------------------------------------------------------------
+# Legacy audit mode — retained for compatibility.
+# ----------------------------------------------------------------------
+AUDIT_DIR="$OUTDIR/audits/audit-$(date +%Y%m%dT%H%M%S)"
+mkdir -p "$AUDIT_DIR"
+BD_OUT="$AUDIT_DIR/beads.jsonl"
+PR_OUT="$AUDIT_DIR/prs.md"
+PROMPT_OUT="$AUDIT_DIR/audit-prompt.md"
+STATE_OUT="$AUDIT_DIR/current-state.md"
+BUNDLE_OUT="$AUDIT_DIR/audit-bundle.md"
+RAW_AUDIT_OUT="$AUDIT_DIR/raw-beads.jsonl"
+
+echo "→ acquiring canonical Beads snapshot with bd export --all..."
+_export_all "$RAW_AUDIT_OUT"
+
+python3 - "$RAW_AUDIT_OUT" "$BD_OUT" "$EPIC" <<'PY'
+import json
+import sys
+
+raw_path, out_path, epic = sys.argv[1:]
+TERMINAL = {"closed", "done", "completed", "cancelled", "canceled", "tombstone", "deleted"}
+PARENT_TYPES = {"parent-child", "parent", "child-of"}
+
+
+def rows(path):
+    text = open(path, encoding="utf-8").read().strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, list):
+            return parsed
+        if isinstance(parsed, dict):
+            for key in ("issues", "beads", "records"):
+                if isinstance(parsed.get(key), list):
+                    return parsed[key]
+    except json.JSONDecodeError:
+        pass
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def entity_id(value):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("id", "issue_id", "bead_id", "parent_id", "target_id", "target"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    return None
+
+
+def dependency_target(value):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("depends_on_id", "depends_on_issue_id", "target_id", "target", "parent_id", "bead_id"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    return None
+
+
+def parent_ids(row):
+    out = []
+    vals = row.get("parents", row.get("parent", []))
+    if not isinstance(vals, list):
+        vals = [vals] if vals else []
+    for value in vals:
+        parent = entity_id(value)
+        if parent and parent not in out:
+            out.append(parent)
+    for key in ("deps", "dependencies", "relations"):
+        vals = row.get(key, [])
+        if not isinstance(vals, list):
+            continue
+        for value in vals:
+            if not isinstance(value, dict):
+                continue
+            typ = str(value.get("type") or value.get("dependency_type") or value.get("relation_type") or "")
+            if typ in PARENT_TYPES:
+                parent = dependency_target(value)
+                if parent and parent not in out:
+                    out.append(parent)
+    return out
+
+
+records = [row for row in rows(raw_path) if isinstance(row, dict) and row.get("id") is not None]
+by_id = {str(row["id"]): row for row in records}
+children = {rid: [] for rid in by_id}
+for rid, row in by_id.items():
+    ps = [p for p in parent_ids(row) if p != rid]
+    known_explicit = [p for p in ps if p in by_id]
+    if not known_explicit and "." in rid:
+        dotted_parent = rid.rsplit(".", 1)[0]
+        if dotted_parent in by_id and dotted_parent != rid and dotted_parent not in ps:
+            ps.append(dotted_parent)
+    for parent in ps:
+        children.setdefault(parent, []).append(rid)
+
+if epic:
+    if epic not in by_id:
+        raise SystemExit(f"error: epic '{epic}' not found")
+    keep = {epic}
+    stack = [epic]
+    while stack:
+        current = stack.pop()
+        for child in children.get(current, []):
+            if child not in keep:
+                keep.add(child)
+                stack.append(child)
+else:
+    keep = {rid for rid, row in by_id.items() if str(row.get("status", "")).lower() not in TERMINAL}
+
+with open(out_path, "w", encoding="utf-8") as f:
+    for rid in sorted(keep):
+        f.write(json.dumps(by_id[rid], ensure_ascii=False, separators=(",", ":"), sort_keys=True) + "\n")
+PY
+BEAD_COUNT=$(wc -l < "$BD_OUT" | tr -d ' ')
+
+PR_LIMIT="${BOARD_AUDIT_PR_LIMIT:-500}"
+if [ "$NO_PR" -eq 1 ]; then
+  echo "→ --no-pr: skipping PR export"
+  PR_COUNT=0
+  PR_SINCE="n/a (--no-pr)"
+  PR_WINDOW_SOURCE="skipped via --no-pr"
+  : > "$PR_OUT"
+else
+  if [ -n "${BOARD_AUDIT_PR_SINCE:-}" ]; then
+    PR_SINCE="$BOARD_AUDIT_PR_SINCE"
+    PR_WINDOW_SOURCE="env override"
+  else
+    PR_SINCE="$(python3 - "$BD_OUT" <<'PY'
+import json
+import sys
+from datetime import date, datetime, timedelta
+oldest = None
+for line in open(sys.argv[1], encoding="utf-8"):
+    if not line.strip():
+        continue
+    row = json.loads(line)
+    created = row.get("created") or row.get("created_at")
+    if not created:
+        continue
+    current = datetime.fromisoformat(created.replace("Z", "+00:00")).date()
+    oldest = current if oldest is None or current < oldest else oldest
+print(((oldest - timedelta(days=7)) if oldest else (date.today() - timedelta(days=90))).isoformat())
+PY
+)"
+    PR_WINDOW_SOURCE="oldest bead minus 7d buffer"
+  fi
+
+  echo "→ exporting merged PRs since ${PR_SINCE} (${PR_WINDOW_SOURCE}; cap ${PR_LIMIT})..."
+  mapfile -t PR_NUMBERS < <(
+    gh pr list --state=merged --limit "$PR_LIMIT" \
+      --search "merged:>=${PR_SINCE} sort:updated-asc" \
+      --json number,mergedAt \
+      --jq 'sort_by(.mergedAt) | .[] | .number' 2>/dev/null
+  )
+  PR_COUNT="${#PR_NUMBERS[@]}"
+  [ "$PR_COUNT" -ne "$PR_LIMIT" ] || echo "warning: hit ${PR_LIMIT} PR cap; raise BOARD_AUDIT_PR_LIMIT" >&2
+  : > "$PR_OUT"
+  for N in "${PR_NUMBERS[@]}"; do
+    gh pr view "$N" \
+      --json number,mergedAt,title,body,files,commits,author,url \
+      --template '## PR #{{.number}} — {{.title}}
+
+- **merged:** {{.mergedAt}}
+- **author:** @{{.author.login}}
+- **url:** {{.url}}
+- **files ({{len .files}}):** {{range $i, $f := .files}}{{if $i}}, {{end}}`{{$f.path}}` (+{{$f.additions}}/-{{$f.deletions}}){{end}}
+
+### Body
+{{.body}}
+
+### Commits ({{len .commits}})
+{{range .commits}}- `{{slice .oid 0 8}}` {{.messageHeadline}}
+{{end}}
+
+---
+
+' >> "$PR_OUT" 2>/dev/null || echo "warning: gh pr view $N failed" >&2
+  done
+fi
+
+BD_STATS="$(bd stats 2>/dev/null | grep -v Warning || true)"
+cat > "$STATE_OUT" <<EOF
+# Board state — ${GH_REPO} @ ${TODAY}
+
+\`\`\`
+${BD_STATS}
+\`\`\`
+
+Non-closed beads exported: ${BEAD_COUNT}
+Merged PRs exported: ${PR_COUNT}
+EOF
+
+cat > "$PROMPT_OUT" <<EOF
+# Board audit — ${GH_REPO}
+
+Audit date: ${TODAY}
+$([ -n "$EPIC" ] && printf '**Scope:** bead `%s` and descendants.\n' "$EPIC")
+
+Use the embedded Beads and merged-PR corpus to perform the established board-audit workflow: classify each active bead as live, silently shipped, superseded, stale, blocked-in-fact, or ambiguous; verify testable claims with GitHub/Jira/observability tools; inspect dependency wiring, codebase drift, stale epics, duplicate scope, validation/no-regression coverage, and existing-library reuse. Do not mutate the board. Cite concrete evidence and finish with proposed mechanical `bd` commands.
+
+The Beads corpus is a projection from a single lossless `bd export --all` snapshot; every source record is preserved verbatim at the JSON-object level.
+EOF
+
+{
+  cat "$PROMPT_OUT"
+  echo
+  echo "---"
+  echo
+  echo "## Attached data (embedded)"
+  echo
+  echo "### beads.jsonl (${BEAD_COUNT} beads)"
+  echo '```jsonl'
+  cat "$BD_OUT"
+  echo '```'
+  echo
+  if [ "$NO_PR" -eq 1 ]; then
+    echo "### prs.md — SKIPPED (--no-pr)"
+  else
+    echo "### prs.md (${PR_COUNT} merged PRs)"
+    echo
+    cat "$PR_OUT"
+  fi
+} > "$BUNDLE_OUT"
+
+BUNDLE_SIZE="$(du -h "$BUNDLE_OUT" | cut -f1)"
+echo "✓ audit bundle: $BUNDLE_OUT ($BUNDLE_SIZE)"
+echo "  beads: $BEAD_COUNT | PRs: $PR_COUNT"
+if [[ "$AUDIT_DIR" == "$REPO_ROOT/"* ]]; then
+  echo "  git add: ${AUDIT_DIR#$REPO_ROOT/}"
+fi

--- a/.githooks/board-audit-flow.py
+++ b/.githooks/board-audit-flow.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""High-level board-audit handoff/reconcile UX.
+
+The low-level exporter and round-trip reconciler remain deterministic primitives.
+This layer composes them with `bd worktree create` so the caller's checkout is
+never switched and every worktree shares the authoritative Beads database via
+Git common-directory discovery.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+INDEX_SCHEMA = "xtrm.board-audit.index.v1"
+TRANSPORT_PREFIX = "board-audit/"
+
+
+class FlowError(RuntimeError):
+    pass
+
+
+def utcnow() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def run(command: list[str], *, cwd: Path, capture: bool = False, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(command, cwd=cwd, text=True, capture_output=capture, check=False)
+    if check and proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip() if capture else ""
+        raise FlowError(
+            f"command failed ({proc.returncode}): {shlex.join(command)}"
+            + (f"\n{detail}" if detail else "")
+        )
+    return proc
+
+
+def git_output(repo: Path, *args: str) -> str:
+    return run(["git", *args], cwd=repo, capture=True).stdout.strip()
+
+
+def repo_root() -> Path:
+    proc = subprocess.run(["git", "rev-parse", "--show-toplevel"], text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        raise FlowError("not inside a git working tree")
+    return Path(proc.stdout.strip()).resolve()
+
+
+def script_paths() -> tuple[Path, Path]:
+    here = Path(__file__).resolve().parent
+    core = Path(os.environ.get("BOARD_AUDIT_CORE", str(here / "board-audit-core"))).resolve()
+    roundtrip = Path(os.environ.get("BOARD_AUDIT_ROUNDTRIP", str(here / "board-audit-roundtrip.py"))).resolve()
+    if not core.exists():
+        raise FlowError(f"board-audit core not found: {core}")
+    if not roundtrip.exists():
+        raise FlowError(f"board-audit round-trip tool not found: {roundtrip}")
+    return core, roundtrip
+
+
+def require_commands(*names: str) -> None:
+    missing = [name for name in names if shutil.which(name) is None]
+    if missing:
+        raise FlowError("required command(s) not on PATH: " + ", ".join(missing))
+
+
+def validate_id(value: str) -> str:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", value):
+        raise FlowError(f"unsupported bead id {value!r}; expected letters/numbers plus . _ -")
+    return value
+
+
+def transport_branch(bead_id: str) -> str:
+    return f"{TRANSPORT_PREFIX}{bead_id}"
+
+
+def remote_ref_exists(repo: Path, ref: str) -> bool:
+    return run(["git", "show-ref", "--verify", "--quiet", ref], cwd=repo, check=False).returncode == 0
+
+
+def default_remote_ref(repo: Path) -> str:
+    proc = run(
+        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo,
+        capture=True,
+        check=False,
+    )
+    if proc.returncode == 0 and proc.stdout.strip():
+        return proc.stdout.strip()
+    if remote_ref_exists(repo, "refs/remotes/origin/main"):
+        return "origin/main"
+    raise FlowError("cannot determine origin default branch; configure origin/HEAD or origin/main")
+
+
+def cache_worktree_path(repo: Path, bead_id: str) -> Path:
+    cache = Path(os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache")))
+    root = cache / "xtrm" / "board-audit" / "worktrees" / repo.name
+    root.mkdir(parents=True, exist_ok=True)
+    stamp = dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+    path = root / f"{bead_id}-{stamp}-{os.getpid()}"
+    if path.exists():
+        raise FlowError(f"worktree path unexpectedly exists: {path}")
+    return path
+
+
+def make_staging_branch(repo: Path, bead_id: str, start_ref: str) -> str:
+    token = f"{bead_id}-{os.getpid()}-{dt.datetime.now().strftime('%H%M%S')}"
+    branch = f"board-audit-staging/{token}"
+    run(["git", "branch", branch, start_ref], cwd=repo)
+    return branch
+
+
+def create_bd_worktree(repo: Path, path: Path, branch: str) -> None:
+    run(["bd", "worktree", "create", str(path), "--branch", branch], cwd=repo)
+
+
+def remove_bd_worktree(repo: Path, path: Path) -> None:
+    # `bd worktree remove` is name-oriented; the created path has a unique basename.
+    run(["bd", "worktree", "remove", path.name], cwd=repo)
+
+
+def delete_local_branch(repo: Path, branch: str) -> None:
+    run(["git", "branch", "-D", branch], cwd=repo)
+
+
+def start_transport_worktree(repo: Path, bead_id: str) -> tuple[Path, str, str]:
+    run(["git", "fetch", "origin"], cwd=repo)
+    remote_branch = transport_branch(bead_id)
+    remote_ref = f"refs/remotes/origin/{remote_branch}"
+    start_ref = f"origin/{remote_branch}" if remote_ref_exists(repo, remote_ref) else default_remote_ref(repo)
+    staging = make_staging_branch(repo, bead_id, start_ref)
+    path = cache_worktree_path(repo, bead_id)
+    try:
+        create_bd_worktree(repo, path, staging)
+    except Exception:
+        delete_local_branch(repo, staging)
+        raise
+    return path, staging, remote_branch
+
+
+def cleanup_transport_worktree(repo: Path, path: Path, staging: str, *, keep_on_error: bool) -> None:
+    if keep_on_error:
+        print(f"worktree retained for recovery: {path}", file=sys.stderr)
+        print(f"staging branch retained: {staging}", file=sys.stderr)
+        return
+    remove_bd_worktree(repo, path)
+    delete_local_branch(repo, staging)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise FlowError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise FlowError(f"expected JSON object: {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def rel(worktree: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(worktree.resolve()).as_posix()
+    except ValueError as exc:
+        raise FlowError(f"artifact escaped transport worktree: {path}") from exc
+
+
+def latest_export_dir(worktree: Path) -> Path:
+    root = worktree / ".xtrm" / "board-audit" / "exports"
+    exports = sorted((p for p in root.glob("export-*") if p.is_dir()), key=lambda p: p.name)
+    if not exports:
+        raise FlowError(f"no structured export found under {root}")
+    return exports[-1]
+
+
+def package_from_manifest(export_dir: Path, bead_id: str) -> tuple[Path, dict[str, Any]]:
+    manifest = read_json(export_dir / "manifest.json")
+    packages = manifest.get("packages")
+    if not isinstance(packages, list):
+        raise FlowError("manifest packages must be a list")
+    matches = [row for row in packages if isinstance(row, dict) and str(row.get("root_id")) == bead_id]
+    if len(matches) != 1:
+        raise FlowError(f"expected one work package for {bead_id}, found {len(matches)}")
+    file_name = matches[0].get("file")
+    if not isinstance(file_name, str) or not file_name:
+        raise FlowError("manifest package has no file path")
+    package = export_dir / file_name
+    if not package.exists():
+        raise FlowError(f"manifest package file missing: {package}")
+    return package, manifest
+
+
+def load_index(worktree: Path) -> dict[str, Any]:
+    path = worktree / ".xtrm" / "board-audit" / "index.json"
+    if not path.exists():
+        return {"schema_version": INDEX_SCHEMA, "packages": {}}
+    data = read_json(path)
+    if data.get("schema_version") != INDEX_SCHEMA:
+        raise FlowError(f"unsupported board-audit index schema: {data.get('schema_version')!r}")
+    if not isinstance(data.get("packages"), dict):
+        raise FlowError("board-audit index packages must be an object")
+    return data
+
+
+def update_index_for_handoff(
+    worktree: Path,
+    bead_id: str,
+    remote_branch: str,
+    export_dir: Path,
+    package: Path,
+    editable: Path,
+    manifest: dict[str, Any],
+) -> Path:
+    index = load_index(worktree)
+    index["packages"][bead_id] = {
+        "branch": remote_branch,
+        "state": "prepared",
+        "updated_at": utcnow(),
+        "export_dir": rel(worktree, export_dir),
+        "manifest": rel(worktree, export_dir / "manifest.json"),
+        "package": rel(worktree, package),
+        "editable": rel(worktree, editable),
+        "base_package_sha256": read_json(package).get("content_sha256"),
+        "selected_record_count": (manifest.get("selection") or {}).get("selected_record_count"),
+    }
+    path = worktree / ".xtrm" / "board-audit" / "index.json"
+    write_json(path, index)
+    return path
+
+
+def commit_and_push(worktree: Path, *, paths: list[Path], message: str, remote_branch: str) -> None:
+    run(["git", "add", "--", *[rel(worktree, path) for path in paths]], cwd=worktree)
+    staged = run(["git", "diff", "--cached", "--quiet"], cwd=worktree, check=False).returncode != 0
+    if staged:
+        run(["git", "commit", "-m", message], cwd=worktree)
+    run(["git", "push", "origin", f"HEAD:refs/heads/{remote_branch}"], cwd=worktree)
+
+
+def locate_editable(worktree: Path, bead_id: str) -> tuple[Path, dict[str, Any]]:
+    index = load_index(worktree)
+    entry = (index.get("packages") or {}).get(bead_id)
+    if isinstance(entry, dict) and isinstance(entry.get("editable"), str):
+        candidate = worktree / entry["editable"]
+        if candidate.exists():
+            return candidate, index
+
+    # Compatibility with handoffs created before index.json existed.
+    matches = sorted(
+        worktree.glob(f".xtrm/board-audit/exports/export-*/work-packages/{bead_id}__*.editable.json"),
+        key=lambda path: path.as_posix(),
+    )
+    if not matches:
+        raise FlowError(f"no editable handoff artifact found for {bead_id} on transport branch")
+    return matches[-1], index
+
+
+def mark_applied(worktree: Path, index: dict[str, Any], bead_id: str) -> Path | None:
+    packages = index.get("packages")
+    if not isinstance(packages, dict) or not isinstance(packages.get(bead_id), dict):
+        return None
+    entry = packages[bead_id]
+    entry["state"] = "applied"
+    entry["updated_at"] = utcnow()
+    entry["applied_at"] = utcnow()
+    path = worktree / ".xtrm" / "board-audit" / "index.json"
+    write_json(path, index)
+    return path
+
+
+def cmd_handoff(args: argparse.Namespace) -> int:
+    require_commands("git", "bd", "python3")
+    bead_id = validate_id(args.bead_id)
+    repo = repo_root()
+    original_branch = git_output(repo, "branch", "--show-current") or "(detached)"
+    core, roundtrip = script_paths()
+
+    worktree: Path | None = None
+    staging = ""
+    keep = False
+    try:
+        worktree, staging, remote_branch = start_transport_worktree(repo, bead_id)
+        run([str(core), "--export", "--bead", bead_id], cwd=worktree)
+        export_dir = latest_export_dir(worktree)
+        package, manifest = package_from_manifest(export_dir, bead_id)
+        prepared = run([sys.executable, str(roundtrip), "prepare", str(package)], cwd=worktree, capture=True)
+        editable = Path(prepared.stdout.strip())
+        if not editable.is_absolute():
+            editable = (worktree / editable).resolve()
+        if not editable.exists():
+            raise FlowError(f"prepare did not create expected artifact: {editable}")
+        editable_rel = rel(worktree, editable)
+        index_path = update_index_for_handoff(worktree, bead_id, remote_branch, export_dir, package, editable, manifest)
+        commit_and_push(
+            worktree,
+            paths=[export_dir, index_path],
+            message=f"chore(board-audit): handoff {bead_id}",
+            remote_branch=remote_branch,
+        )
+        selected = (manifest.get("selection") or {}).get("selected_record_count")
+    except Exception:
+        keep = True
+        raise
+    finally:
+        if worktree is not None and staging:
+            cleanup_transport_worktree(repo, worktree, staging, keep_on_error=keep)
+
+    print()
+    print(f"✓ {bead_id} ready for handoff")
+    print(f"  branch:   {remote_branch}")
+    print(f"  issues:   {selected}")
+    print(f"  editable: {editable_rel}")
+    print(f"  checkout: unchanged ({original_branch})")
+    print()
+    print(f'Tell ChatGPT: "leggi export {bead_id}"')
+    return 0
+
+
+def cmd_reconcile(args: argparse.Namespace) -> int:
+    require_commands("git", "bd", "python3")
+    bead_id = validate_id(args.bead_id)
+    repo = repo_root()
+    original_branch = git_output(repo, "branch", "--show-current") or "(detached)"
+    _, roundtrip = script_paths()
+
+    worktree: Path | None = None
+    staging = ""
+    keep = False
+    try:
+        run(["git", "fetch", "origin"], cwd=repo)
+        remote_branch = transport_branch(bead_id)
+        if not remote_ref_exists(repo, f"refs/remotes/origin/{remote_branch}"):
+            raise FlowError(f"transport branch origin/{remote_branch} does not exist; run handoff first")
+        staging = make_staging_branch(repo, bead_id, f"origin/{remote_branch}")
+        worktree = cache_worktree_path(repo, bead_id)
+        create_bd_worktree(repo, worktree, staging)
+        editable, index = locate_editable(worktree, bead_id)
+
+        print("== validate ==")
+        run([sys.executable, str(roundtrip), "validate", str(editable)], cwd=worktree)
+        print("\n== three-way diff ==")
+        run([sys.executable, str(roundtrip), "diff", str(editable)], cwd=worktree)
+        print("\n== apply + verify ==" if args.execute else "\n== apply dry-run ==")
+        command = [sys.executable, str(roundtrip), "apply", str(editable)]
+        if args.execute:
+            command.append("--execute")
+        run(command, cwd=worktree)
+
+        if args.execute:
+            index_path = mark_applied(worktree, index, bead_id)
+            if index_path is not None:
+                commit_and_push(
+                    worktree,
+                    paths=[index_path],
+                    message=f"chore(board-audit): mark {bead_id} applied",
+                    remote_branch=remote_branch,
+                )
+    except Exception:
+        keep = True
+        raise
+    finally:
+        if worktree is not None and staging:
+            cleanup_transport_worktree(repo, worktree, staging, keep_on_error=keep)
+
+    print()
+    if args.execute:
+        print(f"✓ {bead_id} applied and verified")
+    else:
+        print(f"✓ {bead_id} reconciled safely; no Beads mutation performed")
+        print(f"  execute: board-audit reconcile {bead_id} --execute")
+    print(f"  checkout: unchanged ({original_branch})")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="board-audit",
+        description="Simple handoff/reconcile UX over deterministic Beads work-package primitives.",
+        epilog="Low-level --export/audit commands and board-audit-roundtrip remain available for debugging and automation.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    handoff = sub.add_parser("handoff", help="export + prepare + commit + push through an isolated bd-managed worktree")
+    handoff.add_argument("bead_id", help="epic/bead root to hand off")
+    handoff.set_defaults(func=cmd_handoff)
+
+    reconcile = sub.add_parser("reconcile", help="fetch edited handoff, validate/diff, dry-run, optionally apply + verify")
+    reconcile.add_argument("bead_id", help="epic/bead root to reconcile")
+    reconcile.add_argument("--execute", action="store_true", help="mutate Beads and verify; otherwise dry-run only")
+    reconcile.set_defaults(func=cmd_reconcile)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        parser = build_parser()
+        args = parser.parse_args(argv)
+        if not getattr(args, "command", None):
+            parser.print_help()
+            return 0
+        return int(args.func(args))
+    except FlowError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.githooks/board-audit-pr-adapter.sh
+++ b/.githooks/board-audit-pr-adapter.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# board-audit-pr-adapter — PR-checkpoint event adapter.
+#
+# Publishes a FRESH PR-checkpoint Board-Audit handoff for every push to a
+# pull-request branch. Wire it as a client-side pre-push hook (board-audit
+# init does this), run it from a self-hosted PR-event executor, or invoke it
+# manually.
+#
+# Post-delivery semantics from a pre-push hook: a plain pre-push fires BEFORE
+# the code push succeeds, so a synchronous checkpoint there could only bind
+# the previous remote head (STALE). The adapter therefore defers to git's own
+# push (no second push — a double push races on GitHub and fails with
+# "cannot lock ref") and starts a detached one-shot poller that waits for the
+# remote ref to reach the pushed SHA (max ~60s), then publishes the
+# checkpoint against the now-remote PR head. The handoff is FRESH after every
+# push, and any agent in the repository can verify it with:
+#   board-audit pr-status <pr> --check
+#
+# The adapter never blocks the code push. Adapter or poller failures only
+# warn (poller log: /tmp/board-audit-adapter-<pr>.log). There is no
+# allowlist: every PR produces its Board-Audit evidence.
+#
+# Protocol: as a pre-push hook, refspecs arrive on stdin as
+#   <local ref> <local sha> <remote ref> <remote sha>
+# and the remote name is argv[1]. Invoked directly with a PR number, it
+# checkpoints that PR synchronously.
+set -uo pipefail
+
+# Hook environments set GIT_DIR (and friends); they must not leak into the
+# child checkpoint, whose bd worktree create / git calls resolve the repo
+# from cwd.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR 2>/dev/null || true
+
+SELF="$(readlink -f "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "$SELF")" && pwd)"
+PR_FLOW="$SCRIPT_DIR/board-audit-pr.py"
+
+REMOTE="${1:-origin}"
+PR="${2:-}"
+
+# Direct/manual invocation: adapter <pr> or adapter <remote> <pr> — the first
+# numeric argument is the explicit PR to checkpoint synchronously.
+if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
+  PR="${1}"
+  export BOARD_AUDIT_PR_TRIGGER="${BOARD_AUDIT_PR_TRIGGER:-auto}"
+  exec python3 "$PR_FLOW" pr-checkpoint "$PR" --trigger auto
+fi
+if [[ "${2:-}" =~ ^[0-9]+$ ]]; then
+  export BOARD_AUDIT_PR_TRIGGER="${BOARD_AUDIT_PR_TRIGGER:-auto}"
+  exec python3 "$PR_FLOW" pr-checkpoint "$PR" --trigger auto
+fi
+
+# Determine the pushed SHA of the current branch from the pre-push stdin
+# protocol (skipped for non-branch refs, deletions, and TTY stdin).
+branch="$(git branch --show-current 2>/dev/null || true)"
+pushed_sha=""
+if [ -n "$branch" ] && [ ! -t 0 ]; then
+  while read -r local_ref local_sha remote_ref remote_sha; do
+    [ -z "$local_ref" ] && continue
+    case "$local_ref" in
+      refs/heads/*)
+        if [ "$local_sha" != "0000000000000000000000000000000000000000" ] \
+           && [ "${local_ref#refs/heads/}" = "$branch" ]; then
+          pushed_sha="$local_sha"
+        fi
+        ;;
+    esac
+  done
+fi
+# A preceding hook block (e.g. a gate runner) may have consumed stdin, so
+# the loop above saw no refs. For the common case — pushing the current
+# branch — fall back to HEAD.
+if [ -z "$pushed_sha" ] && [ -n "$branch" ]; then
+  pushed_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+fi
+
+# Resolve the PR for the current branch.
+PR_NUMBER=""
+if [ -n "${BOARD_AUDIT_PR_JSON:-}" ] && [ -f "$BOARD_AUDIT_PR_JSON" ]; then
+  PR_NUMBER="$(python3 -c "import json,os;print(json.load(open(os.environ['BOARD_AUDIT_PR_JSON']))['number'])" 2>/dev/null || true)"
+fi
+if [ -z "$PR_NUMBER" ]; then
+  # gh pr view resolves the branch itself and has mis-resolved in some
+  # worktrees; pass the branch explicitly for a deterministic lookup.
+  PR_NUMBER="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null || true)"
+fi
+if [ -z "$PR_NUMBER" ] || ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "board-audit-pr-adapter: no pull request for the current branch; nothing to publish" >&2
+  exit 0
+fi
+
+# No branch ref pushed (tag-only/deletion push): checkpoint synchronously as
+# best effort against the current remote head.
+if [ -z "$pushed_sha" ]; then
+  export BOARD_AUDIT_PR_TRIGGER="${BOARD_AUDIT_PR_TRIGGER:-auto}"
+  if python3 "$PR_FLOW" pr-checkpoint "$PR_NUMBER" --trigger auto; then
+    echo "board-audit-pr-adapter: published FRESH Board-Audit checkpoint for PR #$PR_NUMBER" >&2
+  else
+    echo "board-audit-pr-adapter: WARNING — checkpoint for PR #$PR_NUMBER failed (see above)" >&2
+  fi
+  exit 0
+fi
+
+# Detached one-shot poller: wait for git's own push to land (remote ref ==
+# pushed SHA), then publish the checkpoint. Never blocks the push; failures
+# land in the poller log.
+export BA_REMOTE="$REMOTE" BA_BRANCH="$branch" BA_SHA="$pushed_sha" \
+       BA_PR="$PR_NUMBER" BA_FLOW="$PR_FLOW" BA_CWD="$(pwd)" \
+       BOARD_AUDIT_PR_TRIGGER="${BOARD_AUDIT_PR_TRIGGER:-auto}"
+LOG="/tmp/board-audit-adapter-$PR_NUMBER.log"
+nohup setsid bash -c '
+  cd "$BA_CWD" 2>/dev/null || exit 1
+  unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR 2>/dev/null || true
+  for _ in $(seq 1 30); do
+    ref="$(git ls-remote "$BA_REMOTE" "refs/heads/$BA_BRANCH" 2>/dev/null | awk "{print \$1}")"
+    if [ -n "${BOARD_AUDIT_PR_JSON:-}" ] && [ -f "$BOARD_AUDIT_PR_JSON" ]; then
+      gh_head="$(python3 -c "import json,os;print(json.load(open(os.environ[\"BOARD_AUDIT_PR_JSON\"]))[\"headRefOid\"])" 2>/dev/null || true)"
+    else
+      # GitHub updates the PR headRefOid with a small lag after a push;
+      # wait for it so the checkpoint binds the pushed head, not the old one.
+      gh_head="$(gh pr view "$BA_PR" --json headRefOid --jq .headRefOid 2>/dev/null || true)"
+    fi
+    if [ "$ref" = "$BA_SHA" ] && [ "$gh_head" = "$BA_SHA" ]; then
+      break
+    fi
+    sleep 2
+  done
+  if python3 "$BA_FLOW" pr-checkpoint "$BA_PR" --trigger auto; then
+    echo "board-audit-pr-adapter: published FRESH Board-Audit checkpoint for PR #$BA_PR" >&2
+  else
+    echo "board-audit-pr-adapter: WARNING — checkpoint for PR #$BA_PR failed; the push landed but the handoff may be stale or missing" >&2
+  fi
+' > "$LOG" 2>&1 &
+echo "board-audit-pr-adapter: deferred FRESH checkpoint for PR #$PR_NUMBER (poller log: $LOG)" >&2
+exit 0

--- a/.githooks/board-audit-pr.py
+++ b/.githooks/board-audit-pr.py
@@ -1,0 +1,1437 @@
+#!/usr/bin/env python3
+"""PR-checkpoint Board-Audit handoffs.
+
+Implements the PR-checkpoint handoff publication contract: when repository work
+reaches a Git/PR delivery event, one complete, coherent Board-Audit evidence
+sidecar is published on a dedicated ``board-audit/pr-<number>`` transport
+branch without modifying the caller's implementation worktree and without
+coupling to any XTRM session lifecycle command.
+
+The publication pipeline:
+
+    receive checkpoint event
+    → fetch relevant Git refs
+    → verify PR and implementation head (remote authority via gh)
+    → confidentiality policy check (automation fails closed)
+    → create isolated Beads-managed worktree (transport policy)
+    → acquire one canonical bd export --all snapshot
+    → derive per-Bead read projection + handoff metadata + index
+    → incremental write (unchanged canonical records are preserved)
+    → NO_CHANGES when membership, issue hashes and PR head are unchanged
+    → publish transport branch (exact force-with-lease)
+    → seal commit records the exact published transport SHA
+    → verify remote transport SHA
+    → remove isolated worktree
+    → return receipt
+
+The per-Bead projection under ``.xtrm/board-audit/snapshots/**`` is a read
+model only. Web-originated mutation continues to use the existing bounded
+``desired_issues`` / ``new_comments`` round-trip contract followed by local
+``reconcile`` and explicit authorized ``reconcile --execute``.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+TRANSPORT_IMPL = HERE / "board-audit-transport.py"
+
+spec = importlib.util.spec_from_file_location("board_audit_pr_transport", TRANSPORT_IMPL)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"cannot load board-audit transport policy: {TRANSPORT_IMPL}")
+transport = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(transport)
+
+# The transport module patches the generic flow with its lease/hook/CI policy.
+flow = transport.flow
+
+HANDOFF_SCHEMA = "xtrm.board-audit.pr-handoff.v1"
+PROJECTION_SCHEMA = "xtrm.board-audit.pr-projection.v1"
+ROOT_SCHEMA = "xtrm.board-audit.pr-root.v1"
+SNAPSHOT_MANIFEST_SCHEMA = "xtrm.board-audit.pr-snapshot-manifest.v1"
+TERMINAL = {"closed", "done", "completed", "cancelled", "canceled", "tombstone", "deleted"}
+PARENT_TYPES = {"parent-child", "parent", "child-of"}
+
+# Failure classes from the PR-checkpoint contract.
+PR_NOT_RESOLVED = "PR_NOT_RESOLVED"
+REMOTE_HEAD_MISMATCH = "REMOTE_HEAD_MISMATCH"
+BEADS_UNAVAILABLE = "BEADS_UNAVAILABLE"
+SNAPSHOT_FAILED = "SNAPSHOT_FAILED"
+TRANSPORT_CONFLICT = "TRANSPORT_CONFLICT"
+TRANSPORT_PUSH_FAILED = "TRANSPORT_PUSH_FAILED"
+TRANSPORT_VERIFY_FAILED = "TRANSPORT_VERIFY_FAILED"
+CLEANUP_BLOCKED = "CLEANUP_BLOCKED"
+
+
+class PRCheckpointError(flow.FlowError):
+    """Board-audit PR-checkpoint failure carrying a contract failure class."""
+
+    def __init__(self, kind: str, message: str) -> None:
+        super().__init__(message)
+        self.kind = kind
+
+    def __str__(self) -> str:
+        return f"{self.kind}: {super().__str__()}"
+
+
+def utcnow() -> str:
+    return flow.utcnow()
+
+
+def canonical_bytes(obj: Any) -> bytes:
+    return (json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def canonical_sha256(obj: Any) -> str:
+    return hashlib.sha256(canonical_bytes(obj)).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# PR resolution and remote verification
+# ---------------------------------------------------------------------------
+
+def repo_slug(repo: Path) -> str:
+    """Derive the owner/repo slug from the origin URL without needing gh."""
+    url = flow.git_output(repo, "remote", "get-url", "origin")
+    match = re.search(r"(?:github\.com[:/])([^/]+)/([^/.]+)(?:\.git)?$", url.strip())
+    if match:
+        return f"{match.group(1)}/{match.group(2)}"
+    return flow.git_output(repo, "rev-parse", "--show-toplevel").rsplit("/", 1)[-1]
+
+
+def resolve_pr_number(repo: Path, argument: str | None) -> int:
+    """Resolve the PR number from the argument or the current branch."""
+    if argument:
+        if not re.fullmatch(r"[0-9]+", argument):
+            raise PRCheckpointError(PR_NOT_RESOLVED, f"invalid pull request number {argument!r}")
+        return int(argument)
+    try:
+        branch = flow.git_output(repo, "branch", "--show-current").strip()
+        # gh pr view resolves the branch itself and has mis-resolved in some
+        # worktrees; pass the branch explicitly for a deterministic lookup.
+        pr = flow.run(
+            ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number", "--jq", ".[0].number"],
+            cwd=repo,
+            capture=True,
+        ).stdout.strip()
+    except flow.FlowError as exc:
+        raise PRCheckpointError(PR_NOT_RESOLVED, f"cannot resolve pull request for current branch: {exc}") from exc
+    if not pr or not re.fullmatch(r"[0-9]+", pr):
+        raise PRCheckpointError(PR_NOT_RESOLVED, "no open pull request for current branch")
+    return int(pr)
+
+
+def fetch_pr_info(repo: Path, pr: int) -> dict[str, Any]:
+    """Fetch the remote PR identity (authoritative) through gh.
+
+    ``BOARD_AUDIT_PR_JSON`` may point at a file containing the same JSON shape
+    so integration tests can substitute a fake remote without gh.
+    """
+    override_raw = os.environ.get("BOARD_AUDIT_PR_JSON", "")
+    if override_raw:
+        override = Path(override_raw)
+        if override.exists():
+            data = json.loads(override.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
+    fields = "number,title,state,headRefName,headRefOid,baseRefName,url"
+    try:
+        out = flow.run(
+            ["gh", "pr", "view", str(pr), "--json", fields, "--jq", "."],
+            cwd=repo,
+            capture=True,
+        ).stdout
+    except flow.FlowError as exc:
+        raise PRCheckpointError(PR_NOT_RESOLVED, f"cannot resolve pull request #{pr}: {exc}") from exc
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise PRCheckpointError(PR_NOT_RESOLVED, f"invalid gh output for pull request #{pr}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise PRCheckpointError(PR_NOT_RESOLVED, f"invalid gh output for pull request #{pr}")
+    return data
+
+
+def verify_remote_head(repo: Path, info: dict[str, Any]) -> None:
+    """Prove the implementation branch on the remote carries the PR head.
+
+    ``gh pr view`` reports the remote PR head. We additionally fetch the exact
+    implementation branch and require the fetched head to match, so a handoff
+    is never claimed current against a code head that was not verified remote.
+    """
+    head_ref = str(info.get("headRefName") or "")
+    head_oid = str(info.get("headRefOid") or "")
+    if not head_ref or not head_oid or not re.fullmatch(r"[0-9a-f]{40}", head_oid):
+        raise PRCheckpointError(PR_NOT_RESOLVED, f"pull request has no valid remote head ({head_ref} {head_oid})")
+    try:
+        flow.run(["git", "fetch", "origin", head_ref], cwd=repo)
+    except flow.FlowError as exc:
+        raise PRCheckpointError(REMOTE_HEAD_MISMATCH, f"cannot fetch implementation branch {head_ref!r}: {exc}") from exc
+    try:
+        remote_head = flow.git_output(repo, "rev-parse", "FETCH_HEAD")
+    except flow.FlowError as exc:
+        raise PRCheckpointError(REMOTE_HEAD_MISMATCH, f"cannot resolve fetched head for {head_ref!r}: {exc}") from exc
+    if remote_head != head_oid:
+        raise PRCheckpointError(
+            REMOTE_HEAD_MISMATCH,
+            f"remote PR head mismatch: gh reports {head_oid}, fetched {head_ref!r} is {remote_head}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Producer provenance
+# ---------------------------------------------------------------------------
+
+def package_digest(package_dir: Path) -> str:
+    """Deterministic SHA-256 of the exact board-audit package contents.
+
+    Digests every file under ``package_dir`` (excluding bytecode caches),
+    keyed by relative path, so two checkouts of the same package produce the
+    same digest and a dirty/modified caller copy cannot be attributed to a
+    clean source commit.
+    """
+    entries: list[tuple[str, str]] = []
+    for path in sorted(package_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(package_dir).as_posix()
+        if rel.startswith("__pycache__/") or rel.endswith(".pyc"):
+            continue
+        entries.append((rel, hashlib.sha256(path.read_bytes()).hexdigest()))
+    listing = "\n".join(f"{rel}\0{digest}" for rel, digest in entries)
+    return hashlib.sha256(listing.encode("utf-8")).hexdigest()
+
+
+def caller_producer(package_dir: Path) -> dict[str, Any]:
+    """Producer identity for the caller-package path (no repo-carried copy).
+
+    ``git_sha`` is the caller checkout's HEAD when the package lives inside a
+    git working tree, else null; ``package_sha256`` is always present.
+    """
+    repository: str | None = None
+    git_sha: str | None = None
+    try:
+        root = flow.git_output(package_dir, "rev-parse", "--show-toplevel").strip()
+        repository = repo_slug(Path(root))
+        git_sha = flow.git_output(package_dir, "rev-parse", "HEAD").strip()
+    except flow.FlowError:
+        pass
+    return {
+        "board_audit_source": "caller",
+        "repository": repository,
+        "git_sha": git_sha,
+        "package_sha256": package_digest(package_dir),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Snapshot builder (one canonical bd export --all acquisition)
+# ---------------------------------------------------------------------------
+
+def read_rows(raw_path: Path) -> list[dict[str, Any]]:
+    text = raw_path.read_text(encoding="utf-8").strip()
+    if not text:
+        return []
+    if text.startswith("[") or text.startswith("{"):
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, list):
+                return [r for r in parsed if isinstance(r, dict)]
+            if isinstance(parsed, dict):
+                for key in ("issues", "beads", "records"):
+                    if isinstance(parsed.get(key), list):
+                        return [r for r in parsed[key] if isinstance(r, dict)]
+                return [parsed]
+        except json.JSONDecodeError:
+            pass
+    rows = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise PRCheckpointError(
+                SNAPSHOT_FAILED,
+                f"bd export --all produced a corrupt record line: {exc}",
+            ) from exc
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def entity_id(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("id", "issue_id", "bead_id", "parent_id", "target_id", "target"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    return None
+
+
+def dependency_target(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        for key in ("depends_on_id", "depends_on_issue_id", "target_id", "target", "parent_id", "bead_id"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    return None
+
+
+def relation_type(value: Any) -> str:
+    if not isinstance(value, dict):
+        return "unknown"
+    return str(value.get("type") or value.get("dependency_type") or value.get("relation_type") or value.get("kind") or "unknown")
+
+
+def relation_targets(row: dict[str, Any]) -> list[tuple[str, str]]:
+    """Deterministic (target, type) edge list for a row's outgoing relations."""
+    out: list[tuple[str, str]] = []
+    for key in ("deps", "dependencies", "relations"):
+        vals = row.get(key)
+        if not isinstance(vals, list):
+            continue
+        for value in vals:
+            target = dependency_target(value)
+            if target:
+                out.append((target, relation_type(value)))
+    for key in ("parents", "parent"):
+        vals = row.get(key)
+        if vals is None:
+            continue
+        if not isinstance(vals, list):
+            vals = [vals]
+        for value in vals:
+            target = entity_id(value)
+            if target:
+                typ = relation_type(value)
+                out.append((target, typ if typ != "unknown" else "parent-child"))
+    discovered = row.get("discovered_from")
+    if discovered:
+        vals = discovered if isinstance(discovered, list) else [discovered]
+        for value in vals:
+            target = entity_id(value)
+            if target:
+                out.append((target, "discovered-from"))
+    return out
+
+
+def explicit_parent_ids(row: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for key in ("parents", "parent"):
+        vals = row.get(key)
+        if vals is None:
+            continue
+        if not isinstance(vals, list):
+            vals = [vals]
+        for value in vals:
+            parent = entity_id(value)
+            if parent and parent not in out:
+                out.append(parent)
+    for target, typ in relation_targets(row):
+        if typ in PARENT_TYPES and target not in out:
+            out.append(target)
+    return out
+
+
+def is_terminal(row: dict[str, Any]) -> bool:
+    return str(row.get("status", "")).lower() in TERMINAL
+
+
+def build_tree(rows: list[dict[str, Any]]) -> tuple[dict[str, dict[str, Any]], dict[str, list[str]]]:
+    """Return (by_id, parents) mirroring Beads' own tree semantics.
+
+    Explicit parent-child edges win; dotted-ID ancestry is the fallback when
+    no explicit parent resolves inside the snapshot.
+    """
+    by_id = {str(row["id"]): row for row in rows if row.get("id") is not None}
+    parents: dict[str, list[str]] = {}
+    for rid, row in by_id.items():
+        ps = [p for p in explicit_parent_ids(row) if p != rid]
+        known_explicit = [p for p in ps if p in by_id]
+        if not known_explicit and "." in rid:
+            dotted_parent = rid.rsplit(".", 1)[0]
+            if dotted_parent in by_id and dotted_parent != rid and dotted_parent not in ps:
+                ps.append(dotted_parent)
+        parents[rid] = ps
+    return by_id, parents
+
+
+def highest_known_root(rid: str, parents: dict[str, list[str]], by_id: dict[str, dict[str, Any]]) -> str:
+    current = rid
+    seen = {rid}
+    while True:
+        known = sorted(p for p in parents.get(current, []) if p in by_id and p not in seen)
+        if not known:
+            return current
+        current = known[0]
+        seen.add(current)
+
+
+def compute_snapshot(
+    raw_path: Path,
+    repository: str,
+    bd_version: str,
+    generated_at: str,
+) -> dict[str, Any]:
+    """Build the per-Bead read projection from one raw acquisition.
+
+    Returns ``{snapshot_id, raw_sha256, open_ids, roots, root_of, files,
+    manifest}`` where every file is deterministic: identical Beads state
+    produces identical bytes, so unchanged records are never rewritten across
+    checkpoints.
+    """
+    rows = read_rows(raw_path)
+    by_id, parents = build_tree(rows)
+    open_ids = sorted(rid for rid, row in by_id.items() if not is_terminal(row))
+
+    root_of: dict[str, str] = {}
+    subtree: dict[str, list[str]] = {}
+    for rid in open_ids:
+        root = highest_known_root(rid, parents, by_id)
+        root_of[rid] = root
+        subtree.setdefault(root, []).append(rid)
+
+    projections: dict[str, dict[str, Any]] = {}
+    for rid in open_ids:
+        row = by_id[rid]
+        source_sha = canonical_sha256(row)
+        deps = sorted((target, typ) for target, typ in relation_targets(row))
+        projections[rid] = {
+            "schema_version": PROJECTION_SCHEMA,
+            "bead_id": rid,
+            "source": row,
+            "navigation": {
+                "root": root_of[rid],
+                "parents": sorted(p for p in parents.get(rid, []) if p in by_id),
+                "dependencies": deps,
+                "status": str(row.get("status", "")),
+                "priority": row.get("priority"),
+                "owner": row.get("owner"),
+                "source_sha256": source_sha,
+            },
+        }
+
+    raw_sha = sha256_file(raw_path)
+    # The snapshot identity is content-derived: membership, roots and every
+    # open record hash. Identical boards resolve to the identical snapshot id.
+    identity_payload = {
+        "roots": sorted(subtree),
+        "open": [(rid, projections[rid]["navigation"]["source_sha256"]) for rid in open_ids],
+    }
+    snapshot_id = canonical_sha256(identity_payload)
+
+    files: dict[str, bytes] = {}
+    for rid in open_ids:
+        files[f"snapshots/{snapshot_id}/issues/{rid}.json"] = canonical_bytes(projections[rid])
+    for root in sorted(subtree):
+        files[f"snapshots/{snapshot_id}/roots/{root}.json"] = canonical_bytes({
+            "schema_version": ROOT_SCHEMA,
+            "root_id": root,
+            "title": by_id.get(root, {}).get("title"),
+            "issue_ids": sorted(subtree[root]),
+            "open_issue_count": len(subtree[root]),
+            "source_sha256": canonical_sha256(by_id[root]) if root in by_id else None,
+        })
+
+    file_hashes = {rel: hashlib.sha256(content).hexdigest() for rel, content in sorted(files.items())}
+    manifest = {
+        "schema_version": SNAPSHOT_MANIFEST_SCHEMA,
+        "snapshot_id": snapshot_id,
+        "generated_at": generated_at,
+        "repository": repository,
+        "bd_version": bd_version,
+        "source": {
+            "command": "bd export --all",
+            "raw_file": "raw-beads.jsonl",
+            "raw_sha256": raw_sha,
+            "raw_record_count": len(by_id),
+        },
+        "selection": {
+            "open_record_count": len(open_ids),
+            "root_count": len(subtree),
+        },
+        "files": file_hashes,
+    }
+    files[f"snapshots/{snapshot_id}/manifest.json"] = canonical_bytes(manifest)
+
+    return {
+        "snapshot_id": snapshot_id,
+        "raw_sha256": raw_sha,
+        "open_ids": open_ids,
+        "roots": sorted(subtree),
+        "root_of": root_of,
+        "files": files,
+        "manifest": manifest,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Projection publication
+# ---------------------------------------------------------------------------
+
+def board_audit_dir(worktree: Path) -> Path:
+    return worktree / ".xtrm" / "board-audit"
+
+
+def load_previous_handoff(worktree: Path, pr: int) -> dict[str, Any] | None:
+    path = board_audit_dir(worktree) / "handoffs" / f"pr-{pr}.json"
+    if not path.exists():
+        return None
+    data = flow.read_json(path)
+    if data.get("schema_version") != HANDOFF_SCHEMA:
+        raise PRCheckpointError(SNAPSHOT_FAILED, f"unsupported handoff schema on transport branch: {data.get('schema_version')!r}")
+    return data
+
+
+def build_index(
+    worktree: Path,
+    snapshot: dict[str, Any],
+    pr: int,
+    info: dict[str, Any],
+    generated_at: str,
+) -> dict[str, Any]:
+    """Extend the shared index with the open projection and PR checkpoint.
+
+    ``open_issues`` is the deterministic per-Bead addressability surface: every
+    open bead maps to the exact projection file inside the current snapshot.
+    """
+    index = flow.load_index(worktree)
+    open_issues: dict[str, dict[str, Any]] = {}
+    for rid in snapshot["open_ids"]:
+        relpath = f"snapshots/{snapshot['snapshot_id']}/issues/{rid}.json"
+        projection = json.loads(snapshot["files"][relpath].decode("utf-8"))
+        open_issues[rid] = {
+            "snapshot_id": snapshot["snapshot_id"],
+            "file": relpath,
+            "root_id": snapshot["root_of"][rid],
+            "state": "open",
+            "source_sha256": projection["navigation"]["source_sha256"],
+        }
+    index["open_issues"] = open_issues
+    checkpoints = index.setdefault("pr_checkpoints", {})
+    checkpoints[str(pr)] = {
+        "state": "prepared",
+        "branch": f"board-audit/pr-{pr}",
+        "handoff": f"handoffs/pr-{pr}.json",
+        "implementation_head_sha": str(info.get("headRefOid", "")),
+        "snapshot_id": snapshot["snapshot_id"],
+        "updated_at": generated_at,
+    }
+    # Persist immediately; update_index_for_handoff merges the per-root
+    # packages entries on top of this saved state.
+    flow.write_json(board_audit_dir(worktree) / "index.json", index)
+    return index
+
+
+def handoff_payload(
+    repository: str,
+    pr: int,
+    info: dict[str, Any],
+    snapshot: dict[str, Any],
+    generated_at: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": HANDOFF_SCHEMA,
+        "repository": repository,
+        "pull_request": pr,
+        "implementation_branch": str(info.get("headRefName", "")),
+        "implementation_head_sha": str(info.get("headRefOid", "")),
+        "beads_root_ids": snapshot["roots"],
+        "snapshot_id": snapshot["snapshot_id"],
+        # Digest of the one canonical bd export --all acquisition backing this
+        # snapshot (the manifest records the same value as raw_sha256).
+        "snapshot_sha256": snapshot["raw_sha256"],
+        "generated_at": generated_at,
+        "transport_branch": f"board-audit/pr-{pr}",
+        "transport_head_sha": None,  # sealed after the artifacts commit
+        "state": "prepared",
+        "open_issue_count": len(snapshot["open_ids"]),
+        "index": ".xtrm/board-audit/index.json",
+        "handoff": f".xtrm/board-audit/handoffs/pr-{pr}.json",
+    }
+
+
+def locator_block(handoff: dict[str, Any]) -> str:
+    work_packages = handoff.get("work_package_count")
+    work_line = f"Work packages: {work_packages}\n" if work_packages is not None else ""
+    return (
+        "Board-Audit Handoff\n"
+        f"PR: #{handoff['pull_request']}\n"
+        f"Code head: {handoff['implementation_head_sha']}\n"
+        f"Beads root: {', '.join(handoff['beads_root_ids']) if handoff['beads_root_ids'] else '(none)'}\n"
+        f"Transport: {handoff['transport_branch']}\n"
+        f"Snapshot: {handoff['snapshot_id']}\n"
+        f"Generated: {handoff['generated_at']}\n"
+        f"State: {handoff['state']}\n"
+        + work_line
+        + f"Index: {handoff['index']}\n"
+        f"PR handoff: {handoff['handoff']}\n"
+        "_board-audit locator_\n"
+    )
+
+
+LOCATOR_MARKER = "Board-Audit Handoff"
+
+
+def post_locator_comment(repo: Path, pr: int, block: str) -> None:
+    """Post or update the Board-Audit locator comment on the PR.
+
+    Idempotent: an existing comment whose body starts with the locator marker
+    is updated in place (PATCH) so repeated checkpoints do not spam the PR.
+    """
+    slug = repo_slug(repo)
+    comments = flow.run(
+        ["gh", "api", f"repos/{slug}/issues/{pr}/comments", "--jq", ".[] | select(.body | startswith(\"Board-Audit Handoff\")) | .id"],
+        cwd=repo,
+        capture=True,
+        check=False,
+    ).stdout.strip()
+    existing_id = comments.splitlines()[-1] if comments else ""
+    if existing_id:
+        flow.run(
+            ["gh", "api", "-X", "PATCH", f"repos/{slug}/issues/comments/{existing_id}", "-f", f"body={block}"],
+            cwd=repo,
+            capture=True,
+            check=True,
+        )
+    else:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as tmp:
+            tmp.write(block)
+            tmp_path = tmp.name
+        try:
+            flow.run(["gh", "pr", "comment", str(pr), "--body-file", tmp_path], cwd=repo)
+        finally:
+            os.unlink(tmp_path)
+
+
+def write_projection(worktree: Path, snapshot: dict[str, Any]) -> list[Path]:
+    """Write changed projection files, preserving unchanged records.
+
+    A file whose content already matches the previously published projection
+    (restored from the transport branch) is preserved untouched. Stale snapshot
+    directories from earlier identities are removed so the committed tree
+    carries exactly one current snapshot.
+    """
+    base = board_audit_dir(worktree)
+    written: list[Path] = []
+    for relpath, content in snapshot["files"].items():
+        target = base / relpath
+        if target.exists() and target.read_bytes() == content:
+            continue  # unchanged record: preserve the published projection
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+        written.append(target)
+
+    snapshots_dir = base / "snapshots"
+    if snapshots_dir.exists():
+        for candidate in snapshots_dir.iterdir():
+            if candidate.is_dir() and candidate.name != snapshot["snapshot_id"]:
+                shutil.rmtree(candidate)
+    return written
+
+
+def cmd_pr_checkpoint(args: argparse.Namespace) -> int:
+    flow.require_commands("git", "bd", "python3", "gh")
+    repo = flow.repo_root()
+    original_branch = flow.git_output(repo, "branch", "--show-current") or "(detached)"
+
+    pr = resolve_pr_number(repo, args.pr_number)
+    info = fetch_pr_info(repo, pr)
+    state = str(info.get("state", "")).lower()
+    if state != "open":
+        raise PRCheckpointError(PR_NOT_RESOLVED, f"pull request #{pr} is not open (state={state})")
+    slug = repo_slug(repo)
+    verify_remote_head(repo, info)
+
+    identity = f"pr-{pr}"
+    remote_branch = f"board-audit/pr-{pr}"
+    generated_at = utcnow()
+
+    worktree: Path | None = None
+    staging = ""
+    no_changes = False
+    cherry_picked = False
+    handoff: dict[str, Any] | None = None
+    head_after_push = ""
+    keep = False
+    try:
+        worktree, staging, _ = transport.start_transport_worktree(repo, identity, remote_branch=remote_branch)
+        previous = load_previous_handoff(worktree, pr)
+
+        # Board-audit must run from the repository's own copy when the repo
+        # carries the package: cherry-pick packages/board-audit from the default
+        # branch into the isolated worktree WITHOUT staging it (git archive +
+        # tar, not checkout), so the derivation uses the repo's version while
+        # the transport commit still contains only .xtrm/board-audit/** assets.
+        cherry_picked = False
+        producer_sha: str | None = None
+        if repo_carries_package(repo):
+            try:
+                default_ref = flow.default_remote_ref(repo)
+                # Pin the archive to the exact producer SHA, not the moving
+                # ref name, so provenance records the commit that was used.
+                producer_sha = flow.git_output(repo, "rev-parse", f"{default_ref}^{{commit}}").strip()
+                archive = subprocess.run(
+                    ["git", "archive", "--format=tar", producer_sha, "packages/board-audit"],
+                    cwd=repo,
+                    capture_output=True,
+                )
+                package_target = worktree  # archive entries are prefixed packages/board-audit/...
+                untar = subprocess.run(
+                    ["tar", "-xf", "-", "-C", str(package_target)],
+                    input=archive.stdout,
+                )
+                if archive.returncode == 0 and untar.returncode == 0 and (worktree / "packages/board-audit/board-audit-core").exists():
+                    cherry_picked = True
+                    # tar -xf as a non-root user applies the umask and strips
+                    # the exec bit; the core script is executed directly.
+                    (worktree / "packages/board-audit/board-audit-core").chmod(0o755)
+                    os.environ["BOARD_AUDIT_CORE"] = str(worktree / "packages/board-audit/board-audit-core")
+                    os.environ["BOARD_AUDIT_ROUNDTRIP"] = str(worktree / "packages/board-audit/board-audit-roundtrip.py")
+            except flow.FlowError:
+                cherry_picked = False
+        if not cherry_picked:
+            os.environ.pop("BOARD_AUDIT_CORE", None)
+            os.environ.pop("BOARD_AUDIT_ROUNDTRIP", None)
+
+        if cherry_picked:
+            producer: dict[str, Any] = {
+                "board_audit_source": "repository",
+                "repository": slug,
+                "git_sha": producer_sha,
+                "package_sha256": package_digest(worktree / "packages" / "board-audit"),
+            }
+        else:
+            caller_pkg = Path(os.environ.get("BOARD_AUDIT_CORE", str(HERE / "board-audit-core"))).resolve().parent
+            producer = caller_producer(caller_pkg)
+
+        # The raw acquisition lives outside the worktree (cache dir) so the
+        # isolated checkout stays clean for bd worktree remove; it is retained
+        # on failure as recovery evidence and removed after a successful run.
+        raw = worktree.parent / f"{identity}-{os.getpid()}.raw.jsonl"
+        try:
+            flow.run(["bd", "export", "--all", "-o", str(raw)], cwd=worktree)
+        except flow.FlowError as exc:
+            raise PRCheckpointError(BEADS_UNAVAILABLE, f"bd export --all failed: {exc}") from exc
+        if not raw.exists() or raw.stat().st_size == 0:
+            print("warning: Beads export is empty; publishing an empty open projection", file=sys.stderr)
+        try:
+            bd_version = flow.run(["bd", "version"], cwd=worktree, capture=True).stdout.strip().splitlines()[0]
+        except flow.FlowError:
+            bd_version = "unknown"
+
+        snapshot = compute_snapshot(raw, slug, bd_version, generated_at)
+
+        # NO_CHANGES: membership, issue hashes, PR head and the bounded
+        # work-package handoff (count) are unchanged. The count comparison
+        # also forces a republish when an older handoff lacks the work-package
+        # artifacts entirely.
+        if (
+            previous is not None
+            and str(previous.get("implementation_head_sha", "")) == str(info.get("headRefOid", ""))
+            and str(previous.get("snapshot_id", "")) == snapshot["snapshot_id"]
+            and str(previous.get("work_package_count", "") or "") == str(len(snapshot["roots"]))
+        ):
+            no_changes = True
+            if raw.exists():
+                raw.unlink()
+            print(f"NO_CHANGES: PR #{pr} handoff is already current")
+            print(f"  snapshot: {snapshot['snapshot_id']}")
+            print(f"  head:     {info.get('headRefOid')}")
+            return 0
+
+        # Bounded root/work-package handoff: derive the same work packages the
+        # handoff flow publishes, from the SAME acquisition (--from-raw), then
+        # prepare each as an editable round-trip artifact so the existing
+        # Web edit → reconcile → reconcile --execute contract resolves off
+        # this PR transport branch.
+        core, roundtrip = flow.script_paths()
+        try:
+            flow.run([str(core), "--export", "--open", "--from-raw", str(raw)], cwd=worktree)
+        except flow.FlowError as exc:
+            raise PRCheckpointError(SNAPSHOT_FAILED, f"work-package export failed: {exc}") from exc
+        export_dir = flow.latest_export_dir(worktree)
+        work_entries: list[tuple[str, Path, Path, dict[str, Any]]] = []
+        for root in snapshot["roots"]:
+            try:
+                package, manifest = flow.package_from_manifest(export_dir, root)
+            except flow.FlowError as exc:
+                print(f"warning: no work package for root {root}: {exc}", file=sys.stderr)
+                continue
+            prepared = flow.run(
+                [sys.executable, str(roundtrip), "prepare", str(package)],
+                cwd=worktree,
+                capture=True,
+            )
+            editable = Path(prepared.stdout.strip())
+            if not editable.is_absolute():
+                editable = (worktree / editable).resolve()
+            if not editable.exists():
+                raise PRCheckpointError(
+                    SNAPSHOT_FAILED,
+                    f"prepare did not create expected artifact: {editable}",
+                )
+            work_entries.append((root, package, editable, manifest))
+        # The branch carries exactly one current work-package export tree.
+        exports_root = board_audit_dir(worktree) / "exports"
+        if exports_root.exists():
+            for candidate in exports_root.iterdir():
+                if candidate.is_dir() and candidate != export_dir:
+                    shutil.rmtree(candidate)
+        # The projection files inside the worktree already carry lossless
+        # source records; the raw acquisition is no longer needed and keeping
+        # the checkout clean is what allows bd worktree remove to succeed.
+        if raw.exists():
+            raw.unlink()
+
+        # Committed evidence tree. transport_head_sha is sealed after the
+        # artifacts commit so the recorded SHA is an exact published transport
+        # SHA; the seal commit then becomes the branch head.
+        handoff = handoff_payload(slug, pr, info, snapshot, generated_at)
+        handoff["producer"] = producer
+        handoff["work_package_count"] = len(work_entries)
+        # Persists index.json (open_issues + pr_checkpoints); the per-root
+        # packages entries are merged on top by update_index_for_handoff.
+        build_index(worktree, snapshot, pr, info, generated_at)
+        for root, package, editable, manifest in work_entries:
+            flow.update_index_for_handoff(
+                worktree,
+                root,
+                remote_branch,
+                export_dir,
+                package,
+                editable,
+                manifest,
+            )
+        write_projection(worktree, snapshot)
+
+        handoff_path = board_audit_dir(worktree) / "handoffs" / f"pr-{pr}.json"
+        handoff_path.parent.mkdir(parents=True, exist_ok=True)
+        flow.write_json(handoff_path, handoff)
+        index_path = board_audit_dir(worktree) / "index.json"
+        # update_index_for_handoff already persisted the merged index (with
+        # the per-root packages entries); do not rewrite it here from the
+        # pre-loop ``index`` snapshot or the packages entries are lost.
+        snapshots_path = board_audit_dir(worktree) / "snapshots"
+        exports_path = board_audit_dir(worktree) / "exports"
+
+        try:
+            transport.commit_transport(
+                worktree,
+                paths=[snapshots_path, exports_path, index_path, handoff_path],
+                message=f"chore(board-audit): pr #{pr} checkpoint",
+            )
+        except flow.FlowError as exc:
+            raise PRCheckpointError(TRANSPORT_PUSH_FAILED, f"transport commit failed: {exc}") from exc
+
+        artifacts_sha = flow.git_output(worktree, "rev-parse", "HEAD")
+        handoff["transport_head_sha"] = artifacts_sha
+        flow.write_json(handoff_path, handoff)
+        try:
+            transport.commit_transport(
+                worktree,
+                paths=[handoff_path],
+                message=f"chore(board-audit): seal pr #{pr} transport head",
+            )
+        except flow.FlowError as exc:
+            raise PRCheckpointError(TRANSPORT_PUSH_FAILED, f"transport seal commit failed: {exc}") from exc
+
+        # The lease is popped inside push_transport, so capture whether a
+        # concurrent-update guard was armed before the push attempt: a failure
+        # with a lease held is a remote race (TRANSPORT_CONFLICT).
+        had_lease = remote_branch in transport._HANDOFF_LEASES
+        try:
+            transport.push_transport(worktree, remote_branch=remote_branch)
+        except flow.FlowError as exc:
+            kind = TRANSPORT_CONFLICT if had_lease else TRANSPORT_PUSH_FAILED
+            raise PRCheckpointError(kind, f"transport push failed: {exc}") from exc
+
+        head_after_push = flow.git_output(worktree, "rev-parse", "HEAD")
+        # Always publish the compact locator on the code PR so a web agent can
+        # find the evidence without guessing branch names. Idempotent: the
+        # existing locator comment is updated in place.
+        try:
+            post_locator_comment(repo, pr, locator_block(handoff))
+        except flow.FlowError as exc:
+            print(f"warning: could not post/update PR comment: {exc}", file=sys.stderr)
+    except PRCheckpointError:
+        keep = True
+        raise
+    except flow.FlowError as exc:
+        keep = True
+        raise PRCheckpointError(CLEANUP_BLOCKED, f"checkpoint failed: {exc}") from exc
+    except Exception as exc:
+        # Do not let a cleanup error in finally mask the real failure.
+        keep = True
+        raise PRCheckpointError(CLEANUP_BLOCKED, f"checkpoint failed unexpectedly: {exc!r}") from exc
+    finally:
+        if worktree is not None and staging:
+            if keep:
+                transport.cleanup_transport_worktree(repo, worktree, staging, keep_on_error=True)
+            else:
+                # The cherry-picked board-audit package was extracted without
+                # staging; discard it so the worktree matches the committed
+                # tree (only .xtrm/board-audit/** assets) before removal.
+                if cherry_picked:
+                    flow.run(["git", "clean", "-fdx", "--", "packages/board-audit"], cwd=worktree)
+                if no_changes:
+                    # Nothing was committed. The transport-branch restore staged
+                    # the previous artifacts into the index; discard them so the
+                    # untouched staging worktree matches HEAD exactly. Real bd
+                    # worktree removal refuses branches without a resolvable
+                    # upstream, so point the staging branch at the origin default
+                    # (HEAD equals it: the branch was created from it).
+                    flow.run(["git", "reset", "-q"], cwd=worktree)
+                    flow.run(
+                        ["git", "clean", "-fdx", "--", ".xtrm/board-audit"],
+                        cwd=worktree,
+                    )
+                    flow.run(
+                        ["git", "branch", "--set-upstream-to", flow.default_remote_ref(repo), staging],
+                        cwd=repo,
+                    )
+                    # flow.cleanup_transport_worktree is the transport-patched
+                    # version; the raw base implementation is preserved separately.
+                    transport._BASE_CLEANUP_TRANSPORT_WORKTREE(
+                        repo,
+                        worktree,
+                        staging,
+                        keep_on_error=False,
+                    )
+                else:
+                    # Verification of the exact remote transport SHA happens here;
+                    # a mismatch is a failed publication and retains recovery state.
+                    try:
+                        transport.cleanup_transport_worktree(repo, worktree, staging, keep_on_error=False)
+                    except flow.FlowError as exc:
+                        raise PRCheckpointError(TRANSPORT_VERIFY_FAILED, f"transport verification/cleanup failed: {exc}") from exc
+
+    assert handoff is not None
+    print(f"✓ PR #{pr} checkpoint published")
+    print(f"  branch:   {remote_branch}")
+    print(f"  head:     {info.get('headRefOid')}")
+    print(f"  snapshot: {snapshot['snapshot_id']}")
+    print(f"  transport:{head_after_push}")
+    print(f"  checkout: unchanged ({original_branch})")
+    print()
+    print(locator_block(handoff), end="")
+    return 0
+
+
+def cmd_pr_status(args: argparse.Namespace) -> int:
+    """Report handoff freshness against the live remote PR head."""
+    flow.require_commands("git", "gh")
+    repo = flow.repo_root()
+    pr = resolve_pr_number(repo, args.pr_number)
+    info = fetch_pr_info(repo, pr)
+
+    flow.run(["git", "fetch", "origin"], cwd=repo)
+    branch = f"board-audit/pr-{pr}"
+    handoff_rel = f".xtrm/board-audit/handoffs/pr-{pr}.json"
+    proc = flow.run(
+        ["git", "cat-file", "-e", f"origin/{branch}:{handoff_rel}"],
+        cwd=repo,
+        check=False,
+    )
+    if proc.returncode != 0:
+        print(f"STATUS: NO_HANDOFF (PR #{pr})")
+        return 3 if args.check else 0
+
+    text = flow.git_output(repo, "show", f"origin/{branch}:{handoff_rel}")
+    try:
+        handoff = json.loads(text)
+    except json.JSONDecodeError as exc:
+        print(f"STATUS: CORRUPT_HANDOFF (PR #{pr}: {exc})")
+        return 3 if args.check else 0
+
+    head_oid = str(info.get("headRefOid", ""))
+    current_head = head_oid == str(handoff.get("implementation_head_sha", ""))
+    snapshot_id = str(handoff.get("snapshot_id", ""))
+    # The snapshot is current only when its manifest actually resolves on the
+    # transport branch; a missing snapshot directory is a stale/broken handoff.
+    current_snapshot = False
+    if snapshot_id:
+        manifest_rel = f".xtrm/board-audit/snapshots/{snapshot_id}/manifest.json"
+        current_snapshot = (
+            flow.run(
+                ["git", "cat-file", "-e", f"origin/{branch}:{manifest_rel}"],
+                cwd=repo,
+                check=False,
+            ).returncode
+            == 0
+        )
+    if current_head and current_snapshot:
+        status = "FRESH"
+    elif not current_head:
+        status = "STALE_CODE_HEAD"
+    else:
+        status = "STALE_SNAPSHOT"
+
+    print(f"STATUS: {status} (PR #{pr})")
+    print(locator_block(handoff), end="")
+    print(f"Live head: {head_oid}")
+    if not current_head:
+        print(f"Handoff head: {handoff.get('implementation_head_sha')}")
+    if args.check and status != "FRESH":
+        return 3
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Doctor and init
+# ---------------------------------------------------------------------------
+
+DEFAULT_REF_HINT = "configure origin/HEAD or origin/main"
+
+
+def repo_carries_package(repo: Path) -> bool:
+    """True when the repository's default branch carries packages/board-audit.
+
+    Used to decide whether the checkpoint cherry-picks the package into the
+    isolated worktree (self-contained derivation) or falls back to the caller's
+    package.
+    """
+    try:
+        default_ref = flow.default_remote_ref(repo)
+    except flow.FlowError:
+        return False
+    probe = f"{default_ref}:packages/board-audit/board-audit-core"
+    return (
+        flow.run(["git", "cat-file", "-e", probe], cwd=repo, check=False).returncode
+        == 0
+    )
+
+
+def _report(mark: str, name: str, detail: str = "") -> None:
+    suffix = f" — {detail}" if detail else ""
+    print(f"[{mark}] {name}{suffix}")
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    """Check the environment and report PASS/FAIL/WARN per item."""
+    import shutil as _shutil
+
+    failures = 0
+    warnings = 0
+
+    # 1. git repository
+    repo: Path | None = None
+    if flow.run(["git", "rev-parse", "--is-inside-work-tree"], cwd=Path.cwd(), capture=True, check=False).returncode == 0:
+        repo = flow.repo_root()
+        _report("PASS", "git repository", str(repo))
+    else:
+        _report("FAIL", "git repository", "not inside a git working tree")
+        failures += 1
+        print("doctor: cannot continue without a git repository")
+        return 2
+
+    # 2. required commands
+    gh_present = False
+    for name in ("bd", "gh", "python3"):
+        if _shutil.which(name):
+            _report("PASS", f"command {name}")
+            if name == "gh":
+                gh_present = True
+        else:
+            _report("FAIL", f"command {name}", "not on PATH")
+            failures += 1
+
+    # 2b. usable GitHub authentication (binary exists != authenticated)
+    if gh_present:
+        auth = flow.run(["gh", "auth", "status"], cwd=repo, capture=True, check=False)
+        if auth.returncode == 0:
+            _report("PASS", "GitHub authentication", "gh auth status ok")
+        else:
+            _report("FAIL", "GitHub authentication", "gh auth status failed; run gh auth login")
+            failures += 1
+
+    # 3. beads workspace
+    ws = flow.run(["bd", "where"], cwd=repo, capture=True, check=False)
+    if ws.returncode == 0 and ws.stdout.strip():
+        _report("PASS", "beads workspace", ws.stdout.strip().splitlines()[0])
+    else:
+        _report("FAIL", "beads workspace", "bd where failed; run bd init or check the workspace")
+        failures += 1
+
+    # 4. board-audit package availability
+    if repo_carries_package(repo):
+        _report("PASS", "board-audit package", "carried by the repository default branch (cherry-picked into checkpoints)")
+    elif Path(os.environ.get("BOARD_AUDIT_CORE", str(HERE / "board-audit-core"))).exists():
+        _report("WARN", "board-audit package", "not carried by this repository; checkpoints use the caller's package")
+        warnings += 1
+    else:
+        _report("FAIL", "board-audit package", "no package copy found")
+        failures += 1
+
+    # 5. hooks
+    hooks_dir = Path(flow.git_output(repo, "rev-parse", "--git-path", "hooks"))
+    _report("PASS", "hooks directory", str(hooks_dir))
+    pre_push = hooks_dir / "pre-push"
+    if not pre_push.exists():
+        _report("WARN", "pre-push hook", "not installed; board-audit init installs it")
+        warnings += 1
+    else:
+        text = pre_push.read_text(encoding="utf-8", errors="replace")
+        if "BEGIN BEADS INTEGRATION" in text:
+            _report("PASS", "beads shim", "pre-push hooks managed by bd")
+        else:
+            _report("WARN", "beads shim", "no bd-managed pre-push shim; bd hooks install not run")
+            warnings += 1
+        if "[ $rc -ne 0 ] && exit $rc" in text:
+            _report("FAIL", "hook exit-status idiom", "broken && idiom present; every push will fail on success")
+            failures += 1
+        if "board-audit-pr-adapter" in text or "pr-checkpoint" in text:
+            _report("PASS", "checkpoint hook", "pre-push checkpoint adapter wired (every push to a PR branch publishes a fresh handoff)")
+        else:
+            _report("WARN", "checkpoint hook", "no automatic per-PR publication; run board-audit init")
+            warnings += 1
+        if f"{pre_push.name}.bd-sync" in text:
+            _report("PASS", "dolt-sync chaining", "beads/dolt sync before push")
+        else:
+            _report("WARN", "dolt-sync chaining", "no beads/dolt sync chaining")
+            warnings += 1
+
+    # 6. optional PR freshness
+    stale_pr = False
+    if getattr(args, "pr_number", None):
+        try:
+            pr = resolve_pr_number(repo, args.pr_number)
+            info = fetch_pr_info(repo, pr)
+            flow.run(["git", "fetch", "origin"], cwd=repo)
+            branch = f"board-audit/pr-{pr}"
+            handoff_rel = f".xtrm/board-audit/handoffs/pr-{pr}.json"
+            probe = flow.run(
+                ["git", "cat-file", "-e", f"origin/{branch}:{handoff_rel}"],
+                cwd=repo,
+                check=False,
+            )
+            if probe.returncode != 0:
+                _report("WARN", f"PR #{pr} handoff", "NO_HANDOFF")
+                warnings += 1
+            else:
+                handoff_text = flow.git_output(repo, "show", f"origin/{branch}:{handoff_rel}")
+                try:
+                    handoff = json.loads(handoff_text)
+                except json.JSONDecodeError:
+                    handoff = {}
+                if str(info.get("headRefOid", "")) != str(handoff.get("implementation_head_sha", "")):
+                    _report("WARN", f"PR #{pr} handoff", "STALE_CODE_HEAD — run pr-checkpoint")
+                    warnings += 1
+                    stale_pr = True
+                else:
+                    _report("PASS", f"PR #{pr} handoff", "FRESH")
+        except (flow.FlowError, PRCheckpointError) as exc:
+            _report("WARN", "PR freshness", str(exc))
+            warnings += 1
+
+    print()
+    if failures:
+        print(f"doctor: {failures} failure(s), {warnings} warning(s) — exit 2")
+        return 2
+    if stale_pr and args.check:
+        print("doctor: handoff stale — exit 3")
+        return 3
+    print(f"doctor: ok ({warnings} warning(s))")
+    return 0
+
+
+SYNC_CHAINING_TEMPLATE = """\
+# --- BEGIN custom: beads/dolt sync before {hook} ---
+# Outside bd's managed markers (bd hooks install/upgrade won't clobber).
+# Commits pending Beads changes, then pulls and pushes the Dolt remote
+# (refs/dolt/data on the GitHub origin). Fails the Git operation on sync failure.
+if [ -x "$(dirname "$0")/{hook}.bd-sync" ]; then
+    _bd_timeout=${{BEADS_HOOK_TIMEOUT:-300}}
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$_bd_timeout" "$(dirname "$0")/{hook}.bd-sync" "$@"
+    else
+        "$(dirname "$0")/{hook}.bd-sync" "$@"
+    fi
+    rc=$?
+    if [ $rc -ne 0 ]; then exit $rc; fi
+fi
+# --- END custom ---
+"""
+
+ADAPTER_CHAINING_TEMPLATE = """\
+# --- BEGIN custom: board-audit pr-checkpoint before push ---
+# Publishes a FRESH PR-checkpoint handoff for every push to a PR branch: the
+# adapter performs the code push itself (--no-verify), then binds the
+# checkpoint to the now-remote PR head, so the handoff is current, not stale.
+# Never blocks the code push: adapter failures only warn. Any agent in the
+# repository can verify the evidence via board-audit pr-status <pr> --check.
+if [ -x "{adapter}" ]; then
+    "{adapter}" "$@" || true
+fi
+# --- END custom ---
+"""
+
+# Self-contained Dolt-sync scripts so ``init`` works without a repo-level
+# scripts/hooks tree. Keep in sync with scripts/hooks/*.bd-sync at repo root.
+BD_SYNC_PRE_PUSH = """#!/usr/bin/env bash
+# Beads/Dolt sync chained from the pre-push hook.
+# Default the Dolt pre-push fsck timeout: 30s is too tight for large stores.
+: "${BEADS_FSCK_TIMEOUT:=600}"
+#
+# Synchronizes Beads data with the GitHub-backed Dolt remote (refs/dolt/data):
+#   1. commit pending Beads changes (idempotent)
+#   2. pull the Dolt remote (pull before push, per Beads concurrency policy)
+#   3. push the Dolt remote
+#
+# A non-zero exit aborts the Git push, so the push cannot succeed while Beads
+# state is unsynced.
+set -uo pipefail
+
+if ! command -v bd >/dev/null 2>&1 || ! bd where >/dev/null 2>&1; then
+  echo "beads-sync: no beads database in this checkout — skipping Dolt sync" >&2
+  exit 0
+fi
+
+echo "beads-sync: commit pending Beads changes"
+if ! bd dolt commit; then
+  echo "beads-sync: ERROR: 'bd dolt commit' failed — aborting Git push" >&2
+  exit 1
+fi
+
+echo "beads-sync: pull Dolt remote"
+if ! bd dolt pull; then
+  echo "beads-sync: ERROR: 'bd dolt pull' failed — aborting Git push" >&2
+  exit 1
+fi
+
+echo "beads-sync: push Dolt remote"
+if ! bd dolt push; then
+  echo "beads-sync: ERROR: 'bd dolt push' failed — aborting Git push" >&2
+  exit 1
+fi
+
+echo "beads-sync: Dolt sync OK"
+exit 0
+"""
+
+BD_SYNC_POST_MERGE = """#!/usr/bin/env bash
+# Beads/Dolt sync chained from the post-merge hook.
+: "${BEADS_FSCK_TIMEOUT:=600}"
+# Pulls Beads data from the GitHub-backed Dolt remote (refs/dolt/data) after a
+# Git pull/merge. A failed pull is reported loudly: the Git pull/merge command
+# reports failure (post-merge exit code) and the operator sees the message.
+set -uo pipefail
+
+if ! command -v bd >/dev/null 2>&1 || ! bd where >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "beads-sync: pull Dolt remote"
+if ! bd dolt pull; then
+  echo "beads-sync: ERROR: 'bd dolt pull' failed after Git merge." >&2
+  echo "beads-sync: Beads data may be stale. Run 'bd dolt pull' manually." >&2
+  exit 1
+fi
+exit 0
+"""
+
+
+def _append_if_absent(target: Path, marker: str, block: str) -> bool:
+    if not target.exists():
+        target.write_text("#!/usr/bin/env sh\n", encoding="utf-8")
+        target.chmod(0o755)
+    text = target.read_text(encoding="utf-8", errors="replace")
+    if marker in text:
+        return False
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(block)
+    return True
+
+
+def _replace_section(target: Path, begin: str, end: str, block: str) -> bool:
+    """Replace the delimited section holding ``begin``..``end`` with ``block``.
+
+    Used to re-point the board-audit chaining at the hooks-dir adapter copy
+    after ``init`` moves/updates the adapter, without touching the rest of the
+    hook file (bd shim, other chaining). Returns True when the file changed;
+    a section with identical content is left untouched (idempotent).
+    """
+    try:
+        text = target.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return False  # caller falls back to creating/append
+    start = text.find(begin)
+    if start == -1:
+        return False
+    stop = text.find("# --- END custom ---", start + len(begin))
+    if stop == -1:
+        return False
+    stop += len("# --- END custom ---")
+    if text.startswith("\n", stop):
+        stop += 1
+    if text[start:stop] == block:
+        return False
+    target.write_text(text[:start] + block + text[stop:], encoding="utf-8")
+    return True
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    """Non-destructive additive setup: hooks + chaining, no branch or tree changes."""
+    repo = flow.repo_root()
+    hooks_dir = Path(flow.git_output(repo, "rev-parse", "--git-path", "hooks"))
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"init: {repo}")
+
+    # 1. refresh the bd-managed shims (additive; preserves custom blocks)
+    if shutil.which("bd"):
+        flow.run(["bd", "hooks", "install"], cwd=repo)
+        print("  · refreshed bd hook shims")
+
+    # 2. Dolt-sync scripts + chaining (if-idiom). The chaining block is
+    # section-replaced when an older installed version differs (e.g. a
+    # leftover explicit `exit 0` that would terminate the hook before later
+    # chained blocks like the board-audit adapter).
+    sync_src = HERE / "scripts" / "hooks"
+    embedded = {"pre-push": BD_SYNC_PRE_PUSH, "post-merge": BD_SYNC_POST_MERGE}
+    for hook in ("pre-push", "post-merge"):
+        target = hooks_dir / f"{hook}.bd-sync"
+        template = sync_src / f"{hook}.bd-sync"
+        content = template.read_text(encoding="utf-8") if template.exists() else embedded[hook]
+        target.write_text(content, encoding="utf-8")
+        target.chmod(0o700)
+        sync_block = SYNC_CHAINING_TEMPLATE.format(hook=hook)
+        if _replace_section(
+            hooks_dir / hook,
+            # The historical installed block says "before push"; the template
+            # says "before pre-push". Match the shared prefix so an older
+            # installed block is found and replaced either way.
+            "# --- BEGIN custom: beads/dolt sync before",
+            "# --- END custom",
+            sync_block,
+        ):
+            print(f"  · refreshed {hook} dolt-sync chaining")
+        elif _append_if_absent(
+            hooks_dir / hook,
+            f"{hook}.bd-sync",
+            sync_block,
+        ):
+            print(f"  · added {hook} dolt-sync chaining")
+        else:
+            print(f"  · {hook} dolt-sync chaining already present")
+
+    # 3. PR-checkpoint adapter + runtime (pre-push). The adapter and its python
+    # runtime are staged into the hooks dir so the wiring survives
+    # worktree/session churn and the hook is self-contained (sibling-based
+    # imports: pr.py loads flow/transport from its own directory). A
+    # pre-existing chaining that points at an older path is replaced in place
+    # (section-scoped, additive elsewhere).
+    adapter = HERE / "board-audit-pr-adapter.sh"
+    if adapter.exists():
+        runtime_files = [
+            "board-audit-pr-adapter.sh",
+            "board-audit-pr.py",
+            "board-audit-flow.py",
+            "board-audit-transport.py",
+            "board-audit-roundtrip.py",
+            "board-audit-core",
+        ]
+        for name in runtime_files:
+            src = HERE / name
+            if not src.exists():
+                continue
+            dst = hooks_dir / name
+            if not dst.exists() or dst.read_bytes() != src.read_bytes():
+                shutil.copyfile(src, dst)
+                if name in ("board-audit-core", "board-audit-pr-adapter.sh"):
+                    dst.chmod(0o755)
+        installed_adapter = hooks_dir / "board-audit-pr-adapter.sh"
+        section = ADAPTER_CHAINING_TEMPLATE.format(adapter=installed_adapter)
+        if _replace_section(
+            hooks_dir / "pre-push",
+            "# --- BEGIN custom: board-audit pr-checkpoint",
+            "# --- END custom",
+            section,
+        ):
+            print("  · re-pointed pr-checkpoint chaining to hooks-dir adapter")
+        elif _append_if_absent(
+            hooks_dir / "pre-push",
+            "board-audit-pr-adapter",
+            section,
+        ):
+            print("  · added pr-checkpoint adapter to pre-push")
+        else:
+            print("  · pr-checkpoint adapter already present")
+
+    # 4. package availability notice
+    if repo_carries_package(repo):
+        print("  · repo carries packages/board-audit; checkpoints are self-contained")
+    else:
+        print("  · WARN: repo does not carry packages/board-audit; checkpoints use the caller's package")
+        print("    (commit the package or install it; doctor reports this as a warning)")
+
+    print("✓ init complete — additive only; no working-tree or branch changes")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="board-audit pr",
+        description="PR-checkpoint Board-Audit handoffs: per-Bead evidence projection bound to an exact PR head.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    checkpoint = sub.add_parser("pr-checkpoint", help="publish/refresh a PR-checkpoint handoff for the exact remote PR head")
+    checkpoint.add_argument("pr_number", nargs="?", help="pull request number; default: current branch's PR")
+    checkpoint.add_argument("--comment", action="store_true", help="deprecated: the locator comment is now always posted/updated")
+    checkpoint.add_argument("--trigger", choices=["manual", "auto", "hook"], default=None, help="publication trigger class (classification only; publication is never blocked by an allowlist)")
+    checkpoint.set_defaults(func=cmd_pr_checkpoint)
+
+    status = sub.add_parser("pr-status", help="report handoff freshness (FRESH / STALE_CODE_HEAD / STALE_SNAPSHOT / NO_HANDOFF)")
+    status.add_argument("pr_number", nargs="?", help="pull request number; default: current branch's PR")
+    status.add_argument("--check", action="store_true", help="exit 3 when the handoff is not FRESH")
+    status.set_defaults(func=cmd_pr_status)
+
+    doctor = sub.add_parser("doctor", help="check the environment: repo, commands, beads workspace, package, hooks, optional PR freshness")
+    doctor.add_argument("pr_number", nargs="?", help="optional pull request number to also check handoff freshness")
+    doctor.add_argument("--check", action="store_true", help="exit 3 when the checked PR handoff is stale")
+    doctor.set_defaults(func=cmd_doctor)
+
+    init = sub.add_parser("init", help="non-destructive additive setup: install the pre-push checkpoint hook and dolt-sync chaining (idempotent)")
+    init.set_defaults(func=cmd_init)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        parser = build_parser()
+        args = parser.parse_args(argv)
+        if not getattr(args, "command", None):
+            parser.print_help()
+            return 0
+        return int(args.func(args))
+    except PRCheckpointError as exc:
+        print(f"FAILURE: {exc}", file=sys.stderr)
+        return 2
+    except flow.FlowError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.githooks/board-audit-roundtrip.py
+++ b/.githooks/board-audit-roundtrip.py
@@ -1,0 +1,1391 @@
+#!/usr/bin/env python3
+"""Safe Beads work-package edit/reconcile/apply tool for board-audit.
+
+A package exported by ``board-audit --export`` contains immutable source state
+under ``issues.<id>.source``. ``prepare`` adds a separate ``desired_issues``
+projection and ``new_comments`` plane for human/model edits.
+
+Before compilation the tool performs a three-way reconciliation:
+
+    base (export) + current (fresh bd export --all) + desired (edited artifact)
+
+Overlapping changes fail closed. Disjoint concurrent changes survive. Existing
+Beads lifecycle/claim/storage state is deliberately read-only in round-trip v1.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import datetime as dt
+import hashlib
+import json
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+PACKAGE_SCHEMA = "xtrm.board-audit.work-package.v1"
+ROUNDTRIP_SCHEMA = "xtrm.board-audit.roundtrip.v1"
+PLAN_SCHEMA = "xtrm.board-audit.apply-plan.v1"
+
+PROTECTED_EXISTING_FIELDS = {
+    "id",
+    "created_at",
+    "created",
+    "created_by",
+    "updated_at",
+    "updated",
+    "closed_at",
+    "started_at",
+}
+
+# Fields that an edited package may change on an existing Beads record. This is
+# intentionally narrower than the lossless export schema. Assignment, status,
+# lease/heartbeat, scheduling, persistence, compaction, gates/events and other
+# operational state must eventually use their guarded native commands instead
+# of the migration/recovery import door.
+EDITABLE_EXISTING_FIELDS = {
+    "title",
+    "description",
+    "design",
+    "acceptance_criteria",
+    "notes",
+    "spec_id",
+    "priority",
+    "issue_type",
+    "estimated_minutes",
+    "external_ref",
+    "metadata",
+    "labels",
+    "dependencies",
+    "deps",
+    "relations",
+}
+NEW_ISSUE_FIELDS = set(EDITABLE_EXISTING_FIELDS)
+AUX_FIELDS = {"labels", "dependencies", "deps", "relations", "comments"}
+MISSING = object()
+
+
+class RoundtripError(RuntimeError):
+    pass
+
+
+def utcnow() -> str:
+    return (
+        dt.datetime.now(dt.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def canonical_bytes(obj: Any) -> bytes:
+    return (
+        json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        + "\n"
+    ).encode()
+
+
+def sha256_obj(obj: Any) -> str:
+    return hashlib.sha256(canonical_bytes(obj)).hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RoundtripError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RoundtripError("work package must be a JSON object")
+    return data
+
+
+def write_json(path: Path, obj: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(obj, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_export_rows(path: Path) -> list[dict[str, Any]]:
+    """Read canonical Beads JSONL, plus common list/object wrappers for tests."""
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return []
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+
+    if isinstance(parsed, list):
+        return [r for r in parsed if isinstance(r, dict) and r.get("id")]
+    if isinstance(parsed, dict):
+        for key in ("issues", "beads", "records"):
+            if isinstance(parsed.get(key), list):
+                return [
+                    r for r in parsed[key] if isinstance(r, dict) and r.get("id")
+                ]
+        if parsed.get("id"):
+            return [parsed]
+
+    rows: list[dict[str, Any]] = []
+    for line_no, line in enumerate(text.splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RoundtripError(f"invalid JSONL line {line_no}: {exc}") from exc
+        if isinstance(row, dict) and row.get("_schema"):
+            continue
+        if isinstance(row, dict) and row.get("id"):
+            rows.append(row)
+    return rows
+
+
+def source_issues(pkg: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    issues = pkg.get("issues")
+    if not isinstance(issues, dict):
+        raise RoundtripError("package issues must be an object")
+
+    out: dict[str, dict[str, Any]] = {}
+    for key, wrapper in issues.items():
+        if not isinstance(wrapper, dict) or not isinstance(wrapper.get("source"), dict):
+            raise RoundtripError(f"issues.{key}.source must be an object")
+        row = wrapper["source"]
+        rid = str(row.get("id") or key)
+        if rid != str(key):
+            raise RoundtripError(
+                f"issues.{key}.source.id is {rid!r}; IDs must agree"
+            )
+        out[rid] = row
+    return out
+
+
+def selected_ids(pkg: dict[str, Any]) -> set[str]:
+    return {
+        str(key)
+        for key, wrapper in (pkg.get("issues") or {}).items()
+        if isinstance(wrapper, dict) and wrapper.get("selection_state") != "context-only"
+    }
+
+
+def prepare_package(pkg: dict[str, Any]) -> dict[str, Any]:
+    if pkg.get("schema_version") != PACKAGE_SCHEMA:
+        raise RoundtripError(
+            f"unsupported package schema {pkg.get('schema_version')!r}"
+        )
+
+    base = source_issues(pkg)
+    selected = selected_ids(pkg)
+    out = copy.deepcopy(pkg)
+    out.setdefault(
+        "desired_issues",
+        {rid: copy.deepcopy(base[rid]) for rid in sorted(selected)},
+    )
+    out.setdefault("new_comments", {})
+    out.setdefault("roundtrip", {})
+    out["roundtrip"].update(
+        {
+            "schema_version": ROUNDTRIP_SCHEMA,
+            "prepared_at": out["roundtrip"].get("prepared_at") or utcnow(),
+            "base_package_sha256": out.get("content_sha256") or sha256_obj(pkg),
+            "base_record_sha256": {
+                rid: sha256_obj(base[rid]) for rid in sorted(base)
+            },
+            "edit_contract": (
+                "modify desired_issues and new_comments only; "
+                "issues.*.source is immutable base state"
+            ),
+        }
+    )
+    return out
+
+
+def desired_issues(pkg: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    raw = pkg.get("desired_issues")
+    if not isinstance(raw, dict):
+        raise RoundtripError(
+            "package is not prepared: missing desired_issues; run prepare first"
+        )
+
+    out: dict[str, dict[str, Any]] = {}
+    for key, row in raw.items():
+        if not isinstance(row, dict):
+            raise RoundtripError(f"desired_issues.{key} must be an object")
+        rid = str(row.get("id") or key)
+        if rid != str(key):
+            raise RoundtripError(
+                f"desired_issues.{key}.id is {rid!r}; IDs must agree"
+            )
+        row = copy.deepcopy(row)
+        row["id"] = rid
+        out[rid] = row
+    return out
+
+
+def proposed_comments(pkg: dict[str, Any]) -> dict[str, list[str]]:
+    raw = pkg.get("new_comments", {})
+    if not isinstance(raw, dict):
+        raise RoundtripError("new_comments must be an object mapping issue IDs to text lists")
+
+    out: dict[str, list[str]] = {}
+    for key, values in raw.items():
+        rid = str(key)
+        if not isinstance(values, list):
+            raise RoundtripError(f"new_comments.{rid} must be a list of strings")
+        texts: list[str] = []
+        for idx, text in enumerate(values):
+            if not isinstance(text, str) or not text.strip():
+                raise RoundtripError(
+                    f"new_comments.{rid}[{idx}] must be a non-empty string"
+                )
+            texts.append(text)
+        if texts:
+            out[rid] = texts
+    return out
+
+
+def comment_text(comment: Any) -> str | None:
+    if isinstance(comment, str):
+        return comment
+    if isinstance(comment, dict):
+        for key in ("text", "body", "comment"):
+            value = comment.get(key)
+            if isinstance(value, str):
+                return value
+    return None
+
+
+def validate_package(
+    pkg: dict[str, Any], *, allow_context_edit: bool = False
+) -> list[str]:
+    if pkg.get("schema_version") != PACKAGE_SCHEMA:
+        raise RoundtripError(
+            f"unsupported package schema {pkg.get('schema_version')!r}"
+        )
+
+    base = source_issues(pkg)
+    desired = desired_issues(pkg)
+    selected = selected_ids(pkg)
+    comments = proposed_comments(pkg)
+    warnings: list[str] = []
+
+    rt = pkg.get("roundtrip")
+    if not isinstance(rt, dict) or rt.get("schema_version") != ROUNDTRIP_SCHEMA:
+        raise RoundtripError("missing/unsupported roundtrip metadata; run prepare first")
+    recorded = rt.get("base_record_sha256")
+    if not isinstance(recorded, dict):
+        raise RoundtripError("roundtrip.base_record_sha256 is missing")
+
+    tampered = [
+        rid for rid, row in base.items() if recorded.get(rid) != sha256_obj(row)
+    ]
+    if tampered:
+        raise RoundtripError(
+            "immutable base source records were modified: "
+            + ", ".join(sorted(tampered))
+        )
+
+    missing = selected - desired.keys()
+    if missing:
+        raise RoundtripError(
+            "desired_issues may not delete existing selected beads; "
+            "close/supersede requires a future guarded lifecycle compiler: "
+            + ", ".join(sorted(missing))
+        )
+
+    context = set(base) - selected
+    edited_context = context & desired.keys()
+    if edited_context and not allow_context_edit:
+        raise RoundtripError(
+            "context-only ancestors are read-only by default: "
+            + ", ".join(sorted(edited_context))
+        )
+
+    for rid, row in desired.items():
+        if rid not in base:
+            if not str(row.get("title") or "").strip():
+                raise RoundtripError(f"new bead {rid} requires title")
+            unsupported = sorted(set(row) - NEW_ISSUE_FIELDS - {"id"})
+            if unsupported:
+                raise RoundtripError(
+                    f"new bead {rid}: unsupported v1 fields: {', '.join(unsupported)}"
+                )
+            continue
+
+        b = base[rid]
+        for field in PROTECTED_EXISTING_FIELDS:
+            if field == "id":
+                continue
+            if row.get(field, MISSING) != b.get(field, MISSING):
+                raise RoundtripError(
+                    f"{rid}: protected provenance field {field!r} was edited"
+                )
+
+        changed = {
+            field
+            for field in set(b) | set(row)
+            if row.get(field, MISSING) != b.get(field, MISSING)
+        }
+        unsupported = sorted(
+            changed - EDITABLE_EXISTING_FIELDS - PROTECTED_EXISTING_FIELDS
+        )
+        if unsupported:
+            raise RoundtripError(
+                f"{rid}: fields are preserved losslessly but not mutable through "
+                f"round-trip v1: {', '.join(unsupported)}"
+            )
+
+    unknown_comment_targets = set(comments) - set(desired)
+    if unknown_comment_targets:
+        raise RoundtripError(
+            "new_comments targets must be selected/new desired issues: "
+            + ", ".join(sorted(unknown_comment_targets))
+        )
+
+    package_ids = set(base) | set(desired)
+    for rid, row in desired.items():
+        for rel in relation_map(rid, row):
+            if rel[1] not in package_ids:
+                warnings.append(
+                    f"{rid}: relation target {rel[1]} is outside this package; "
+                    "current-board validation will resolve it"
+                )
+    return warnings
+
+
+def dep_target(dep: Any) -> str | None:
+    if isinstance(dep, str):
+        return dep
+    if not isinstance(dep, dict):
+        return None
+    for key in (
+        "depends_on_id",
+        "depends_on_issue_id",
+        "target_id",
+        "target",
+        "bead_id",
+        "id",
+    ):
+        value = dep.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def dep_type(dep: Any, default: str = "blocks") -> str:
+    if isinstance(dep, dict):
+        return str(
+            dep.get("type")
+            or dep.get("dependency_type")
+            or dep.get("relation_type")
+            or default
+        )
+    return default
+
+
+def relation_map(
+    rid: str, row: dict[str, Any]
+) -> dict[tuple[str, str, str], Any]:
+    out: dict[tuple[str, str, str], Any] = {}
+    for field in ("dependencies", "deps", "relations"):
+        values = row.get(field)
+        if not isinstance(values, list):
+            continue
+        for dep in values:
+            target = dep_target(dep)
+            if target:
+                out[(rid, target, dep_type(dep))] = copy.deepcopy(dep)
+    return out
+
+
+def val(value: Any) -> Any:
+    return "<missing>" if value is MISSING else value
+
+
+def merge_metadata(
+    base: Any,
+    desired: Any,
+    current: Any,
+    rid: str,
+    conflicts: list[dict[str, Any]],
+) -> Any:
+    if not all(isinstance(x, dict) for x in (base, desired, current)):
+        if desired != base and current != base and desired != current:
+            conflicts.append(
+                {
+                    "id": rid,
+                    "field": "metadata",
+                    "base": base,
+                    "current": current,
+                    "desired": desired,
+                }
+            )
+        return copy.deepcopy(desired if desired != base else current)
+
+    result = copy.deepcopy(current)
+    for key in set(base) | set(desired) | set(current):
+        b = base.get(key, MISSING)
+        d = desired.get(key, MISSING)
+        c = current.get(key, MISSING)
+        user_changed = d != b
+        current_changed = c != b
+        if user_changed and current_changed and d != c:
+            conflicts.append(
+                {
+                    "id": rid,
+                    "field": f"metadata.{key}",
+                    "base": val(b),
+                    "current": val(c),
+                    "desired": val(d),
+                }
+            )
+            continue
+        if user_changed:
+            if d is MISSING:
+                result.pop(key, None)
+            else:
+                result[key] = copy.deepcopy(d)
+    return result
+
+
+def merge_labels(base: Any, desired: Any, current: Any) -> tuple[list[str], list[str], list[str]]:
+    b = {str(x) for x in (base if isinstance(base, list) else [])}
+    d = {str(x) for x in (desired if isinstance(desired, list) else [])}
+    c = {str(x) for x in (current if isinstance(current, list) else [])}
+    added = d - b
+    removed = b - d
+    return sorted((c - removed) | added), sorted(added), sorted(removed)
+
+
+def merge_dependencies(
+    rid: str,
+    base: dict[str, Any],
+    desired: dict[str, Any],
+    current: dict[str, Any],
+) -> tuple[
+    list[Any],
+    set[tuple[str, str, str]],
+    set[tuple[str, str, str]],
+    set[tuple[str, str, str]],
+]:
+    bm = relation_map(rid, base)
+    dm = relation_map(rid, desired)
+    cm = relation_map(rid, current)
+    b, d, c = set(bm), set(dm), set(cm)
+    added = d - b
+    removed = b - d
+    result_keys = (c - removed) | added
+
+    merged: list[Any] = []
+    for key in sorted(result_keys):
+        raw = dm.get(key) or cm.get(key) or bm.get(key)
+        if isinstance(raw, dict):
+            merged.append(copy.deepcopy(raw))
+        else:
+            merged.append(
+                {
+                    "issue_id": rid,
+                    "depends_on_id": key[1],
+                    "type": key[2],
+                }
+            )
+    return merged, added, removed, result_keys
+
+
+def merge_issue(
+    base: dict[str, Any],
+    desired: dict[str, Any],
+    current: dict[str, Any],
+    rid: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    conflicts: list[dict[str, Any]] = []
+    result = copy.deepcopy(current)
+    user_changed_fields: list[str] = []
+    current_changed_fields: list[str] = []
+
+    special = AUX_FIELDS | {"metadata"}
+    for field in sorted(set(base) | set(desired) | set(current)):
+        if field in special or field in PROTECTED_EXISTING_FIELDS:
+            continue
+        b = base.get(field, MISSING)
+        d = desired.get(field, MISSING)
+        c = current.get(field, MISSING)
+        user_changed = d != b
+        current_changed = c != b
+        if user_changed:
+            user_changed_fields.append(field)
+        if current_changed:
+            current_changed_fields.append(field)
+        if user_changed and current_changed and d != c:
+            conflicts.append(
+                {
+                    "id": rid,
+                    "field": field,
+                    "base": val(b),
+                    "current": val(c),
+                    "desired": val(d),
+                }
+            )
+            continue
+        if user_changed:
+            if d is MISSING:
+                result.pop(field, None)
+            else:
+                result[field] = copy.deepcopy(d)
+
+    result["metadata"] = merge_metadata(
+        base.get("metadata", {}),
+        desired.get("metadata", {}),
+        current.get("metadata", {}),
+        rid,
+        conflicts,
+    )
+
+    labels, label_add, label_remove = merge_labels(
+        base.get("labels"), desired.get("labels"), current.get("labels")
+    )
+    if "labels" in base or "labels" in desired or "labels" in current:
+        result["labels"] = labels
+
+    dependencies, dep_add, dep_remove, dep_result = merge_dependencies(
+        rid, base, desired, current
+    )
+    if any(
+        key in base or key in desired or key in current
+        for key in ("dependencies", "deps", "relations")
+    ):
+        result["dependencies"] = dependencies
+        result.pop("deps", None)
+        result.pop("relations", None)
+
+    # Historical comments are never editor-controlled. The freshest local
+    # comments ride through the import row unchanged; proposals use native
+    # ``bd comments add`` after import so Beads owns author/timestamp provenance.
+    if "comments" in current:
+        result["comments"] = copy.deepcopy(current["comments"])
+
+    result["id"] = rid
+    for field in ("created_at", "created", "created_by"):
+        if field in current:
+            result[field] = copy.deepcopy(current[field])
+        elif field in base:
+            result[field] = copy.deepcopy(base[field])
+
+    issue_changed = desired != base
+    return result, {
+        "id": rid,
+        "new": False,
+        "issue_changed": issue_changed,
+        "changed": issue_changed,
+        "user_changed_fields": user_changed_fields,
+        "current_changed_fields": current_changed_fields,
+        "label_add": label_add,
+        "label_remove": label_remove,
+        "dependency_add": [list(x) for x in sorted(dep_add)],
+        "dependency_remove": [list(x) for x in sorted(dep_remove)],
+        "dependency_result": [list(x) for x in sorted(dep_result)],
+        "new_comment_count": 0,
+        "conflicts": conflicts,
+    }
+
+
+def acquire_current_jsonl() -> tuple[Path, tempfile.TemporaryDirectory[str]]:
+    if shutil.which("bd") is None:
+        raise RoundtripError(
+            "bd is not on PATH; pass --current-jsonl for offline reconciliation"
+        )
+
+    td = tempfile.TemporaryDirectory(prefix="board-audit-roundtrip-")
+    path = Path(td.name) / "current.jsonl"
+    proc = subprocess.run(
+        ["bd", "export", "--all", "-o", str(path)],
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != 0 or not path.exists():
+        proc = subprocess.run(
+            ["bd", "export", "--all"], text=True, capture_output=True
+        )
+        if proc.returncode != 0:
+            td.cleanup()
+            raise RoundtripError(
+                f"bd export --all failed: {proc.stderr.strip() or proc.stdout.strip()}"
+            )
+        path.write_text(proc.stdout, encoding="utf-8")
+    return path, td
+
+
+def current_map(path: Path) -> dict[str, dict[str, Any]]:
+    return {
+        str(row["id"]): row
+        for row in read_export_rows(path)
+        if row.get("id") is not None
+    }
+
+
+def reconcile(
+    pkg: dict[str, Any],
+    current: dict[str, dict[str, Any]],
+    *,
+    allow_context_edit: bool = False,
+) -> dict[str, Any]:
+    warnings = validate_package(pkg, allow_context_edit=allow_context_edit)
+    base = source_issues(pkg)
+    desired = desired_issues(pkg)
+    comments = proposed_comments(pkg)
+    merged: dict[str, dict[str, Any]] = {}
+    changes: list[dict[str, Any]] = []
+    conflicts: list[dict[str, Any]] = []
+
+    for rid in sorted(desired):
+        d = desired[rid]
+        if rid not in base:
+            if rid in current:
+                conflict = {
+                    "id": rid,
+                    "field": "<issue>",
+                    "base": "missing",
+                    "current": "present",
+                    "desired": "new",
+                }
+                conflicts.append(conflict)
+                changes.append(
+                    {
+                        "id": rid,
+                        "new": True,
+                        "issue_changed": True,
+                        "changed": True,
+                        "new_comment_count": len(comments.get(rid, [])),
+                        "conflicts": [conflict],
+                    }
+                )
+                continue
+
+            row = copy.deepcopy(d)
+            row["id"] = rid
+            # Beads JSON unmarshal defaults status/type but omitted integer
+            # priority becomes P0. Set explicit conservative creation defaults.
+            row.setdefault("status", "open")
+            row.setdefault("priority", 2)
+            row.setdefault("issue_type", "task")
+            merged[rid] = row
+            changes.append(
+                {
+                    "id": rid,
+                    "new": True,
+                    "issue_changed": True,
+                    "changed": True,
+                    "user_changed_fields": sorted(row),
+                    "current_changed_fields": [],
+                    "label_add": sorted(str(x) for x in row.get("labels", [])),
+                    "label_remove": [],
+                    "dependency_add": [
+                        list(x) for x in sorted(relation_map(rid, row))
+                    ],
+                    "dependency_remove": [],
+                    "dependency_result": [
+                        list(x) for x in sorted(relation_map(rid, row))
+                    ],
+                    "new_comment_count": len(comments.get(rid, [])),
+                    "conflicts": [],
+                }
+            )
+            continue
+
+        if rid not in current:
+            conflict = {
+                "id": rid,
+                "field": "<issue>",
+                "base": "present",
+                "current": "missing",
+                "desired": "present",
+            }
+            conflicts.append(conflict)
+            changes.append(
+                {
+                    "id": rid,
+                    "new": False,
+                    "issue_changed": d != base[rid],
+                    "changed": d != base[rid] or bool(comments.get(rid)),
+                    "new_comment_count": len(comments.get(rid, [])),
+                    "conflicts": [conflict],
+                }
+            )
+            continue
+
+        row, change = merge_issue(base[rid], d, current[rid], rid)
+        change["new_comment_count"] = len(comments.get(rid, []))
+        change["changed"] = bool(change["issue_changed"] or comments.get(rid))
+        merged[rid] = row
+        changes.append(change)
+        conflicts.extend(change["conflicts"])
+
+    known = set(current) | set(desired)
+    for rid, row in desired.items():
+        for rel in relation_map(rid, row):
+            if rel[1] not in known:
+                conflicts.append(
+                    {
+                        "id": rid,
+                        "field": "dependencies",
+                        "base": None,
+                        "current": "target missing",
+                        "desired": list(rel),
+                    }
+                )
+
+    return {
+        "schema_version": "xtrm.board-audit.reconciliation.v1",
+        "generated_at": utcnow(),
+        "root_id": pkg.get("root_id"),
+        "warnings": sorted(set(warnings)),
+        "changes": changes,
+        "conflicts": conflicts,
+        "merged_issues": merged,
+        "new_comments": comments,
+        "safe": not conflicts,
+    }
+
+
+def ensure_updated_at(row: dict[str, Any], *, is_new: bool) -> dict[str, Any]:
+    out = copy.deepcopy(row)
+    if is_new:
+        return out
+    stamp = utcnow()
+    if "updated_at" in out or "updated" not in out:
+        out["updated_at"] = stamp
+        out.pop("updated", None)
+    else:
+        out["updated"] = stamp
+    return out
+
+
+def cycle_signature(cycle: Any) -> tuple[str, ...] | str:
+    if isinstance(cycle, dict) and isinstance(cycle.get("members"), list):
+        ids = [
+            str(member["id"])
+            for member in cycle["members"]
+            if isinstance(member, dict) and member.get("id") is not None
+        ]
+        if ids:
+            return tuple(ids)
+    return "raw:" + sha256_obj(cycle)
+
+
+def introduced_cycles(before: list[Any], after: list[Any]) -> list[Any]:
+    known = {cycle_signature(cycle) for cycle in before}
+    return [cycle for cycle in after if cycle_signature(cycle) not in known]
+
+
+def post_commands(rec: dict[str, Any]) -> list[list[str]]:
+    commands: list[list[str]] = []
+    for change in rec["changes"]:
+        if change.get("new") or not change.get("issue_changed"):
+            continue
+        rid = change["id"]
+        for label in change.get("label_remove", []):
+            commands.append(["bd", "update", rid, "--remove-label", label])
+
+        removed = {tuple(x) for x in change.get("dependency_remove", [])}
+        result = {tuple(x) for x in change.get("dependency_result", [])}
+        pairs = {(source, target) for source, target, _ in removed}
+        for source, target in sorted(pairs):
+            # ``bd dep remove`` removes the source/target pair irrespective of
+            # relation type. Re-add every type that the reconciled graph keeps.
+            commands.append(["bd", "dep", "remove", source, target])
+            for s, t, typ in sorted(
+                edge
+                for edge in result
+                if edge[0] == source and edge[1] == target
+            ):
+                commands.append(["bd", "dep", "add", s, t, "--type", typ])
+
+    for rid in sorted(rec.get("new_comments", {})):
+        for text in rec["new_comments"][rid]:
+            commands.append(["bd", "comments", "add", rid, text])
+    return commands
+
+
+def compile_plan(
+    pkg_path: Path,
+    pkg: dict[str, Any],
+    current_path: Path,
+    out_dir: Path,
+    *,
+    allow_context_edit: bool = False,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    rec = reconcile(
+        pkg, current_map(current_path), allow_context_edit=allow_context_edit
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    if not rec["safe"]:
+        write_json(out_dir / "changes.json", rec)
+        raise RoundtripError(
+            f"three-way reconciliation found {len(rec['conflicts'])} conflict(s); "
+            f"see {out_dir / 'changes.json'}"
+        )
+
+    base = source_issues(pkg)
+    changed_ids = [change["id"] for change in rec["changes"] if change["changed"]]
+    import_ids = [
+        change["id"]
+        for change in rec["changes"]
+        if change.get("new") or change.get("issue_changed")
+    ]
+    records = [
+        ensure_updated_at(rec["merged_issues"][rid], is_new=rid not in base)
+        for rid in import_ids
+    ]
+
+    import_path = out_dir / "beads-import.jsonl"
+    with import_path.open("w", encoding="utf-8") as handle:
+        for row in records:
+            handle.write(
+                json.dumps(
+                    row,
+                    ensure_ascii=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+                + "\n"
+            )
+
+    commands = post_commands(rec)
+    plan = {
+        "schema_version": PLAN_SCHEMA,
+        "generated_at": utcnow(),
+        "package": str(pkg_path),
+        "base_package_sha256": (pkg.get("roundtrip") or {}).get(
+            "base_package_sha256"
+        ),
+        "current_snapshot_sha256": hashlib.sha256(
+            current_path.read_bytes()
+        ).hexdigest(),
+        "import_file": "beads-import.jsonl",
+        "changed_ids": changed_ids,
+        "import_ids": import_ids,
+        "post_import_commands": commands,
+        "conflict_count": 0,
+        "verified_against_current": True,
+    }
+    write_json(out_dir / "changes.json", rec)
+    write_json(out_dir / "apply-plan.json", plan)
+
+    apply_sh = out_dir / "apply.sh"
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'HERE="$(cd "$(dirname "$0")" && pwd)"',
+        'CYCLES_BEFORE="$(mktemp)"',
+        'CYCLES_AFTER="$(mktemp)"',
+        'trap \'rm -f "$CYCLES_BEFORE" "$CYCLES_AFTER"\' EXIT',
+        'bd dep cycles --json > "$CYCLES_BEFORE"',
+        'if [ -s "$HERE/beads-import.jsonl" ]; then',
+        '  echo "== Beads import dry-run =="',
+        '  bd import "$HERE/beads-import.jsonl" --dry-run --json',
+        "else",
+        '  echo "== No issue-row import required =="',
+        "fi",
+        'if [ "${1:-}" != "--execute" ]; then',
+        '  echo "dry-run only; pass --execute to mutate" >&2',
+        "  exit 0",
+        "fi",
+        'if [ -s "$HERE/beads-import.jsonl" ]; then',
+        '  bd import "$HERE/beads-import.jsonl" --json',
+        "fi",
+    ]
+    lines.extend(shlex.join(command) for command in commands)
+    lines.extend(
+        [
+            'bd dep cycles --json > "$CYCLES_AFTER"',
+            'python3 - "$CYCLES_BEFORE" "$CYCLES_AFTER" <<\'PY\'',
+            "import json, sys",
+            'before = json.load(open(sys.argv[1], encoding="utf-8"))',
+            'after = json.load(open(sys.argv[2], encoding="utf-8"))',
+            "def sig(c):",
+            '    members = c.get("members", []) if isinstance(c, dict) else []',
+            '    ids = tuple(str(m.get("id")) for m in members if isinstance(m, dict) and m.get("id") is not None)',
+            '    return ids or json.dumps(c, sort_keys=True, separators=(",", ":"))',
+            "known = {sig(c) for c in before}",
+            "introduced = [c for c in after if sig(c) not in known]",
+            "if introduced:",
+            '    print(json.dumps({"error":"new dependency cycles introduced","cycles":introduced}, indent=2), file=sys.stderr)',
+            "    raise SystemExit(4)",
+            "PY",
+            'echo "apply complete; run board-audit-roundtrip verify on the package"',
+        ]
+    )
+    apply_sh.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    apply_sh.chmod(0o755)
+    return rec, plan
+
+
+def intent_fields(
+    base: dict[str, Any] | None, desired: dict[str, Any]
+) -> set[str]:
+    if base is None:
+        return set(desired)
+    return {
+        key
+        for key in set(base) | set(desired)
+        if base.get(key, MISSING) != desired.get(key, MISSING)
+    } - PROTECTED_EXISTING_FIELDS
+
+
+def verify_metadata_delta(
+    base: Any, desired: Any, actual: Any, rid: str
+) -> list[dict[str, Any]]:
+    if not all(isinstance(x, dict) for x in (base, desired, actual)):
+        if actual != desired:
+            return [
+                {
+                    "id": rid,
+                    "field": "metadata",
+                    "expected": desired,
+                    "actual": actual,
+                }
+            ]
+        return []
+
+    failures: list[dict[str, Any]] = []
+    for key in sorted(set(base) | set(desired)):
+        b = base.get(key, MISSING)
+        d = desired.get(key, MISSING)
+        a = actual.get(key, MISSING)
+        if d == b:
+            continue
+        if a != d:
+            failures.append(
+                {
+                    "id": rid,
+                    "field": f"metadata.{key}",
+                    "expected": val(d),
+                    "actual": val(a),
+                }
+            )
+    return failures
+
+
+def verify_intent(
+    pkg: dict[str, Any], actual: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
+    base = source_issues(pkg)
+    desired = desired_issues(pkg)
+    comments = proposed_comments(pkg)
+    failures: list[dict[str, Any]] = []
+
+    for rid, d in desired.items():
+        a = actual.get(rid)
+        if a is None:
+            failures.append(
+                {
+                    "id": rid,
+                    "field": "<issue>",
+                    "expected": "present",
+                    "actual": "missing",
+                }
+            )
+            continue
+
+        b = base.get(rid)
+        if b is None:
+            # Compiler-owned defaults for new rows are part of resulting state,
+            # but only editor-specified fields are strict verification targets.
+            fields = set(d)
+        else:
+            fields = intent_fields(b, d)
+
+        for field in sorted(fields):
+            if field in {"dependencies", "deps", "relations"}:
+                desired_set = set(relation_map(rid, d))
+                actual_set = set(relation_map(rid, a))
+                base_set = set(relation_map(rid, b or {}))
+                for rel in desired_set - base_set:
+                    if rel not in actual_set:
+                        failures.append(
+                            {
+                                "id": rid,
+                                "field": "dependencies",
+                                "expected": list(rel),
+                                "actual": "missing",
+                            }
+                        )
+                for rel in base_set - desired_set:
+                    if rel in actual_set:
+                        failures.append(
+                            {
+                                "id": rid,
+                                "field": "dependencies",
+                                "expected": f"removed {list(rel)}",
+                                "actual": "present",
+                            }
+                        )
+            elif field == "labels":
+                base_set = set((b or {}).get("labels") or [])
+                desired_set = set(d.get("labels") or [])
+                actual_set = set(a.get("labels") or [])
+                if not (desired_set - base_set) <= actual_set or (
+                    base_set - desired_set
+                ) & actual_set:
+                    failures.append(
+                        {
+                            "id": rid,
+                            "field": "labels",
+                            "expected_delta": {
+                                "add": sorted(desired_set - base_set),
+                                "remove": sorted(base_set - desired_set),
+                            },
+                            "actual": sorted(actual_set),
+                        }
+                    )
+            elif field == "metadata":
+                failures.extend(
+                    verify_metadata_delta(
+                        (b or {}).get("metadata", {}),
+                        d.get("metadata", {}),
+                        a.get("metadata", {}),
+                        rid,
+                    )
+                )
+            elif a.get(field, MISSING) != d.get(field, MISSING):
+                failures.append(
+                    {
+                        "id": rid,
+                        "field": field,
+                        "expected": val(d.get(field, MISSING)),
+                        "actual": val(a.get(field, MISSING)),
+                    }
+                )
+
+    # New comments are a separate append intent. Existing comment records are
+    # immutable source history and never compared as editor-controlled objects.
+    for rid, texts in comments.items():
+        actual_row = actual.get(rid)
+        if actual_row is None:
+            continue
+        actual_texts = [
+            text
+            for comment in (actual_row.get("comments") or [])
+            if (text := comment_text(comment)) is not None
+        ]
+        base_texts = [
+            text
+            for comment in ((base.get(rid) or {}).get("comments") or [])
+            if (text := comment_text(comment)) is not None
+        ]
+        for text in sorted(set(texts)):
+            required = base_texts.count(text) + texts.count(text)
+            observed = actual_texts.count(text)
+            if observed < required:
+                failures.append(
+                    {
+                        "id": rid,
+                        "field": "new_comments",
+                        "expected_text": text,
+                        "expected_min_count": required,
+                        "actual_count": observed,
+                    }
+                )
+    return failures
+
+
+def resolve_current_path(
+    arg: str | None,
+) -> tuple[Path, tempfile.TemporaryDirectory[str] | None]:
+    if arg:
+        return Path(arg), None
+    return acquire_current_jsonl()
+
+
+def cmd_prepare(args: argparse.Namespace) -> int:
+    src = Path(args.package)
+    pkg = prepare_package(load_json(src))
+    out = Path(args.output) if args.output else src.with_name(src.stem + ".editable.json")
+    write_json(out, pkg)
+    print(out)
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    pkg = load_json(Path(args.package))
+    warnings = validate_package(pkg, allow_context_edit=args.allow_context_edit)
+    result: dict[str, Any] = {"valid": True, "warnings": warnings}
+    temp = None
+    if args.current_jsonl is not None or not args.offline:
+        current_path, temp = resolve_current_path(args.current_jsonl)
+        rec = reconcile(
+            pkg,
+            current_map(current_path),
+            allow_context_edit=args.allow_context_edit,
+        )
+        result["reconciliation"] = {
+            key: value for key, value in rec.items() if key != "merged_issues"
+        }
+        result["valid"] = rec["safe"]
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    if temp:
+        temp.cleanup()
+    return 0 if result["valid"] else 3
+
+
+def cmd_diff(args: argparse.Namespace) -> int:
+    pkg = load_json(Path(args.package))
+    current_path, temp = resolve_current_path(args.current_jsonl)
+    rec = reconcile(
+        pkg,
+        current_map(current_path),
+        allow_context_edit=args.allow_context_edit,
+    )
+    print(
+        json.dumps(
+            {key: value for key, value in rec.items() if key != "merged_issues"},
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    if temp:
+        temp.cleanup()
+    return 0 if rec["safe"] else 3
+
+
+def cmd_compile(args: argparse.Namespace) -> int:
+    pkg_path = Path(args.package)
+    pkg = load_json(pkg_path)
+    current_path, temp = resolve_current_path(args.current_jsonl)
+    out_dir = (
+        Path(args.output_dir)
+        if args.output_dir
+        else pkg_path.with_name(pkg_path.stem + ".roundtrip")
+    )
+    rec, plan = compile_plan(
+        pkg_path,
+        pkg,
+        current_path,
+        out_dir,
+        allow_context_edit=args.allow_context_edit,
+    )
+    print(
+        json.dumps(
+            {
+                "output_dir": str(out_dir),
+                "changed_ids": plan["changed_ids"],
+                "import_ids": plan["import_ids"],
+                "post_import_commands": len(plan["post_import_commands"]),
+                "safe": rec["safe"],
+            },
+            indent=2,
+        )
+    )
+    if temp:
+        temp.cleanup()
+    return 0
+
+
+def run_checked(command: list[str]) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(command, text=True, capture_output=True)
+    if proc.returncode != 0:
+        raise RoundtripError(
+            f"command failed ({proc.returncode}): {shlex.join(command)}\n"
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    return proc
+
+
+def dependency_cycles() -> list[Any]:
+    proc = run_checked(["bd", "dep", "cycles", "--json"])
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RoundtripError(
+            f"bd dep cycles --json returned invalid JSON: {exc}"
+        ) from exc
+    if not isinstance(data, list):
+        raise RoundtripError("bd dep cycles --json returned a non-list payload")
+    return data
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    if shutil.which("bd") is None:
+        raise RoundtripError("bd is required for apply")
+
+    pkg_path = Path(args.package)
+    pkg = load_json(pkg_path)
+    with tempfile.TemporaryDirectory(prefix="board-audit-apply-") as temp_dir:
+        current_path, current_temp = resolve_current_path(args.current_jsonl)
+        out_dir = Path(temp_dir) / "compiled"
+        _, plan = compile_plan(
+            pkg_path,
+            pkg,
+            current_path,
+            out_dir,
+            allow_context_edit=args.allow_context_edit,
+        )
+        if current_temp:
+            current_temp.cleanup()
+
+        import_path = out_dir / plan["import_file"]
+        if import_path.stat().st_size:
+            dry = run_checked(
+                ["bd", "import", str(import_path), "--dry-run", "--json"]
+            )
+            print(dry.stdout.strip())
+        else:
+            print('{"dry_run":true,"issue_rows":0}')
+
+        if not args.execute:
+            print("dry-run only; re-run with --execute to mutate", file=sys.stderr)
+            return 0
+
+        before_cycles = dependency_cycles()
+        if import_path.stat().st_size:
+            run_checked(["bd", "import", str(import_path), "--json"])
+        for command in plan["post_import_commands"]:
+            run_checked(list(command))
+        after_cycles = dependency_cycles()
+        new_cycles = introduced_cycles(before_cycles, after_cycles)
+        if new_cycles:
+            print(
+                json.dumps(
+                    {
+                        "verified": False,
+                        "error": "new dependency cycles introduced",
+                        "cycles": new_cycles,
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                file=sys.stderr,
+            )
+            return 4
+
+        post_path, post_temp = acquire_current_jsonl()
+        failures = verify_intent(pkg, current_map(post_path))
+        post_temp.cleanup()
+        if failures:
+            print(
+                json.dumps(
+                    {"verified": False, "failures": failures},
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                file=sys.stderr,
+            )
+            return 4
+
+        print(json.dumps({"verified": True, "changed_ids": plan["changed_ids"]}, indent=2))
+        return 0
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    pkg = load_json(Path(args.package))
+    current_path, temp = resolve_current_path(args.current_jsonl)
+    failures = verify_intent(pkg, current_map(current_path))
+    if temp:
+        temp.cleanup()
+    print(
+        json.dumps(
+            {"verified": not failures, "failures": failures},
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if not failures else 4
+
+
+def add_current_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--current-jsonl",
+        help="use this bd export --all snapshot instead of acquiring local Beads",
+    )
+    parser.add_argument(
+        "--allow-context-edit",
+        action="store_true",
+        help="allow edits to context-only ancestor records",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="board-audit-roundtrip",
+        description="Safely reconcile edited board-audit work packages back into Beads",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    command = sub.add_parser(
+        "prepare", help="add editable desired state to an exported work package"
+    )
+    command.add_argument("package")
+    command.add_argument("-o", "--output")
+    command.set_defaults(func=cmd_prepare)
+
+    command = sub.add_parser(
+        "validate", help="validate package and optionally reconcile current Beads"
+    )
+    command.add_argument("package")
+    command.add_argument(
+        "--offline",
+        action="store_true",
+        help="edit-contract validation only; do not acquire current board",
+    )
+    add_current_args(command)
+    command.set_defaults(func=cmd_validate)
+
+    command = sub.add_parser(
+        "diff", help="show base/current/desired three-way reconciliation"
+    )
+    command.add_argument("package")
+    add_current_args(command)
+    command.set_defaults(func=cmd_diff)
+
+    for name in ("compile-import", "compile-apply"):
+        command = sub.add_parser(
+            name,
+            help="compile native Beads JSONL plus explicit post-import mutations",
+        )
+        command.add_argument("package")
+        command.add_argument("-o", "--output-dir")
+        add_current_args(command)
+        command.set_defaults(func=cmd_compile)
+
+    command = sub.add_parser(
+        "apply", help="dry-run, optionally execute, then verify an edited package"
+    )
+    command.add_argument("package")
+    command.add_argument(
+        "--execute",
+        action="store_true",
+        help="perform mutations; without this flag apply is dry-run only",
+    )
+    add_current_args(command)
+    command.set_defaults(func=cmd_apply)
+
+    command = sub.add_parser(
+        "verify", help="verify local Beads satisfies the package's intended delta"
+    )
+    command.add_argument("package")
+    add_current_args(command)
+    command.set_defaults(func=cmd_verify)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = build_parser().parse_args(argv)
+        return int(args.func(args))
+    except RoundtripError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.githooks/board-audit-transport.py
+++ b/.githooks/board-audit-transport.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Transport-branch freshness policy for board-audit handoff/reconcile.
+
+The generic high-level flow lives in ``board-audit-flow.py``. This shim keeps
+transport branches as artifact branches rooted on the current origin default
+branch instead of letting them accumulate stale code history. Existing
+``.xtrm/board-audit/**`` artifacts are restored from the previous transport
+branch, and the rewritten transport branch is pushed with an exact
+``--force-with-lease`` guard.
+
+Transport commits are not product-code delivery. After a strict path fence
+proves every staged path is under ``.xtrm/board-audit/**``, board-audit bypasses
+repository-local commit/push hooks and marks the transport commit ``[skip ci]``.
+This prevents code-oriented size/lint/SAST hooks and broad push CI from treating
+lossless Beads transport JSON as application code. Repository review/test gates
+remain unchanged for normal branches and pull requests.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+FLOW_IMPL = HERE / "board-audit-flow.py"
+
+spec = importlib.util.spec_from_file_location("board_audit_flow_impl", FLOW_IMPL)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"cannot load board-audit flow implementation: {FLOW_IMPL}")
+flow = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(flow)
+
+# Each CLI invocation is one process. A lease recorded here belongs only to the
+# handoff started in that process; reconcile --execute therefore falls back to a
+# normal fast-forward push from the fetched transport head.
+_HANDOFF_LEASES: dict[str, str | None] = {}
+
+# ``bd worktree remove`` compares the worktree HEAD with the staging branch's
+# configured upstream. Handoff staging branches start from origin/HEAD, but the
+# commit is deliberately pushed to board-audit/<id>. Track that relationship so
+# successful cleanup can realign the comparator before asking Beads to remove
+# the worktree with its normal safety checks intact.
+_STAGING_TRANSPORTS: dict[str, str] = {}
+_BASE_MAKE_STAGING_BRANCH = flow.make_staging_branch
+_BASE_CLEANUP_TRANSPORT_WORKTREE = flow.cleanup_transport_worktree
+
+
+def _transport_artifacts_exist(repo: Path, remote_branch: str) -> bool:
+    return (
+        flow.run(
+            [
+                "git",
+                "cat-file",
+                "-e",
+                f"origin/{remote_branch}:.xtrm/board-audit",
+            ],
+            cwd=repo,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _transport_relpaths(worktree: Path, paths: list[Path]) -> list[str]:
+    """Return force-stageable transport paths, rejecting every other path.
+
+    ``handoff`` deliberately versions ``.xtrm/board-audit/**`` even when a
+    repository ignores ``.xtrm/`` wholesale. Because both ``git add -f`` and
+    hook bypasses are powerful, keep their boundary narrower than the caller-
+    provided path list and fail closed if anything escapes the transport tree.
+    """
+    relative_paths = [flow.rel(worktree, path) for path in paths]
+    if not relative_paths:
+        raise flow.FlowError("refusing to force-stage an empty transport path set")
+    for relative in relative_paths:
+        if relative != ".xtrm/board-audit" and not relative.startswith(
+            ".xtrm/board-audit/"
+        ):
+            raise flow.FlowError(
+                "refusing to force-stage non-board-audit path: " + relative
+            )
+    return relative_paths
+
+
+def _transport_commit_message(message: str) -> str:
+    """Mark artifact transport commits so broad push/pull_request CI skips them."""
+    if any(
+        marker in message.lower()
+        for marker in ("[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]")
+    ):
+        return message
+    return f"{message} [skip ci]"
+
+
+def make_staging_branch(repo: Path, bead_id: str, start_ref: str) -> str:
+    """Create a staging branch and remember its intended transport branch."""
+    staging = _BASE_MAKE_STAGING_BRANCH(repo, bead_id, start_ref)
+    _STAGING_TRANSPORTS[staging] = flow.transport_branch(bead_id)
+    return staging
+
+
+def _prepare_cleanup_upstream(
+    repo: Path,
+    worktree: Path,
+    staging: str,
+    remote_branch: str,
+) -> None:
+    """Prove publication and point Beads' normal comparator at that proof.
+
+    Beads' normal worktree-removal policy checks cleanliness and requires the
+    worktree HEAD to be contained in its comparison target. Handoff staging
+    branches initially track origin/HEAD, while their generated commit is pushed
+    to board-audit/<id>. Refresh exactly that transport ref, require exact HEAD
+    equality, then repoint the ephemeral staging branch upstream so
+    ``bd worktree remove`` can run without ``--force``.
+    """
+    remote_tracking = f"origin/{remote_branch}"
+    refspec = f"+refs/heads/{remote_branch}:refs/remotes/origin/{remote_branch}"
+    flow.run(["git", "fetch", "origin", refspec], cwd=repo)
+
+    local_head = flow.git_output(worktree, "rev-parse", "HEAD")
+    remote_head = flow.git_output(repo, "rev-parse", remote_tracking)
+    if local_head != remote_head:
+        raise flow.FlowError(
+            "refusing worktree cleanup: local transport HEAD does not match "
+            f"{remote_tracking} ({local_head} != {remote_head})"
+        )
+
+    flow.run(
+        ["git", "branch", "--set-upstream-to", remote_tracking, staging],
+        cwd=repo,
+    )
+
+
+def cleanup_transport_worktree(
+    repo: Path,
+    path: Path,
+    staging: str,
+    *,
+    keep_on_error: bool,
+) -> None:
+    """Preserve Beads safety checks while cleaning published staging worktrees."""
+    if keep_on_error:
+        _STAGING_TRANSPORTS.pop(staging, None)
+        _BASE_CLEANUP_TRANSPORT_WORKTREE(
+            repo,
+            path,
+            staging,
+            keep_on_error=True,
+        )
+        return
+
+    remote_branch = _STAGING_TRANSPORTS.get(staging)
+    if not remote_branch:
+        raise flow.FlowError(
+            f"cannot determine transport branch for cleanup staging branch {staging}"
+        )
+
+    try:
+        _prepare_cleanup_upstream(repo, path, staging, remote_branch)
+        _BASE_CLEANUP_TRANSPORT_WORKTREE(
+            repo,
+            path,
+            staging,
+            keep_on_error=False,
+        )
+    finally:
+        _STAGING_TRANSPORTS.pop(staging, None)
+
+
+def start_transport_worktree(
+    repo: Path,
+    bead_id: str,
+    remote_branch: str | None = None,
+) -> tuple[Path, str, str]:
+    """Start transport publication from current origin default.
+
+    ``bead_id`` names the identity (used for the staging branch and cache
+    path); ``remote_branch`` overrides the derived ``board-audit/<bead-id>``
+    branch for identities whose transport branch has a different name, e.g.
+    PR-checkpoint handoffs published to ``board-audit/pr-<number>``.
+
+    If a transport branch already exists we capture its exact remote SHA for a
+    later lease-protected rewrite, then restore only the interchange tree into
+    a staging branch rooted at current origin/main (or origin/HEAD).
+    """
+    flow.run(["git", "fetch", "origin"], cwd=repo)
+    remote_branch = remote_branch or flow.transport_branch(bead_id)
+    remote_ref = f"refs/remotes/origin/{remote_branch}"
+
+    previous_sha: str | None = None
+    if flow.remote_ref_exists(repo, remote_ref):
+        previous_sha = flow.git_output(repo, "rev-parse", f"origin/{remote_branch}")
+
+    staging = flow.make_staging_branch(repo, bead_id, flow.default_remote_ref(repo))
+    # Keep this explicit as well as in make_staging_branch so tests or callers
+    # that temporarily replace the flow hook cannot lose the cleanup mapping.
+    _STAGING_TRANSPORTS[staging] = remote_branch
+    path = flow.cache_worktree_path(repo, bead_id)
+    try:
+        flow.create_bd_worktree(repo, path, staging)
+        if previous_sha and _transport_artifacts_exist(repo, remote_branch):
+            # Path checkout updates the staging worktree/index without importing
+            # stale code from the previous transport branch.
+            flow.run(
+                [
+                    "git",
+                    "checkout",
+                    f"origin/{remote_branch}",
+                    "--",
+                    ".xtrm/board-audit",
+                ],
+                cwd=path,
+            )
+    except Exception:
+        # Match the base flow's recovery behaviour: preserve a partially-created
+        # worktree for inspection, but remove the staging ref if creation failed
+        # before the worktree became usable.
+        if not path.exists():
+            flow.delete_local_branch(repo, staging)
+        _STAGING_TRANSPORTS.pop(staging, None)
+        raise
+
+    _HANDOFF_LEASES[remote_branch] = previous_sha
+    return path, staging, remote_branch
+
+
+def commit_transport(
+    worktree: Path,
+    *,
+    paths: list[Path],
+    message: str,
+) -> bool:
+    """Force-stage transport paths and commit with hook/CI bypass.
+
+    Returns True when a commit was created, False when nothing was staged.
+    ``commit_and_push`` keeps its original behaviour; callers that need more
+    than one commit under a single lease-protected push (PR-checkpoint
+    evidence commit plus transport-seal commit) call this directly and finish
+    with ``push_transport``.
+    """
+    relative_paths = _transport_relpaths(worktree, paths)
+    # Transport artifacts are intentionally versioned even when the owning
+    # repository ignores .xtrm/ globally. Force applies only after the strict
+    # .xtrm/board-audit/** path check above.
+    flow.run(["git", "add", "-f", "--", *relative_paths], cwd=worktree)
+    staged = (
+        flow.run(
+            ["git", "diff", "--cached", "--quiet"],
+            cwd=worktree,
+            check=False,
+        ).returncode
+        != 0
+    )
+    if not staged:
+        return False
+    # Repository hooks are designed for product-code commits and can reject
+    # valid lossless transport JSON for size/entropy/SAST reasons. The
+    # strict transport path fence above is the authority boundary for this
+    # narrow bypass; normal repository commits keep their hooks unchanged.
+    flow.run(
+        [
+            "git",
+            "commit",
+            "--no-verify",
+            "-m",
+            _transport_commit_message(message),
+        ],
+        cwd=worktree,
+    )
+    return True
+
+
+def push_transport(worktree: Path, *, remote_branch: str) -> None:
+    """Push the current worktree HEAD to the transport branch under lease.
+
+    Pre-push hooks (Semgrep/OSV/full test mirrors in many Mercury repos) are
+    code-delivery gates, not transport gates. Skip only for this
+    board-audit-owned push. GitHub-side push/pull_request workflows are also
+    suppressed by the transport commit's [skip ci] marker where applicable.
+    """
+    push = ["git", "push", "--no-verify"]
+    lease = _HANDOFF_LEASES.pop(remote_branch, None)
+    if lease:
+        push.append(
+            f"--force-with-lease=refs/heads/{remote_branch}:{lease}"
+        )
+    push.extend(["origin", f"HEAD:refs/heads/{remote_branch}"])
+    flow.run(push, cwd=worktree)
+
+
+def commit_and_push(
+    worktree: Path,
+    *,
+    paths: list[Path],
+    message: str,
+    remote_branch: str,
+) -> None:
+    commit_transport(worktree, paths=paths, message=message)
+    push_transport(worktree, remote_branch=remote_branch)
+
+
+# Install the transport policy into the generic flow implementation.
+flow.make_staging_branch = make_staging_branch
+flow.cleanup_transport_worktree = cleanup_transport_worktree
+flow.start_transport_worktree = start_transport_worktree
+flow.commit_and_push = commit_and_push
+
+
+def main(argv: list[str] | None = None) -> int:
+    return int(flow.main(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -96,3 +96,13 @@ if command -v bd >/dev/null 2>&1; then
   if [ "$_bd_exit" -ne 0 ]; then exit "$_bd_exit"; fi
 fi
 # --- END BEADS INTEGRATION v1.2.1 ---
+# --- BEGIN custom: board-audit pr-checkpoint before push ---
+# Publishes a FRESH PR-checkpoint handoff for every push to a PR branch: the
+# adapter performs the code push itself (--no-verify), then binds the
+# checkpoint to the now-remote PR head, so the handoff is current, not stale.
+# Never blocks the code push: adapter failures only warn. Any agent in the
+# repository can verify the evidence via board-audit pr-status <pr> --check.
+if [ -x "/home/dawid/dev/core/.githooks/board-audit-pr-adapter.sh" ]; then
+    "/home/dawid/dev/core/.githooks/board-audit-pr-adapter.sh" "$@" || true
+fi
+# --- END custom ---


### PR DESCRIPTION
> **Note:** supersedes closed [#590](https://github.com/xtrm-dev/core/pull/590), which auto-closed when its base branch (\`chore/xtrm-6xbb5-*\`) got deleted on merge of #587. This PR has the same content, rebased onto main.

## Purpose of this PR

Six board-audit scripts + pre-push wiring block have been sitting untracked in the working tree for days with no owning session. This PR folds them in **for design review** — approving means the feature ships; rejecting means we revert and the WIP author has to explain.

## What lands

**6 new hook scripts (all under \`.githooks/\`):**

| File | Purpose (per script header) |
|---|---|
| \`board-audit-core\` | bd board/work-package exporter + merged-PR audit bundle. Audit + structured-export modes. |
| \`board-audit-flow.py\` | High-level board-audit handoff/reconcile UX. Composes exporter + reconciler with \`bd worktree create\`. |
| \`board-audit-pr-adapter.sh\` | PR-checkpoint event adapter. Publishes a FRESH PR-checkpoint handoff on every push to a PR branch. |
| \`board-audit-pr.py\` | PR-mode primitive (bulk audit). |
| \`board-audit-roundtrip.py\` | Round-trip reconciler. |
| \`board-audit-transport.py\` | Transport layer. |

**Pre-push wiring block:**

```sh
# --- BEGIN custom: board-audit pr-checkpoint before push ---
# Never blocks the code push: adapter failures only warn.
if [ -x "/home/dawid/dev/core/.githooks/board-audit-pr-adapter.sh" ]; then
    "/home/dawid/dev/core/.githooks/board-audit-pr-adapter.sh" "$@" || true
fi
# --- END custom ---
```

## Reviewer questions

1. **Is this the intended design?** Ambient WIP with no session owner — needs someone to say \"yes, ship.\"
2. **Executable bits.** Two shell scripts (\`board-audit-core\`, \`board-audit-pr-adapter.sh\`) are \`+x\`. Four python scripts are NOT \`+x\`. If they're meant to be invoked directly (they have \`python3\` shebangs), they need \`chmod +x\`. If they're called via \`python3 <script>\`, current perms are fine. **Which is it?**
3. **Hardcoded path.** \`pre-push\` hardcodes \`/home/dawid/dev/core\` in the adapter path. Should probably be \`$(dirname \"$0\")/board-audit-pr-adapter.sh\` for portability across worktrees / other clones. **Confirm intent.**
4. **\`|| true\` guard.** Deliberate — adapter failure must never fail the code push. Left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)