### PR TITLE
chore(vendor): pin specialists@v3.21.5 (0253e3e4)

### DIFF
--- a/.xtrm/specialists-source.json
+++ b/.xtrm/specialists-source.json
@@ -2,8 +2,8 @@
   "version": 1,
   "source": {
     "kind": "ref",
-    "ref": "bcdbd30cb8248155c0e57dd9243f6d32c612bab9",
-    "resolved_sha": "bcdbd30cb8248155c0e57dd9243f6d32c612bab9",
+    "ref": "0253e3e4b823de419bf1acc54f07eb618e10a054",
+    "resolved_sha": "0253e3e4b823de419bf1acc54f07eb618e10a054",
     "repo_path": "../specialists",
     "source_path": "config/skills"
   },


### PR DESCRIPTION
## Summary

Pre-release pin bump for core v0.11.5. Only \`.xtrm/specialists-source.json\` bumps from bcdbd30c → 0253e3e4 (the specialists v3.21.5 release commit).

## Vendored payload

**No changes.** \`git diff bcdbd30c..0253e3e4 -- config/skills/\` is empty — 0253e3e4 is just CHANGELOG + package.json + dist/ bumps for the release.

## Verification

- [x] \`npm run check:vendored-specialists-parity\` — OK @ 0253e3e4
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)