### PR TITLE
release: v0.11.6 — fix pi-integration-eof absolute-path leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.6] - 2026-08-20
+
+### Fixed
+- Replace hardcoded pi path with PATH lookup ([cc98590](https://github.com/xtrm-dev/core/commit/cc98590b3c4c319a1882782fa5a310f8a063d7e9))
+
 ## [0.11.5] - 2026-08-20
 
 Broad reliability sweep on the launch model plus a Pi extension polish pass. Structured launch outcomes are now schema-validated, refuse invalid slugs before spawning, preflight the codex/claude/pi paths, and degrade cleanly on incomplete persistence — the code path every session starts through. Pi extension gets a rendering refresh: phase-colored tool prefixes (dim command when success), preserved tree indentation on wrapped tool lines, flat rows for external tools, char counts on collapsed thinking rows, and accented bash command-names + light-magenta separators for readable multi-command lines. Also new: `xt worktree reap` for reclaiming abandoned worktrees, an experimental Codex runtime with K4 distribution parity, a dedicated `read-line-numbers` Pi extension that owns model-facing line numbering, a Python kernel + global prompt doctrine subsystem (`xtrm-3ljgz`), a `board-audit` hook feature (bd exporter + PR-checkpoint adapter), and the `sp log` monitor-recipe corrections in the `using-specialists` skill that fix silent-fail monitors on keep-alive specialists (via specialists v3.21.5 re-vendor).

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xtrm-cli",
   "private": true,
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xtrm-tools",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xtrm-tools",
-      "version": "0.11.5",
+      "version": "0.11.6",
       "license": "MIT",
       "workspaces": [
         "cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xtrm-tools",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Claude Code tools installer (skills, hooks, MCP servers)",
   "license": "MIT",
   "type": "module",

--- a/packages/pi-extensions/package.json
+++ b/packages/pi-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaggerxtrm/pi-extensions",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Unified Pi extension entrypoint for xtrm-managed extensions",
   "type": "module",
   "publishConfig": {

--- a/packages/pi-extensions/tests/pi-integration-eof.test.ts
+++ b/packages/pi-extensions/tests/pi-integration-eof.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -23,8 +23,9 @@ describe("Pi EOF real spawn (RUN_PI_INTEGRATION=1)", () => {
     const target = join(dir, "eof.txt");
     writeFileSync(target, "one\ntwo\n");
     try {
-      if (!existsSync("/home/dawid/.nvm/versions/node/v24.15.0/bin/pi")) {
-        console.warn("[pi-integration-eof] pi binary not found — skipping");
+      const piCheck = spawnSync("which", ["pi"], { encoding: "utf-8" });
+      if (piCheck.status !== 0) {
+        console.warn("[pi-integration-eof] pi binary not found in PATH — skipping");
         return;
       }
       const model = process.env.PI_MODEL ?? "google/gemini-2.0-flash-exp";


### PR DESCRIPTION
## Summary

Bugfix + patch release. \`packages/pi-extensions/tests/pi-integration-eof.test.ts\` (added in PR #579) guarded on an absolute \`/home/dawid/.nvm/versions/node/v24.15.0/bin/pi\` path. \`check:payload-hygiene\` rejected \`npm publish\` on v0.11.5 — the leak would ship into the tarball. Replace with \`spawnSync(\"which\", [\"pi\"])\` — same guard, portable.

## Why v0.11.6, not v0.11.5.1

Retagging the already-pushed v0.11.5 tag would violate the Git Safety Protocol. v0.11.6 is a clean patch: 1 fix + version bump.

## Verification

- [x] \`check:payload-hygiene\` — OK (419 packed files, no leaks)
- [ ] CI green

## Rollout

- Retag \`v0.11.6\` to squash SHA post-merge → push → \`gh release create\`
- \`npm publish --access public\` (v0.11.5 stays as git tag only; v0.11.6 is the first v0.11.x-since-v0.11.4 on npm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)